### PR TITLE
Migrate all blocks to Block API v2 for WP 7 compatibility

### DIFF
--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -430,7 +430,9 @@ class Jeo {
 			}
 		);
 
-		return '<div class="story-map-container" data-properties="' . htmlentities( wp_json_encode( $saved_data ) ) . '" ></div>';
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'story-map-container' ) );
+
+		return '<div ' . $wrapper_attributes . ' data-properties="' . htmlentities( wp_json_encode( $saved_data ) ) . '" ></div>';
 	}
 
 	public function filter_rest_query_by_zone( $args, $request ) {

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -289,6 +289,7 @@ class Jeo {
 		register_block_type(
 			'jeo/storymap',
 			array(
+				'api_version'     => 2,
 				'render_callback' => array( $this, 'story_map_dynamic_render_callback' ),
 				'editor_script'   => 'jeo-map-blocks',
 				'editor_style'    => 'jeo-map-blocks',
@@ -297,6 +298,7 @@ class Jeo {
 		register_block_type(
 			'jeo/embedded-storymap',
 			array(
+				'api_version'     => 2,
 				'render_callback' => array( $this, 'embedded_story_map_dynamic_render_callback' ),
 				'editor_script'   => 'jeo-map-blocks',
 				'editor_style'    => 'jeo-map-blocks',
@@ -304,8 +306,34 @@ class Jeo {
 		);
 	}
 
+	/**
+	 * Extract JSON content from block save output.
+	 * Handles both legacy format (raw JSON string) and API v2+ format
+	 * (JSON wrapped in a <div> element with useBlockProps).
+	 *
+	 * @param string $content Block save output.
+	 * @return string Extracted JSON string.
+	 */
+	private function extract_json_from_block_content( $content ) {
+		$content = trim( $content );
+
+		// If it's already valid JSON, return as-is (legacy format)
+		$decoded = json_decode( $content );
+		if ( json_last_error() === JSON_ERROR_NONE ) {
+			return $content;
+		}
+
+		// API v2+ format: JSON is wrapped in a <div> element
+		// Strip the outer HTML wrapper to get the JSON content inside
+		$inner = preg_replace( '/^<div[^>]*>/', '', $content );
+		$inner = preg_replace( '/<\/div>$/', '', $inner );
+		$inner = trim( $inner );
+
+		return $inner;
+	}
+
 	public function embedded_story_map_dynamic_render_callback( $block_attributes, $content ) {
-		$content = json_decode( $content );
+		$content = json_decode( $this->extract_json_from_block_content( $content ) );
 
 		$story_id                       = $content->attributes->storyID;
 		$story                          = get_post( $story_id );
@@ -327,7 +355,7 @@ class Jeo {
 	}
 
 	public function story_map_dynamic_render_callback( $block_attributes, $content ) {
-		$saved_data = json_decode( $content );
+		$saved_data = json_decode( $this->extract_json_from_block_content( $content ) );
 
 		$map_id     = $saved_data->map_id;
 		$map_layers = get_post_meta( $map_id, 'layers', true );

--- a/src/js/src/map-blocks/embedded-story-map-editor.js
+++ b/src/js/src/map-blocks/embedded-story-map-editor.js
@@ -1,16 +1,18 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { Fragment, useId } from '@wordpress/element';
+import { useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import JeoAutosuggest from './jeo-autosuggest';
 
 function EmbeddedStorymapEditor ({ attributes, loadedStory, setAttributes }) {
+	const blockProps = useBlockProps();
 	const instanceId = useId();
 	const inputId = `jeo-storymap-autosuggest-${ instanceId }`
 
 	return (
-		<Fragment>
+		<div { ...blockProps }>
 			<label htmlFor={ inputId }>
 				{ __( 'Insert a story map from the library', 'jeo' ) + ':' }
 			</label>
@@ -24,7 +26,7 @@ function EmbeddedStorymapEditor ({ attributes, loadedStory, setAttributes }) {
 					setAttributes({ ...attributes, storyID: suggestion.id })
 				} }
 			/>
-		</Fragment>
+		</div>
 	);
 }
 

--- a/src/js/src/map-blocks/index.js
+++ b/src/js/src/map-blocks/index.js
@@ -1,9 +1,10 @@
 import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import EmbeddedStorymapEditor from './embedded-story-map-editor';
-import MapDisplay from './map-display';
+import MapDisplay, { MapSave } from './map-display';
 import MapEditor from './map-editor';
-import OnetimeMapDisplay from './onetime-map-display';
+import OnetimeMapDisplay, { OnetimeMapSave } from './onetime-map-display';
 import OnetimeMapEditor from './onetime-map-editor';
 import StorymapEditor from './storymap-editor'
 import MapIcon from '../icons/ion/map';
@@ -11,6 +12,7 @@ import { cloneDeep } from 'lodash';
 import { AsyncModeProvider } from '@wordpress/data';
 
 registerBlockType( 'jeo/map', {
+	apiVersion: 2,
 	title: __( 'JEO Map', 'jeo' ),
 	description: __( 'Display maps with layers and data', 'jeo' ),
 	category: 'jeo',
@@ -28,10 +30,115 @@ registerBlockType( 'jeo/map', {
 			<MapEditor { ...props } />
 		</AsyncModeProvider>
 	),
-	save: ( props ) => <MapDisplay { ...props } />,
+	save: ( props ) => <MapSave { ...props } />,
+	deprecated: [
+		{
+			attributes: {
+				map_id: { type: 'number' },
+			},
+			save: ( props ) => <MapDisplay { ...props } />,
+		},
+	],
 } );
 
+const onetimeMapAttributes = {
+	layers: {
+		type: 'array',
+		default: [],
+		items: {
+			type: 'object',
+			properties: {
+				id: { type: 'number' },
+				use: { type: 'string' /* enum */ },
+				default: { type: 'boolean' },
+				show_legend: { type: 'boolean' },
+			},
+		},
+	},
+	center_lat: {
+		type: 'number',
+	},
+	center_lon: {
+		type: 'number',
+	},
+	initial_zoom: {
+		type: 'number',
+	},
+	min_zoom: {
+		type: 'number',
+	},
+	max_zoom: {
+		type: 'number',
+	},
+	disable_scroll_zoom: {
+		type: 'boolean',
+	},
+	disable_drag_pan: {
+		type: 'booelan',
+	},
+	disable_drag_rotate: {
+		type: 'boolean',
+	},
+	enable_fullscreen: {
+		type: 'boolean',
+	},
+	pan_limits: {
+		type: 'object',
+		'properties': {
+			'east': {
+				'description': __('East pan limit', 'jeo'),
+				'type': 'number'
+			},
+			'north': {
+				'description': __('North pan limit', 'jeo'),
+				'type': 'number'
+			},
+			'south': {
+				'description': __('South pan limit', 'jeo'),
+				'type': 'number'
+			},
+			'west': {
+				'description': __('West pan limit', 'jeo'),
+
+				'type': 'number'
+			},
+		}
+	},
+	related_posts: {
+		type: 'object',
+		default: {
+			categories: [],
+			tags: [],
+			meta_query: [],
+		},
+		properties: {
+			categories: {
+				type: 'array',
+				items: { type: 'integer' },
+			},
+			tags: {
+				type: 'array',
+				items: { type: 'integer' },
+			},
+			before: { type: 'string' },
+			after: { type: 'string' },
+			meta_query: {
+				type: 'array',
+				items: {
+					type: 'object',
+					properties: {
+						key: { type: 'string' },
+						compare: { type: 'string' },
+						value: { type: 'string' },
+					},
+				},
+			},
+		},
+	},
+};
+
 registerBlockType( 'jeo/onetime-map', {
+	apiVersion: 2,
 	title: __( 'JEO One-time Map', 'jeo' ),
 	description: __( 'Display maps with layers and data', 'jeo' ),
 	category: 'jeo',
@@ -39,108 +146,19 @@ registerBlockType( 'jeo/onetime-map', {
 	supports: {
 		align: true,
 	},
-	attributes: {
-		layers: {
-			type: 'array',
-			default: [],
-			items: {
-				type: 'object',
-				properties: {
-					id: { type: 'number' },
-					use: { type: 'string' /* enum */ },
-					default: { type: 'boolean' },
-					show_legend: { type: 'boolean' },
-				},
-			},
-		},
-		center_lat: {
-			type: 'number',
-		},
-		center_lon: {
-			type: 'number',
-		},
-		initial_zoom: {
-			type: 'number',
-		},
-		min_zoom: {
-			type: 'number',
-		},
-		max_zoom: {
-			type: 'number',
-		},
-		disable_scroll_zoom: {
-			type: 'boolean',
-		},
-		disable_drag_pan: {
-			type: 'booelan',
-		},
-		disable_drag_rotate: {
-			type: 'boolean',
-		},
-		enable_fullscreen: {
-			type: 'boolean',
-		},
-		pan_limits: {
-			type: 'object',
-			'properties': {
-				'east': {
-					'description': __('East pan limit', 'jeo'),
-					'type': 'number'
-				},
-				'north': {
-					'description': __('North pan limit', 'jeo'),
-					'type': 'number'
-				},
-				'south': {
-					'description': __('South pan limit', 'jeo'),
-					'type': 'number'
-				},
-				'west': {
-					'description': __('West pan limit', 'jeo'),
-
-					'type': 'number'
-				},
-			}
-		},
-		related_posts: {
-			type: 'object',
-			default: {
-				categories: [],
-				tags: [],
-				meta_query: [],
-			},
-			properties: {
-				categories: {
-					type: 'array',
-					items: { type: 'integer' },
-				},
-				tags: {
-					type: 'array',
-					items: { type: 'integer' },
-				},
-				before: { type: 'string' },
-				after: { type: 'string' },
-				meta_query: {
-					type: 'array',
-					items: {
-						type: 'object',
-						properties: {
-							key: { type: 'string' },
-							compare: { type: 'string' },
-							value: { type: 'string' },
-						},
-					},
-				},
-			},
-		},
-
-	},
+	attributes: onetimeMapAttributes,
 	edit: ( props ) => (
 		<AsyncModeProvider value={ true }>
 			<OnetimeMapEditor { ...props } />
 		</AsyncModeProvider>
 	),
-	save: ( props ) => <OnetimeMapDisplay { ...props } />,
+	save: ( props ) => <OnetimeMapSave { ...props } />,
+	deprecated: [
+		{
+			attributes: onetimeMapAttributes,
+			save: ( props ) => <OnetimeMapDisplay { ...props } />,
+		},
+	],
 } );
 
 const storyMapCleanUp = (props) => {
@@ -192,49 +210,67 @@ const storyMapCleanUp = (props) => {
 	return attributesStructure;
 }
 
+const storymapAttributes = {
+	map_id: {
+		type: 'number',
+	},
+	description: {
+		type: 'string',
+	},
+	slides: {
+		type: 'array'
+	},
+	navigateButton: {
+		type: 'boolean',
+	},
+	hasIntroduction: {
+		type: 'boolean',
+	},
+	loadedLayers: {
+		type: 'array',
+	},
+	navigateMapLayers: {
+		type: 'array'
+	},
+	postID : {
+		type: 'number',
+	},
+};
+
 registerBlockType( 'jeo/storymap', {
+	apiVersion: 2,
 	title: __( 'Story Map', 'jeo' ),
 	description: __( 'Display maps with storytelling', 'jeo' ),
 	category: 'jeo',
 	icon: MapIcon,
-	attributes: {
-		map_id: {
-			type: 'number',
-		},
-		description: {
-			type: 'string',
-		},
-		slides: {
-			type: 'array'
-		},
-		navigateButton: {
-			type: 'boolean',
-		},
-		hasIntroduction: {
-			type: 'boolean',
-		},
-		loadedLayers: {
-			type: 'array',
-		},
-		navigateMapLayers: {
-			type: 'array'
-		},
-		postID : {
-			type: 'number',
-		},
-	},
+	attributes: storymapAttributes,
 	edit: ( props ) => (
 		<AsyncModeProvider value={ true }>
 			<StorymapEditor { ...props } />
 		</AsyncModeProvider>
 	),
-	save: ( props ) => {
-		const attributesStructure = storyMapCleanUp(props);
-		return JSON.stringify(attributesStructure)
+	save: ( { attributes } ) => {
+		const blockProps = useBlockProps.save();
+		const attributesStructure = storyMapCleanUp( { attributes } );
+		return (
+			<div { ...blockProps }>
+				{ JSON.stringify( attributesStructure ) }
+			</div>
+		);
 	},
+	deprecated: [
+		{
+			attributes: storymapAttributes,
+			save: ( props ) => {
+				const attributesStructure = storyMapCleanUp(props);
+				return JSON.stringify(attributesStructure)
+			},
+		},
+	],
 } );
 
 registerBlockType( 'jeo/embedded-storymap', {
+	apiVersion: 2,
 	title: __( 'Embedded Story Map', 'jeo' ),
 	description: __( 'Display maps with storytelling', 'jeo' ),
 	category: 'jeo',
@@ -250,6 +286,21 @@ registerBlockType( 'jeo/embedded-storymap', {
 		</AsyncModeProvider>
 	),
 	save: ( props ) => {
-		return JSON.stringify(props);
+		const blockProps = useBlockProps.save();
+		return (
+			<div { ...blockProps }>
+				{ JSON.stringify( props ) }
+			</div>
+		);
 	},
+	deprecated: [
+		{
+			attributes: {
+				storyID: { type: 'number' },
+			},
+			save: ( props ) => {
+				return JSON.stringify(props);
+			},
+		},
+	],
 });

--- a/src/js/src/map-blocks/map-display.js
+++ b/src/js/src/map-blocks/map-display.js
@@ -1,11 +1,9 @@
 import classNames from 'classnames';
+import { useBlockProps } from '@wordpress/block-editor';
 
+// Legacy save component – kept for deprecated block migration
 export default ( { attributes, className } ) => {
 	const style = {};
-
-	// if ( className.includes( 'alignfull' ) ) {
-	// 	style.width = '100vw';
-	// }
 
 	return (
 		<div
@@ -16,5 +14,16 @@ export default ( { attributes, className } ) => {
 			// data-map_id={ attributes.map_id }
 			style={ style }
 		/>
+	);
+};
+
+// New save component with useBlockProps.save() for API v2+
+export const MapSave = ( { attributes } ) => {
+	const blockProps = useBlockProps.save( {
+		className: classNames( [ 'jeomap', 'map_id_'+attributes.map_id ] ),
+	} );
+
+	return (
+		<div { ...blockProps } />
 	);
 };

--- a/src/js/src/map-blocks/map-editor.js
+++ b/src/js/src/map-blocks/map-editor.js
@@ -1,3 +1,4 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { Button, Spinner } from '@wordpress/components';
 import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
 import { useEffect, useId, useMemo, useRef, useState } from '@wordpress/element';
@@ -11,6 +12,7 @@ import './map-editor.css';
 const { map_defaults: mapDefaults } = window.jeo_settings;
 
 export default function MapEditor ( {attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jeo-mapblock' } );
 	const instanceId = useId();
 	console.log({ instanceId });
 	const [ key, setKey ] = useState( 0 );
@@ -42,14 +44,10 @@ export default function MapEditor ( {attributes, setAttributes } ) {
 		per_page: -1,
 	}, { enabled: layerIds.length > 0 } );
 
-	if ( attributes.map_id && !loadedMap ) {
-		return null;
-	}
-
 	return (
-		<div className="jeo-mapblock">
-			{ attributes.map_id && loadingMap && <Spinner /> }
-			{ attributes.map_id && ! loadingMap && (
+		<div { ...blockProps }>
+			{ attributes.map_id && ( loadingMap || !loadedMap ) && <Spinner /> }
+			{ attributes.map_id && ! loadingMap && loadedMap && (
 				<>
 					<div className="jeo-preview-area">
 						<Map

--- a/src/js/src/map-blocks/onetime-map-display.js
+++ b/src/js/src/map-blocks/onetime-map-display.js
@@ -1,5 +1,7 @@
 import classNames from 'classnames';
+import { useBlockProps } from '@wordpress/block-editor';
 
+// Legacy save component – kept for deprecated block migration
 export default ( { attributes, className } ) => {
 	let hasRelatedPosts;
 	if ( ! attributes.related_posts ) {
@@ -38,5 +40,41 @@ export default ( { attributes, className } ) => {
 			}
 			style={ style }
 		/>
+	);
+};
+
+// New save component with useBlockProps.save() for API v2+
+export const OnetimeMapSave = ( { attributes } ) => {
+	let hasRelatedPosts;
+	if ( ! attributes.related_posts ) {
+		hasRelatedPosts = false;
+	} else {
+		hasRelatedPosts = [
+			'categories',
+			'tags',
+			'before',
+			'after',
+			'meta_query',
+		].some( ( key ) => attributes.related_posts[ key ] );
+	}
+
+	const blockProps = useBlockProps.save( {
+		className: 'jeomap',
+		'data-center_lat': attributes.center_lat,
+		'data-center_lon': attributes.center_lon,
+		'data-initial_zoom': attributes.initial_zoom,
+		'data-min_zoom': attributes.min_zoom,
+		'data-max_zoom': attributes.max_zoom,
+		'data-disable_scroll_zoom': attributes.disable_scroll_zoom,
+		'data-disable_drag_pan': attributes.disable_drag_pan,
+		'data-disable_drag_rotate': attributes.disable_drag_rotate,
+		'data-enable_fullscreen': attributes.enable_fullscreen,
+		'data-layers': JSON.stringify( attributes.layers ),
+		'data-pan_limits': JSON.stringify( attributes.pan_limits ),
+		'data-related_posts': hasRelatedPosts ? JSON.stringify( attributes.related_posts ) : undefined,
+	} );
+
+	return (
+		<div { ...blockProps } />
 	);
 };

--- a/src/js/src/map-blocks/onetime-map-editor.js
+++ b/src/js/src/map-blocks/onetime-map-editor.js
@@ -1,4 +1,4 @@
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { Button, PanelBody } from '@wordpress/components';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
@@ -15,6 +15,7 @@ import './onetime-map-editor.css';
 const { map_defaults: mapDefaults } = window.jeo_settings;
 
 export default function OnetimeMapEditor ( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
 	const [ modal, setModal ] = useState( false );
 	const [ key, setKey ] = useState( 0 );
 
@@ -63,7 +64,7 @@ export default function OnetimeMapEditor ( { attributes, setAttributes } ) {
 	}
 
 	return (
-		<>
+		<div { ...blockProps }>
 			{ modal && (
 				<LayersSettingsModal
 					closeModal={ closeModal }
@@ -130,6 +131,6 @@ export default function OnetimeMapEditor ( { attributes, setAttributes } ) {
 					{ __( 'Edit layers settings', 'jeo' ) }
 				</Button>
 			</div>
-		</>
+		</div>
 	);
 };

--- a/src/js/src/map-blocks/storymap-editor.js
+++ b/src/js/src/map-blocks/storymap-editor.js
@@ -1,4 +1,5 @@
 import { CKEditor } from '@ckeditor/ckeditor5-react';
+import { useBlockProps } from '@wordpress/block-editor';
 import { Button, CheckboxControl, Dashicon, Panel, PanelBody, Spinner } from '@wordpress/components';
 import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
 import { useSelect, select } from '@wordpress/data';
@@ -75,6 +76,7 @@ function flyTo ( map, location ) {
 }
 
 export default function StoryMapEditor ( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jeo-mapblock storymap' } );
 	const instanceId = useId();
 	const [ showStorySettings, setShowStorySettings ] = useState( false );
 	const [ showSlidesSettings, setShowSlidesSettings ] = useState( false );
@@ -232,7 +234,7 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 	document.body.style.setProperty('--globalFontFamily', globalFontFamily);
 
 	return (
-		<div className="jeo-mapblock storymap">
+		<div { ...blockProps }>
 			{ attributes.map_id && loadingMap && <Spinner /> }
 			{ attributes.map_id && loadedMap && (
 				<Fragment>


### PR DESCRIPTION
## Summary

Resolves #487

Migrates all four JEO map blocks from Block API v1 to v2, eliminating the deprecation warnings introduced in WordPress 6.9+ and ensuring compatibility with WordPress 7, where all editors run inside iframes.

### Changes

- **`src/js/src/map-blocks/index.js`** — Added `apiVersion: 2` to all four block registrations (`jeo/map`, `jeo/onetime-map`, `jeo/storymap`, `jeo/embedded-storymap`). Added `deprecated` entries for backward compatibility with existing saved content.
- **`src/js/src/map-blocks/map-display.js`** — Added `MapSave` component using `useBlockProps.save()` for API v2 save output.
- **`src/js/src/map-blocks/onetime-map-display.js`** — Added `OnetimeMapSave` component using `useBlockProps.save()` for API v2 save output.
- **`src/js/src/map-blocks/map-editor.js`**, **`onetime-map-editor.js`**, **`storymap-editor.js`**, **`embedded-story-map-editor.js`** — Updated edit components to use `useBlockProps()`.
- **`src/includes/class-jeo.php`** — Added `api_version: 2` to PHP `register_block_type()` calls. Added `extract_json_from_block_content()` helper to handle both legacy (raw JSON string) and API v2 (JSON wrapped in a `<div>` from `useBlockProps.save()`) render callback formats.

## Tested

- Verify no Block API deprecation warnings appear in the WordPress editor (WP 6.9+)
- Confirm existing maps saved with API v1 still render correctly (backward compatibility via `deprecated` entries)
- Confirm new maps created with the updated blocks save and render correctly
- Test all four block types: `jeo/map`, `jeo/onetime-map`, `jeo/storymap`, `jeo/embedded-storymap`
- Test storymap and embedded-storymap dynamic render callbacks with both legacy and v2 saved content

🤖 Generated with [Claude Code](https://claude.com/claude-code)