### PR TITLE
Expand compatibility coverage and fix editor regressions

### DIFF
--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -1,0 +1,45 @@
+name: PHP Compatibility
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  php-compat:
+    name: ${{ matrix.label }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.0'
+            label: PHP 8.0 (backward-compat, non-blocking)
+            experimental: true
+          - php: '8.1'
+            label: PHP 8.1 (backward-compat, non-blocking)
+            experimental: true
+          - php: '8.2'
+            label: PHP 8.2
+            experimental: false
+          - php: '8.3'
+            label: PHP 8.3
+            experimental: false
+          - php: '8.4'
+            label: PHP 8.4
+            experimental: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Show PHP version
+        run: php -v
+
+      - name: Run PHP compatibility review
+        run: php scripts/check-php-compat.php

--- a/.github/workflows/wordpress-smoke.yml
+++ b/.github/workflows/wordpress-smoke.yml
@@ -1,0 +1,112 @@
+name: WordPress Smoke Tests
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  wordpress-smoke:
+    name: ${{ matrix.label }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.0'
+            wordpress: '6.6'
+            label: WordPress 6.6 on PHP 8.0 (backward-compat, non-blocking)
+            experimental: true
+          - php: '8.1'
+            wordpress: '6.6'
+            label: WordPress 6.6 on PHP 8.1 (backward-compat, non-blocking)
+            experimental: true
+          - php: '8.2'
+            wordpress: '6.9.4'
+            label: WordPress 6.9.4 on PHP 8.2
+            experimental: false
+          - php: '8.3'
+            wordpress: '6.9.4'
+            label: WordPress 6.9.4 on PHP 8.3
+            experimental: false
+          - php: '8.4'
+            wordpress: '6.9.4'
+            label: WordPress 6.9.4 on PHP 8.4
+            experimental: false
+          - php: '8.2'
+            wordpress: '7.0-beta4'
+            label: WordPress 7.0-beta4 on PHP 8.2 (forward-compat, non-blocking)
+            experimental: true
+          - php: '8.3'
+            wordpress: '7.0-beta4'
+            label: WordPress 7.0-beta4 on PHP 8.3 (forward-compat, non-blocking)
+            experimental: true
+          - php: '8.4'
+            wordpress: '7.0-beta4'
+            label: WordPress 7.0-beta4 on PHP 8.4 (forward-compat, non-blocking)
+            experimental: true
+
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: wordpress
+          MYSQL_USER: wordpress
+          MYSQL_PASSWORD: wordpress
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mariadb-admin ping -h 127.0.0.1 -uroot -proot --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: mysqli
+          tools: wp-cli
+
+      - name: Show PHP version
+        run: php -v
+
+      - name: Wait for MariaDB
+        env:
+          WP_DB_HOST: 127.0.0.1
+          WP_DB_NAME: wordpress
+          WP_DB_USER: wordpress
+          WP_DB_PASSWORD: wordpress
+        run: |
+          php -r '
+          $host = getenv("WP_DB_HOST");
+          $name = getenv("WP_DB_NAME");
+          $user = getenv("WP_DB_USER");
+          $password = getenv("WP_DB_PASSWORD");
+          for ( $attempt = 1; $attempt <= 30; $attempt++ ) {
+              $mysqli = @mysqli_connect($host, $user, $password, $name, 3306);
+              if ( false !== $mysqli ) {
+                  mysqli_close($mysqli);
+                  exit(0);
+              }
+              sleep(2);
+          }
+          fwrite(STDERR, "Timed out waiting for MariaDB.\n");
+          exit(1);
+          '
+
+      - name: Run WordPress smoke test
+        env:
+          WP_DIR: ${{ runner.temp }}/wordpress
+          WP_VERSION: ${{ matrix.wordpress }}
+          WP_SITE_URL: http://127.0.0.1
+          WP_DB_HOST: 127.0.0.1:3306
+          WP_DB_NAME: wordpress
+          WP_DB_USER: wordpress
+          WP_DB_PASSWORD: wordpress
+        run: bash scripts/wordpress-smoke.sh

--- a/README.md
+++ b/README.md
@@ -6,6 +6,35 @@ With JEO, creating the interaction between data layers and contextual informatio
 
 At the same time, by simply imputing the ids of layers hosted on [Mapbox](https://www.mapbox.com/), you can manage sophisticated maps without losing performance, add legends directly with HTML and set the map parameters. All directly at the WordPress dashboard.
 
+## Compatibility
+
+This repository currently declares `Requires PHP: 8.0`, with primary validation focused on PHP `8.2` to `8.4`.
+
+Compatibility snapshot validated on March 13, 2026:
+
+- Primary support: PHP `8.2`, `8.3`, and `8.4`.
+- Stable WordPress gate: `WordPress 6.9.4` on PHP `8.2`, `8.3`, and `8.4`.
+- Backward-compatibility smoke tests: `WordPress 6.6` on PHP `8.0` and `8.1`.
+- Forward-compatibility smoke tests: `WordPress 7.0-beta4` on PHP `8.2`, `8.3`, and `8.4`.
+
+Automation:
+
+- Static PHP checks run in `.github/workflows/php-compat.yml`.
+- WordPress runtime smoke tests run in `.github/workflows/wordpress-smoke.yml`.
+
+Local commands:
+
+```bash
+php scripts/check-php-compat.php
+WP_CLI_PHP=/opt/homebrew/opt/php@8.4/bin/php \
+WP_DB_HOST=localhost \
+WP_DB_NAME=wordpress \
+WP_DB_USER=your-user \
+WP_DB_PASSWORD='' \
+WP_VERSION=7.0-beta4 \
+bash scripts/wordpress-smoke.sh
+```
+
 ## Setting up local environment
 
 First of all, clone this repository.
@@ -16,7 +45,7 @@ git clone git@github.com:InfoAmazonia/jeo-plugin.git
 ```
 
 Set up a WordPress installation. This could be a dedicated installation to develop Jeo or you can use an existing instance you have.
-(Note: This plugin requires WordPress 5.3+)
+(Note: This plugin requires WordPress 6.6+)
 
 Then create a symbolic link inside of `wp-content/plugins/jeo` pointing to the `src` folder in this repository.
 

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "infoamazonia/jeo-plugin",
     "type": "project",
     "require-dev": {
-        "squizlabs/php_codesniffer": "*",
-        "wp-coding-standards/wpcs": "*"
+        "squizlabs/php_codesniffer": "^3.13.5",
+        "wp-coding-standards/wpcs": "^3.3.0"
     },
     "license": "GPL-2.0",
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,34 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0781f3afe2a4abc64a6a513afc2e7b6f",
+    "content-hash": "712c415babf2d05e22247d6491a80fc1",
     "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.1.2",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
                 "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
@@ -101,31 +101,31 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-07-17T20:45:56+00:00"
+            "time": "2025-11-11T04:32:07+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "882b8c947ada27eb002870fe77fee9ce0a454cdb"
+                "reference": "b598aa890815b8df16363271b659d73280129101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/882b8c947ada27eb002870fe77fee9ce0a454cdb",
-                "reference": "882b8c947ada27eb002870fe77fee9ce0a454cdb",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
+                "reference": "b598aa890815b8df16363271b659d73280129101",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.1.2",
-                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0"
+                "phpcsstandards/phpcsutils": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
                 "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
@@ -183,32 +183,32 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-09-05T06:54:52+00:00"
+            "time": "2025-11-12T23:06:57+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.1.2",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "b22b59e3d9ec8fe4953e42c7d59117c6eae70eae"
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/b22b59e3d9ec8fe4953e42c7d59117c6eae70eae",
-                "reference": "b22b59e3d9ec8fe4953e42c7d59117c6eae70eae",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.13.3 || ^4.0"
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
                 "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
             "type": "phpcodesniffer-standard",
@@ -276,20 +276,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-09-05T00:00:03+00:00"
+            "time": "2025-12-08T14:27:58+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.4",
+            "version": "3.13.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119"
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
-                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
                 "shasum": ""
             },
             "require": {
@@ -306,11 +306,6 @@
                 "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -360,20 +355,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-09-05T05:47:09+00:00"
+            "time": "2025-11-04T16:30:35+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.2.0",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
-                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
                 "shasum": ""
             },
             "require": {
@@ -381,17 +376,17 @@
                 "ext-libxml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
-                "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.4.0",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.0",
                 "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.0"
+                "squizlabs/php_codesniffer": "^3.13.4"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "suggest": {
                 "ext-iconv": "For improved results",
@@ -426,7 +421,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-07-24T20:08:31+00:00"
+            "time": "2025-11-25T12:08:04+00:00"
         }
     ],
     "aliases": [],
@@ -436,5 +431,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/docs/dev/php-compatibility.md
+++ b/docs/dev/php-compatibility.md
@@ -1,0 +1,44 @@
+# PHP Compatibility
+
+This repository keeps two layers of PHP compatibility validation:
+
+- Static compatibility checks for PHP `8.0` through `8.4`.
+- WordPress smoke tests for the PHP and WordPress combinations we currently support or monitor.
+
+## Policy snapshot
+
+Validated on March 13, 2026.
+
+- Primary support: PHP `8.2`, `8.3`, and `8.4`.
+- Stable WordPress gate: `WordPress 6.9.4` on PHP `8.2`, `8.3`, and `8.4`.
+- Backward-compatibility coverage: `WordPress 6.6` on PHP `8.0` and `8.1`.
+- Forward-compatibility coverage: `WordPress 7.0-beta4` on PHP `8.2`, `8.3`, and `8.4`.
+
+## Automation
+
+- Static checks: `.github/workflows/php-compat.yml`
+- WordPress smoke tests: `.github/workflows/wordpress-smoke.yml`
+
+## Local commands
+
+Run the static checks with the PHP binary you want to validate:
+
+```bash
+/opt/homebrew/opt/php@8.0/bin/php scripts/check-php-compat.php
+/opt/homebrew/opt/php@8.1/bin/php scripts/check-php-compat.php
+/opt/homebrew/opt/php@8.2/bin/php scripts/check-php-compat.php
+/opt/homebrew/opt/php@8.3/bin/php scripts/check-php-compat.php
+/opt/homebrew/opt/php@8.4/bin/php scripts/check-php-compat.php
+```
+
+Run the WordPress smoke test locally with an explicit PHP runtime:
+
+```bash
+WP_CLI_PHP=/opt/homebrew/opt/php@8.4/bin/php \
+WP_DB_HOST=localhost \
+WP_DB_NAME=wordpress \
+WP_DB_USER=your-user \
+WP_DB_PASSWORD='' \
+WP_VERSION=7.0-beta4 \
+bash scripts/wordpress-smoke.sh
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,18 +11,18 @@
 			"dependencies": {
 				"@ckeditor/ckeditor5-react": "^9.5.0",
 				"@nazka/map-gl-js-spiderfy": "^1.2.10",
-				"@wordpress/edit-post": "^8.16.0",
-				"@wordpress/editor": "^14.18.0",
-				"@wordpress/plugins": "^7.16.0",
+				"@wordpress/edit-post": "^8.41.0",
+				"@wordpress/editor": "^14.41.0",
+				"@wordpress/plugins": "^7.41.0",
 				"bootstrap-daterangepicker": "^3.1.0",
 				"ckeditor5": "^47.6.1",
 				"classnames": "^2.5.1",
 				"eta": "^3.5.0",
 				"leaflet": "^1.9.4",
-				"lodash-es": "^4.17.21",
+				"lodash-es": "^4.17.23",
 				"map-gl-utils": "^0.50.4",
-				"mapbox-gl": "^3.9.4",
-				"maplibre-gl": "^5.6.2",
+				"mapbox-gl": "^3.20.0",
+				"maplibre-gl": "^5.20.1",
 				"maplibregl-mapbox-request-transformer": "^0.0.3",
 				"react-autosuggest": "^10.1.0",
 				"react-beautiful-dnd": "^13.1.1",
@@ -30,20 +30,20 @@
 				"react-datepicker": "^7.6.0",
 				"react-jsonschema-form": "2.0.0-alpha.1",
 				"react-leaflet": "^4.2.1",
-				"react-map-gl": "^8.0.4",
+				"react-map-gl": "^8.1.0",
 				"react-movable": "^3.4.0",
 				"scrollama": "^3.2.0",
-				"use-debounce": "^10.0.4"
+				"use-debounce": "^10.1.0"
 			},
 			"devDependencies": {
-				"@wordpress/scripts": "^30.21.0",
-				"ajv": "^8.17.1",
-				"css-loader": "^7.1.2",
-				"postcss": "^8.5.1",
-				"sass": "^1.83.4",
-				"sass-loader": "^16.0.4",
+				"@wordpress/scripts": "^30.27.0",
+				"ajv": "^8.18.0",
+				"css-loader": "^7.1.4",
+				"postcss": "^8.5.8",
+				"sass": "^1.98.0",
+				"sass-loader": "^16.0.7",
 				"style-loader": "^4.0.0",
-				"webpack": "^5.101.1"
+				"webpack": "^5.105.4"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -60,18 +60,18 @@
 			}
 		},
 		"node_modules/@ariakit/core": {
-			"version": "0.4.15",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.15.tgz",
-			"integrity": "sha512-vvxmZvkNhiisKM+Y1TbGMUfVVchV/sWu9F0xw0RYADXcimWPK31dd9JnIZs/OQ5pwAryAHmERHwuGQVESkSjwQ==",
+			"version": "0.4.18",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.18.tgz",
+			"integrity": "sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==",
 			"license": "MIT"
 		},
 		"node_modules/@ariakit/react": {
-			"version": "0.4.18",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.18.tgz",
-			"integrity": "sha512-r38DFvdv6JzjC/8mHekTaJEXO6hmx+YPIiyjq9oL7DckLmqGkAKbFrmQd2CeKZZ1c372DDVw7lLhYjj/VYCBZQ==",
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.23.tgz",
+			"integrity": "sha512-zokuZ7C/pUtFi5x1d/0h5ulLGlJpnPXG1aFKU3F4Sj6sD9uNN/J+fXFsg3sZlWdg7u9ZhBLcjsheLypDjjf6WQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/react-core": "0.4.18"
+				"@ariakit/react-core": "0.4.23"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -83,18 +83,31 @@
 			}
 		},
 		"node_modules/@ariakit/react-core": {
-			"version": "0.4.18",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.18.tgz",
-			"integrity": "sha512-wHtojXF7KPRwGTSbPg50l203Qngg2aGYCzCut+mYEwe3S0ZzuYVpiY+2Yh15HssnQ/S5yiDGRL4q94UEXsyO+w==",
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.23.tgz",
+			"integrity": "sha512-cqcgYBgn+rCsZ05o8f3qKQW4ukOdZPgGgiu2BXv889LksbdjdvTMZ6Fd6JTHXm2vmqdnAkmpVulrhKe6NMETDQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/core": "0.4.15",
+				"@ariakit/core": "0.4.18",
 				"@floating-ui/dom": "^1.0.0",
 				"use-sync-external-store": "^1.2.0"
 			},
 			"peerDependencies": {
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@arraypress/waveform-player": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@arraypress/waveform-player/-/waveform-player-1.2.1.tgz",
+			"integrity": "sha512-PsgOZStUN+1GnY0tujbwk2PYE3HMT/Vl3wEvunqH16hIJWzisf8GEngy5EbswTAjQ1aV3Tk4XBkAskc8eslY1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/arraypress"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1890,12 +1903,10 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-			"integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1960,12 +1971,139 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@base-ui/react": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.3.0.tgz",
+			"integrity": "sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.28.6",
+				"@base-ui/utils": "0.2.6",
+				"@floating-ui/react-dom": "^2.1.8",
+				"@floating-ui/utils": "^0.2.11",
+				"tabbable": "^6.4.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+			"integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.7.6"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@base-ui/utils": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.6.tgz",
+			"integrity": "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.28.6",
+				"@floating-ui/utils": "^0.2.11",
+				"reselect": "^5.1.1",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@bcoe/v8-coverage": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@cacheable/memory": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+			"integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cacheable/utils": "^2.4.0",
+				"@keyv/bigmap": "^1.3.1",
+				"hookified": "^1.15.1",
+				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"hashery": "^1.4.0",
+				"hookified": "^1.15.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/@cacheable/memory/node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
+			}
+		},
+		"node_modules/@cacheable/utils": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
+			"integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"hashery": "^1.5.0",
+				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/@cacheable/utils/node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
+			}
 		},
 		"node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
 			"version": "47.6.1",
@@ -2889,7 +3027,7 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
 			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2908,11 +3046,28 @@
 				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.0.tgz",
+			"integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==",
+			"devOptional": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0"
+		},
 		"node_modules/@csstools/css-tokenizer": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
 			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2958,6 +3113,12 @@
 			"integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
 			"license": "MIT"
 		},
+		"node_modules/@date-fns/utc": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
+			"integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==",
+			"license": "MIT"
+		},
 		"node_modules/@discoveryjs/json-ext": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -2971,11 +3132,45 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
 			"integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/JounQin"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+			"integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.0",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+			"integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+			"integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emotion/babel-plugin": {
@@ -3153,9 +3348,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.8.0.tgz",
-			"integrity": "sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3185,9 +3380,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-			"integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3219,9 +3414,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3254,9 +3449,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3277,20 +3472,22 @@
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-			"integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/utils": "^0.2.11"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-			"integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/core": "^1.7.3",
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/core": "^1.7.5",
+				"@floating-ui/utils": "^0.2.11"
 			}
 		},
 		"node_modules/@floating-ui/react": {
@@ -3333,19 +3530,20 @@
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-			"integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+			"license": "MIT"
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
-			"integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+			"integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@formatjs/fast-memoize": "2.2.7",
-				"@formatjs/intl-localematcher": "0.6.1",
+				"@formatjs/intl-localematcher": "0.6.2",
 				"decimal.js": "^10.4.3",
 				"tslib": "^2.8.0"
 			}
@@ -3361,32 +3559,32 @@
 			}
 		},
 		"node_modules/@formatjs/icu-messageformat-parser": {
-			"version": "2.11.2",
-			"resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
-			"integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+			"integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@formatjs/ecma402-abstract": "2.3.4",
-				"@formatjs/icu-skeleton-parser": "1.8.14",
+				"@formatjs/ecma402-abstract": "2.3.6",
+				"@formatjs/icu-skeleton-parser": "1.8.16",
 				"tslib": "^2.8.0"
 			}
 		},
 		"node_modules/@formatjs/icu-skeleton-parser": {
-			"version": "1.8.14",
-			"resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
-			"integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+			"version": "1.8.16",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+			"integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@formatjs/ecma402-abstract": "2.3.4",
+				"@formatjs/ecma402-abstract": "2.3.6",
 				"tslib": "^2.8.0"
 			}
 		},
 		"node_modules/@formatjs/intl-localematcher": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
-			"integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+			"integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3436,9 +3634,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3508,9 +3706,9 @@
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3734,9 +3932,9 @@
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -3898,10 +4096,10 @@
 			}
 		},
 		"node_modules/@keyv/serialize": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
-			"integrity": "sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==",
-			"dev": true,
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@leichtgewicht/ip-codec": {
@@ -3909,18 +4107,6 @@
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
 			"integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
 			"dev": true
-		},
-		"node_modules/@mapbox/geojson-rewind": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
-			"integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
-			"dependencies": {
-				"get-stream": "^6.0.1",
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"geojson-rewind": "geojson-rewind"
-			}
 		},
 		"node_modules/@mapbox/jsonlint-lines-primitives": {
 			"version": "2.0.2",
@@ -3968,10 +4154,20 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@maplibre/geojson-vt": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.0.2.tgz",
+			"integrity": "sha512-OnXnV2m1yBULKOlUanNFTiOeXCktvWYY4yWoHVETlp6ShJGUhY3DNt9XzPByL24h4JcoJRccPBlMhH1o8cvmyQ==",
+			"license": "ISC",
+			"dependencies": {
+				"kdbush": "^4.0.2"
+			}
+		},
 		"node_modules/@maplibre/maplibre-gl-style-spec": {
-			"version": "23.3.0",
-			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-23.3.0.tgz",
-			"integrity": "sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==",
+			"version": "24.7.0",
+			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.7.0.tgz",
+			"integrity": "sha512-Ed7rcKYU5iELfablg9Mj+TVCsXsPBgdMyXPRAxb2v7oWg9YJnpQdZ5msDs1LESu/mtXy3Z48Vdppv2t/x5kAhw==",
+			"license": "ISC",
 			"dependencies": {
 				"@mapbox/jsonlint-lines-primitives": "~2.0.2",
 				"@mapbox/unitbezier": "^0.0.1",
@@ -3987,18 +4183,47 @@
 				"gl-style-validate": "dist/gl-style-validate.mjs"
 			}
 		},
+		"node_modules/@maplibre/mlt": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.7.tgz",
+			"integrity": "sha512-HZSsXrgn2V6T3o0qklMwKERfKaAxjO8shmiFnVygCtXTg4SPKWVX+U99RkvxUfCsjYBEcT4ltor8lSlBSCca7Q==",
+			"license": "(MIT OR Apache-2.0)",
+			"dependencies": {
+				"@mapbox/point-geometry": "^1.1.0"
+			}
+		},
 		"node_modules/@maplibre/vt-pbf": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.0.3.tgz",
-			"integrity": "sha512-YsW99BwnT+ukJRkseBcLuZHfITB4puJoxnqPVjo72rhW/TaawVYsgQHcqWLzTxqknttYoDpgyERzWSa/XrETdA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+			"integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+			"license": "MIT",
 			"dependencies": {
 				"@mapbox/point-geometry": "^1.1.0",
 				"@mapbox/vector-tile": "^2.0.4",
-				"@types/geojson-vt": "3.2.5",
+				"@maplibre/geojson-vt": "^5.0.4",
+				"@types/geojson": "^7946.0.16",
 				"@types/supercluster": "^7.1.3",
-				"geojson-vt": "^4.0.2",
 				"pbf": "^4.0.1",
 				"supercluster": "^8.0.1"
+			}
+		},
+		"node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+			"integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+			"license": "ISC"
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.4.3",
+				"@emnapi/runtime": "^1.4.3",
+				"@tybys/wasm-util": "^0.10.0"
 			}
 		},
 		"node_modules/@nazka/map-gl-js-spiderfy": {
@@ -4021,7 +4246,7 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
@@ -4034,7 +4259,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -4043,7 +4268,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
@@ -4304,9 +4529,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-http/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -4548,9 +4773,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -4626,9 +4851,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
-			"integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -4972,14 +5197,14 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
-			"integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.55.0"
+				"playwright": "1.58.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -5052,9 +5277,9 @@
 			"dev": true
 		},
 		"node_modules/@preact/signals": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.2.tgz",
-			"integrity": "sha512-naxcJgUJ6BTOROJ7C3QML7KvwKwCXQJYTc5L/b0eEsdYgPB6SxwoQ1vDGcS0Q7GVjAenVq/tXrybVdFShHYZWg==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.4.tgz",
+			"integrity": "sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==",
 			"license": "MIT",
 			"dependencies": {
 				"@preact/signals-core": "^1.7.0"
@@ -5068,9 +5293,9 @@
 			}
 		},
 		"node_modules/@preact/signals-core": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
-			"integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.0.tgz",
+			"integrity": "sha512-AowtCcCU/33lFlh1zRFf/u+12rfrhtNakj7UpaGEsmMwUKpKWMVvcktOGcwBBNiB4lWrZWc01LhiyyzVklJyaQ==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -5091,18 +5316,18 @@
 			}
 		},
 		"node_modules/@puppeteer/browsers": {
-			"version": "2.10.8",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.8.tgz",
-			"integrity": "sha512-f02QYEnBDE0p8cteNoPYHHjbDuwyfbe4cCIVlNi8/MRicIxFW4w4CfgU0LNgWEID6s06P+hRJ1qjpBLMhPRCiQ==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+			"integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"debug": "^4.4.1",
+				"debug": "^4.4.3",
 				"extract-zip": "^2.0.1",
 				"progress": "^2.0.3",
 				"proxy-agent": "^6.5.0",
-				"semver": "^7.7.2",
-				"tar-fs": "^3.1.0",
+				"semver": "^7.7.4",
+				"tar-fs": "^3.1.1",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -5113,9 +5338,9 @@
 			}
 		},
 		"node_modules/@puppeteer/browsers/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -5197,6 +5422,29 @@
 				}
 			}
 		},
+		"node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@radix-ui/react-dismissable-layer": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
@@ -5208,6 +5456,29 @@
 				"@radix-ui/react-primitive": "2.1.3",
 				"@radix-ui/react-use-callback-ref": "1.1.1",
 				"@radix-ui/react-use-escape-keydown": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.2.3"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -5248,6 +5519,29 @@
 				"@radix-ui/react-compose-refs": "1.1.2",
 				"@radix-ui/react-primitive": "2.1.3",
 				"@radix-ui/react-use-callback-ref": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.2.3"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -5306,6 +5600,29 @@
 				}
 			}
 		},
+		"node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@radix-ui/react-presence": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
@@ -5331,12 +5648,12 @@
 			}
 		},
 		"node_modules/@radix-ui/react-primitive": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+			"integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-slot": "1.2.3"
+				"@radix-ui/react-slot": "1.2.4"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -5349,6 +5666,24 @@
 					"optional": true
 				},
 				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+			"integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
 					"optional": true
 				}
 			}
@@ -5546,9 +5881,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@sentry/core": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.46.0.tgz",
-			"integrity": "sha512-it7JMFqxVproAgEtbLgCVBYtQ9fIb+Bu0JD+cEplTN/Ukpe6GaolyYib5geZqslVxhp2sQgT+58aGvfd/k0N8Q==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
+			"integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5556,9 +5891,9 @@
 			}
 		},
 		"node_modules/@sentry/node": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.46.0.tgz",
-			"integrity": "sha512-pRLqAcd7GTGvN8gex5FtkQR5Mcol8gOy1WlyZZFq4rBbVtMbqKOQRhohwqnb+YrnmtFpj7IZ7KNDo077MvNeOQ==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.47.1.tgz",
+			"integrity": "sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5592,9 +5927,9 @@
 				"@opentelemetry/sdk-trace-base": "^1.30.1",
 				"@opentelemetry/semantic-conventions": "^1.34.0",
 				"@prisma/instrumentation": "6.11.1",
-				"@sentry/core": "9.46.0",
-				"@sentry/node-core": "9.46.0",
-				"@sentry/opentelemetry": "9.46.0",
+				"@sentry/core": "9.47.1",
+				"@sentry/node-core": "9.47.1",
+				"@sentry/opentelemetry": "9.47.1",
 				"import-in-the-middle": "^1.14.2",
 				"minimatch": "^9.0.0"
 			},
@@ -5603,14 +5938,14 @@
 			}
 		},
 		"node_modules/@sentry/node-core": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.46.0.tgz",
-			"integrity": "sha512-XRVu5pqoklZeh4wqhxCLZkz/ipoKhitctgEFXX9Yh1e1BoHM2pIxT52wf+W6hHM676TFmFXW3uKBjsmRM3AjgA==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.47.1.tgz",
+			"integrity": "sha512-7TEOiCGkyShJ8CKtsri9lbgMCbB+qNts2Xq37itiMPN2m+lIukK3OX//L8DC5nfKYZlgikrefS63/vJtm669hQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "9.46.0",
-				"@sentry/opentelemetry": "9.46.0",
+				"@sentry/core": "9.47.1",
+				"@sentry/opentelemetry": "9.47.1",
 				"import-in-the-middle": "^1.14.2"
 			},
 			"engines": {
@@ -5627,13 +5962,13 @@
 			}
 		},
 		"node_modules/@sentry/opentelemetry": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.46.0.tgz",
-			"integrity": "sha512-w2zTxqrdmwRok0cXBoh+ksXdGRUHUZhlpfL/H2kfTodOL+Mk8rW72qUmfqQceXoqgbz8UyK8YgJbyt+XS5H4Qg==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.47.1.tgz",
+			"integrity": "sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "9.46.0"
+				"@sentry/core": "9.47.1"
 			},
 			"engines": {
 				"node": ">=18"
@@ -5971,6 +6306,15 @@
 				"url": "https://github.com/sponsors/gregberge"
 			}
 		},
+		"node_modules/@tabby_ai/hijri-converter": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+			"integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/@tannin/compile": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
@@ -6008,6 +6352,94 @@
 			"integrity": "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA==",
 			"license": "MIT"
 		},
+		"node_modules/@tanstack/history": {
+			"version": "1.161.4",
+			"resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.161.4.tgz",
+			"integrity": "sha512-Kp/WSt411ZWYvgXy6uiv5RmhHrz9cAml05AQPrtdAp7eUqvIDbMGPnML25OKbzR3RJ1q4wgENxDTvlGPa9+Mww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/react-router": {
+			"version": "1.166.8",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.166.8.tgz",
+			"integrity": "sha512-EfDPSpPQetdtqi0UT9UAeZEo1cE0O57073IF84kLDvolwR3rWhOX8TgvjL6c2h723EN8EcUlcCU7Tb9Pyt/42g==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/history": "1.161.4",
+				"@tanstack/react-store": "^0.9.1",
+				"@tanstack/router-core": "1.166.7",
+				"isbot": "^5.1.22",
+				"tiny-invariant": "^1.3.3",
+				"tiny-warning": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=20.19"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0 || >=19.0.0",
+				"react-dom": ">=18.0.0 || >=19.0.0"
+			}
+		},
+		"node_modules/@tanstack/react-store": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.9.2.tgz",
+			"integrity": "sha512-Vt5usJE5sHG/cMechQfmwvwne6ktGCELe89Lmvoxe3LKRoFrhPa8OCKWs0NliG8HTJElEIj7PLtaBQIcux5pAQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/store": "0.9.2",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@tanstack/router-core": {
+			"version": "1.166.7",
+			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.166.7.tgz",
+			"integrity": "sha512-MCc8wYIIcxmbeidM8PL2QeaAjUIHyhEDIZPW6NGfn/uwvyi+K2ucn3AGCxxcXl4JGGm0Mx9+7buYl1v3HdcFrg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/history": "1.161.4",
+				"@tanstack/store": "^0.9.1",
+				"cookie-es": "^2.0.0",
+				"seroval": "^1.4.2",
+				"seroval-plugins": "^1.4.2",
+				"tiny-invariant": "^1.3.3",
+				"tiny-warning": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=20.19"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/store": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.2.tgz",
+			"integrity": "sha512-K013lUJEFJK2ofFQ/hZKJUmCnpcV00ebLyOyFOWQvyQHUOZp/iYO84BM6aOGiV81JzwbX0APTVmW8YI7yiG5oA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -6030,6 +6462,17 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@types/babel__core": {
@@ -6319,11 +6762,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/mapbox__point-geometry": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
-			"integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA=="
-		},
 		"node_modules/@types/mdast": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -6369,11 +6807,13 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-			"integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+			"version": "20.19.37",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+			"integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.10.0"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/node-forge": {
@@ -6442,12 +6882,13 @@
 			"dev": true
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.24",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
-			"integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@types/react-dom": {
@@ -6527,15 +6968,6 @@
 			"integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@types/simple-peer": {
-			"version": "9.11.8",
-			"resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.8.tgz",
-			"integrity": "sha512-rvqefdp2rvIA6wiomMgKWd2UZNPe6LM2EV5AuY3CPQJF+8TbdrL5TjYdMf0VAjGczzlkH4l1NjDkihwbj3Xodw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
 		},
 		"node_modules/@types/sockjs": {
 			"version": "0.3.36",
@@ -6653,9 +7085,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -6784,9 +7216,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -6823,9 +7255,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -6872,6 +7304,299 @@
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"license": "ISC"
 		},
+		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-android-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+			"integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-freebsd-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^0.2.11"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@use-gesture/core": {
 			"version": "10.3.1",
 			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
@@ -6891,9 +7616,10 @@
 			}
 		},
 		"node_modules/@vis.gl/react-mapbox": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/@vis.gl/react-mapbox/-/react-mapbox-8.0.4.tgz",
-			"integrity": "sha512-NFk0vsWcNzSs0YCsVdt2100Zli9QWR+pje8DacpLkkGEAXFaJsFtI1oKD0Hatiate4/iAIW39SQHhgfhbeEPfQ==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@vis.gl/react-mapbox/-/react-mapbox-8.1.0.tgz",
+			"integrity": "sha512-FwvH822oxEjWYOr+pP2L8hpv+7cZB2UsQbHHHT0ryrkvvqzmTgt7qHDhamv0EobKw86e1I+B4ojENdJ5G5BkyQ==",
+			"license": "MIT",
 			"peerDependencies": {
 				"mapbox-gl": ">=3.5.0",
 				"react": ">=16.3.0",
@@ -6906,9 +7632,10 @@
 			}
 		},
 		"node_modules/@vis.gl/react-maplibre": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/@vis.gl/react-maplibre/-/react-maplibre-8.0.4.tgz",
-			"integrity": "sha512-HwZyfLjEu+y1mUFvwDAkVxinGm8fEegaWN+O8np/WZ2Sqe5Lv6OXFpV6GWz9LOEvBYMbGuGk1FQdejo+4HCJ5w==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@vis.gl/react-maplibre/-/react-maplibre-8.1.0.tgz",
+			"integrity": "sha512-PkAK/gp3mUfhCLhUuc+4gc3PN9zCtVGxTF2hB6R5R5yYUw+hdg84OZ770U5MU4tPMTCG6fbduExuIW6RRKN6qQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@maplibre/maplibre-gl-style-spec": "^19.2.1"
 			},
@@ -6927,6 +7654,7 @@
 			"version": "19.3.3",
 			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
 			"integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+			"license": "ISC",
 			"dependencies": {
 				"@mapbox/jsonlint-lines-primitives": "~2.0.2",
 				"@mapbox/unitbezier": "^0.0.1",
@@ -6944,7 +7672,8 @@
 		"node_modules/@vis.gl/react-maplibre/node_modules/json-stringify-pretty-compact": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
-			"integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
+			"integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.14.1",
@@ -7137,29 +7866,48 @@
 			}
 		},
 		"node_modules/@wordpress/a11y": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.30.0.tgz",
-			"integrity": "sha512-FpKsURiJmlQXyNCYJXiPxdJLsfcVhDSvH4/+kjEsVLOYyqD+vcb9P/oYDmor4XNIIkMT0/Lna9OnwvwCZB8owQ==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.41.0.tgz",
+			"integrity": "sha512-OMv/whQt3eTftN1EIZ1FjbuYQUATzFKUEv+qE8mvfOWTX2wEcVIXrSDJa8iL+h+lpIbsWiwxFYiRlyXSmzVqkQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/dom-ready": "^4.30.0",
-				"@wordpress/i18n": "^6.3.0"
+				"@wordpress/dom-ready": "^4.41.0",
+				"@wordpress/i18n": "^6.14.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/api-fetch": {
-			"version": "7.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
-			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+		"node_modules/@wordpress/admin-ui": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-1.9.0.tgz",
+			"integrity": "sha512-YoaQaZZbeIlsz/PVu7e/z19wcdAEW4vbAhfA81zctMGw7WTOC8ifLWHALTWzfTWjyXlW3hhq0TiYE0wT43DkYg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/url": "^4.30.0"
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/route": "^0.7.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/api-fetch": {
+			"version": "7.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.41.0.tgz",
+			"integrity": "sha512-oZ2HWCEa5v32Rvrgqck8ePYXPsJ/3KEdZjfthXQrt/U/D5LIl7AyFZvdqnV3OxHL6tj8fvFOEzB71OHGeV7H9A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/url": "^4.41.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -7167,33 +7915,30 @@
 			}
 		},
 		"node_modules/@wordpress/autop": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.30.0.tgz",
-			"integrity": "sha512-0VGvgPdmbJDdVUgSYfwgM6aiBI/3G5bAtksQfue3HvNMMmZvsudopPgeOXH2S8jjkbbPLr3AIbx6lFSk4Autqw==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.41.0.tgz",
+			"integrity": "sha512-TpSA6TA6hZVi8EX1wYlLjHrKK2hs2w0Y01shK1Q+EudhFwTLoSsDFVWwuAkvm/Xxx+rLtzzs01QMwG6UAvMeQw==",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.30.0.tgz",
-			"integrity": "sha512-DUEAseIg3Xqa4MroaFQEob4TYTGJv0zKRLsDrLHAgQCTtC4PcvUqU0gM7JZjG3zo20G9R5YCBNzx1353qd1t7Q==",
+			"version": "8.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.41.0.tgz",
+			"integrity": "sha512-A+HTQTLGtHRdorr9aizhBdLR9RmQs/VVAHME1wXG1aPOtU3033PykwKrceSaKe9hYXHs/P3Nota83bMqqjUoUA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
+				"@babel/plugin-syntax-import-attributes": "7.26.0",
 				"@babel/plugin-transform-react-jsx": "7.25.7",
 				"@babel/plugin-transform-runtime": "7.25.7",
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
-				"@babel/runtime": "7.25.7",
-				"@wordpress/browserslist-config": "^6.30.0",
-				"@wordpress/warning": "^3.30.0",
+				"@wordpress/browserslist-config": "^6.41.0",
+				"@wordpress/warning": "^3.41.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -7201,6 +7946,22 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/plugin-syntax-import-attributes": {
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+			"integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/plugin-transform-react-jsx": {
@@ -7382,9 +8143,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.6.0.tgz",
-			"integrity": "sha512-72OqyskL5E8V7trJYt4xlNbOfgAtAFfpwa+8TR+wLwqIYxhFjsWmkZsT3aknE6cyfRAmKZgSUfEZr8zH6Skwyw==",
+			"version": "6.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.17.0.tgz",
+			"integrity": "sha512-6o4Tp9rrGaa2ExnkCjvBZl9CVETFptb6NWtpikrkhGC2HtCSFhXWMzYheK0t+4xSJcssrpm6BMSAQGGGFm6+Tg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7392,60 +8153,59 @@
 			}
 		},
 		"node_modules/@wordpress/blob": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.30.0.tgz",
-			"integrity": "sha512-kiGJFVNM8snw8r45s5cAv+qDaxOdeMWpNRB0scBFiV09yTLJtjtk7tJxVz0FfUHCX5cBA7NhwaOf+m8O4T2xZQ==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.41.0.tgz",
+			"integrity": "sha512-EDAs8jcRPG6sF6SEEfmNErKpgnuZSUy3f1i2N1gBs82IsNuluCplkyszK3J4wtr5Nu8FyQtL8oMZYoIybt0Kkg==",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/block-editor": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.3.0.tgz",
-			"integrity": "sha512-10ZtT4QupAMQCAVEP6uA5nB+vI19WJzZuqGTpQtIDygcD/L8xQ+k5/yHVnhM3Q1W++lfQJ3wTsIS5XdAZYceIw==",
+			"version": "15.14.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.14.0.tgz",
+			"integrity": "sha512-OOAUMeqxCidMCrku1dMEUtLc/9OXzifbZlYZbAf5wOLaN+voZlXi6TSxj8CRoU51lWSMyt5/YA3GgHU4bxePJQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@emotion/react": "^11.7.1",
-				"@emotion/styled": "^11.6.0",
 				"@react-spring/web": "^9.4.5",
-				"@wordpress/a11y": "^4.30.0",
-				"@wordpress/api-fetch": "^7.30.0",
-				"@wordpress/blob": "^4.30.0",
-				"@wordpress/block-serialization-default-parser": "^5.30.0",
-				"@wordpress/blocks": "^15.3.0",
-				"@wordpress/commands": "^1.30.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/date": "^5.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/dom": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/escape-html": "^3.30.0",
-				"@wordpress/hooks": "^4.30.0",
-				"@wordpress/html-entities": "^4.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/is-shallow-equal": "^5.30.0",
-				"@wordpress/keyboard-shortcuts": "^5.30.0",
-				"@wordpress/keycodes": "^4.30.0",
-				"@wordpress/notices": "^5.30.0",
-				"@wordpress/preferences": "^4.30.0",
-				"@wordpress/priority-queue": "^3.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/rich-text": "^7.30.0",
-				"@wordpress/style-engine": "^2.30.0",
-				"@wordpress/token-list": "^3.30.0",
-				"@wordpress/upload-media": "^0.15.0",
-				"@wordpress/url": "^4.30.0",
-				"@wordpress/warning": "^3.30.0",
-				"@wordpress/wordcount": "^4.30.0",
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/blob": "^4.41.0",
+				"@wordpress/block-serialization-default-parser": "^5.41.0",
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/commands": "^1.41.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/dataviews": "^13.0.0",
+				"@wordpress/date": "^5.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/dom": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/escape-html": "^3.41.0",
+				"@wordpress/global-styles-engine": "^1.8.0",
+				"@wordpress/hooks": "^4.41.0",
+				"@wordpress/html-entities": "^4.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/image-cropper": "^1.5.0",
+				"@wordpress/interactivity": "^6.41.0",
+				"@wordpress/is-shallow-equal": "^5.41.0",
+				"@wordpress/keyboard-shortcuts": "^5.41.0",
+				"@wordpress/keycodes": "^4.41.0",
+				"@wordpress/notices": "^5.41.0",
+				"@wordpress/preferences": "^4.41.0",
+				"@wordpress/priority-queue": "^3.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/rich-text": "^7.41.0",
+				"@wordpress/style-engine": "^2.41.0",
+				"@wordpress/token-list": "^3.41.0",
+				"@wordpress/upload-media": "^0.26.0",
+				"@wordpress/url": "^4.41.0",
+				"@wordpress/warning": "^3.41.0",
+				"@wordpress/wordcount": "^4.41.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -7471,51 +8231,54 @@
 			}
 		},
 		"node_modules/@wordpress/block-library": {
-			"version": "9.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.30.0.tgz",
-			"integrity": "sha512-Y4padUNLYKRVnEnk/1bygLqW+5vztjaa4n6VyfLEw/qVEW3uDh8WPzhhwa9h3nYVF2n3qLDL48x8aTCoOeIXcQ==",
+			"version": "9.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.41.0.tgz",
+			"integrity": "sha512-nNMAlOui9dtD5z8hB8klb9H73pWpB+53AY2Cg6EmdYb9Y+ZN+U1HS+rgegSy6nBYd0Rw68b9f5af5EvX0wWRmg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/a11y": "^4.30.0",
-				"@wordpress/api-fetch": "^7.30.0",
-				"@wordpress/autop": "^4.30.0",
-				"@wordpress/blob": "^4.30.0",
-				"@wordpress/block-editor": "^15.3.0",
-				"@wordpress/blocks": "^15.3.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/core-data": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/date": "^5.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/dom": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/escape-html": "^3.30.0",
-				"@wordpress/hooks": "^4.30.0",
-				"@wordpress/html-entities": "^4.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/interactivity": "^6.30.0",
-				"@wordpress/interactivity-router": "^2.30.0",
-				"@wordpress/keyboard-shortcuts": "^5.30.0",
-				"@wordpress/keycodes": "^4.30.0",
-				"@wordpress/notices": "^5.30.0",
-				"@wordpress/patterns": "^2.30.0",
-				"@wordpress/primitives": "^4.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/reusable-blocks": "^5.30.0",
-				"@wordpress/rich-text": "^7.30.0",
-				"@wordpress/server-side-render": "^6.6.0",
-				"@wordpress/url": "^4.30.0",
-				"@wordpress/viewport": "^6.30.0",
-				"@wordpress/wordcount": "^4.30.0",
+				"@arraypress/waveform-player": "1.2.1",
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/autop": "^4.41.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/blob": "^4.41.0",
+				"@wordpress/block-editor": "^15.14.0",
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/core-data": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/date": "^5.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/dom": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/escape-html": "^3.41.0",
+				"@wordpress/hooks": "^4.41.0",
+				"@wordpress/html-entities": "^4.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/interactivity": "^6.41.0",
+				"@wordpress/interactivity-router": "^2.41.0",
+				"@wordpress/keyboard-shortcuts": "^5.41.0",
+				"@wordpress/keycodes": "^4.41.0",
+				"@wordpress/latex-to-mathml": "^1.9.0",
+				"@wordpress/notices": "^5.41.0",
+				"@wordpress/patterns": "^2.41.0",
+				"@wordpress/primitives": "^4.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/reusable-blocks": "^5.41.0",
+				"@wordpress/rich-text": "^7.41.0",
+				"@wordpress/server-side-render": "^6.17.0",
+				"@wordpress/upload-media": "^0.26.0",
+				"@wordpress/url": "^4.41.0",
+				"@wordpress/viewport": "^6.41.0",
+				"@wordpress/wordcount": "^4.41.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
-				"escape-html": "^1.0.3",
 				"fast-average-color": "^9.1.1",
 				"fast-deep-equal": "^3.1.3",
+				"html-react-parser": "5.2.11",
 				"memize": "^2.1.0",
 				"remove-accents": "^0.5.0",
 				"uuid": "^9.0.1"
@@ -7530,40 +8293,36 @@
 			}
 		},
 		"node_modules/@wordpress/block-serialization-default-parser": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.30.0.tgz",
-			"integrity": "sha512-7bCeSqlkzkisn4MsVpkpNM8OsM8Orkulkg2lL6TKH0bYnDGZLYFmz2Jv5PC2MfUf7g0F1lkXu078Rg11s8aQjQ==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.41.0.tgz",
+			"integrity": "sha512-rJdhfuWhLdvc0zGPUzYbnXb9cN5awQo8/XDxEH9q/5NJUFT/y0N1r5Cws2Cws03qiQLJyKCR0DML7M69V6T/6Q==",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/blocks": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.3.0.tgz",
-			"integrity": "sha512-/ojVeDNhWzfA6fAKcF/CO1JFF1SiXcvcLemRrVq4oScC2EJh78Ft7PDbI+dnll+4u0wJnJ9+VUTuAKEBnmjioA==",
+			"version": "15.14.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.14.0.tgz",
+			"integrity": "sha512-k78BDR4IV+V+n/py6e5br89yxdqTPmUec72aUoiJwnm3FHWHjy6xc2t792WeTMYOsctj1lQFPfxp7LcCuptMWQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/autop": "^4.30.0",
-				"@wordpress/blob": "^4.30.0",
-				"@wordpress/block-serialization-default-parser": "^5.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/dom": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/hooks": "^4.30.0",
-				"@wordpress/html-entities": "^4.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/is-shallow-equal": "^5.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/rich-text": "^7.30.0",
-				"@wordpress/shortcode": "^4.30.0",
-				"@wordpress/warning": "^3.30.0",
+				"@wordpress/autop": "^4.41.0",
+				"@wordpress/blob": "^4.41.0",
+				"@wordpress/block-serialization-default-parser": "^5.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/dom": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/hooks": "^4.41.0",
+				"@wordpress/html-entities": "^4.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/is-shallow-equal": "^5.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/rich-text": "^7.41.0",
+				"@wordpress/shortcode": "^4.41.0",
+				"@wordpress/warning": "^3.41.0",
 				"change-case": "^4.1.2",
 				"colord": "^2.7.0",
 				"fast-deep-equal": "^3.1.3",
@@ -7585,9 +8344,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.30.0.tgz",
-			"integrity": "sha512-CjirkPIkMf72VQcKmhmQZUJGHHFEt80ITZVgnxEtyswWA6QPRXIwFhQOAElmfhWg2wS6pCncyg6k7DfgYX3bOg==",
+			"version": "6.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.41.0.tgz",
+			"integrity": "sha512-Cp9JcjdL6ZYVNUGgXR/XOO9Fueb3i0dzpvdpC1pB/iJldiQWYRPZ7LMCaJrwprG92/AfuU68BaR5CwTwrSN5tA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7596,19 +8355,20 @@
 			}
 		},
 		"node_modules/@wordpress/commands": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.30.0.tgz",
-			"integrity": "sha512-1ErowcNAfn0sC6/KkFQje/F+pR1PGsoSbtxk8fxg2ZbDiINZnEMy/sc5yin+7nVLiC4QncAKnwdysbqnBAHb5Q==",
+			"version": "1.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.41.0.tgz",
+			"integrity": "sha512-Ce5LFbn937mIGMzhJ7VFjdxnUpUVCQ9OS28s3YPGcEGlsQVBCBXfgIr68/z3XcC5/H9CSKcb7xJVBqN4H1755Q==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/keyboard-shortcuts": "^5.30.0",
-				"@wordpress/private-apis": "^1.30.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/keyboard-shortcuts": "^5.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/warning": "^3.41.0",
 				"clsx": "^2.1.1",
 				"cmdk": "^1.0.0"
 			},
@@ -7622,43 +8382,46 @@
 			}
 		},
 		"node_modules/@wordpress/components": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.3.0.tgz",
-			"integrity": "sha512-tXe6ucxRThjMPYCk1ZZHAnL0MQqFpCq/PwME/ypBf5dOE3GHKMKXVTvgsJv5bHH6dbJoElkDWRm3ZwqwwQ5CVg==",
+			"version": "32.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.3.0.tgz",
+			"integrity": "sha512-wGDbN2rXEqTTDRHKA+Yn0Gi/dTiLfVK7u/YPAfkQXzvuV4qMGzOz2sSdxQPKmvmogWa6EA0i8Udo9dBYqG1Nig==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
-				"@babel/runtime": "7.25.7",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
+				"@ariakit/react": "^0.4.21",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
 				"@floating-ui/react-dom": "2.0.8",
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.30.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/date": "^5.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/dom": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/escape-html": "^3.30.0",
-				"@wordpress/hooks": "^4.30.0",
-				"@wordpress/html-entities": "^4.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/is-shallow-equal": "^5.30.0",
-				"@wordpress/keycodes": "^4.30.0",
-				"@wordpress/primitives": "^4.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/rich-text": "^7.30.0",
-				"@wordpress/warning": "^3.30.0",
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/date": "^5.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/dom": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/escape-html": "^3.41.0",
+				"@wordpress/hooks": "^4.41.0",
+				"@wordpress/html-entities": "^4.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/is-shallow-equal": "^5.41.0",
+				"@wordpress/keycodes": "^4.41.0",
+				"@wordpress/primitives": "^4.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/rich-text": "^7.41.0",
+				"@wordpress/warning": "^3.41.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
 				"date-fns": "^3.6.0",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
@@ -7669,7 +8432,7 @@
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
+				"react-colorful": "^5.6.1",
 				"react-day-picker": "^9.7.0",
 				"remove-accents": "^0.5.0",
 				"uuid": "^9.0.1"
@@ -7684,20 +8447,19 @@
 			}
 		},
 		"node_modules/@wordpress/compose": {
-			"version": "7.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.30.0.tgz",
-			"integrity": "sha512-2OkdbhGiNWI4A8VXrawZcnqU8dSty3B3KvSLV1YK/TktW4qCGDNvp4W++NO5BY0d/zaSMgDUJryxyk3ejKTfzA==",
+			"version": "7.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.41.0.tgz",
+			"integrity": "sha512-V7z/lz4SdiucDH24eXHp7LeF0LVEkrTYuLLcSkoayZTiimrQnNx0HlZFRVSWIEJ0FrwjVIoFFVCs6gITIZScSQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/dom": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/is-shallow-equal": "^5.30.0",
-				"@wordpress/keycodes": "^4.30.0",
-				"@wordpress/priority-queue": "^3.30.0",
-				"@wordpress/undo-manager": "^1.30.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/dom": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/is-shallow-equal": "^5.41.0",
+				"@wordpress/keycodes": "^4.41.0",
+				"@wordpress/priority-queue": "^3.41.0",
+				"@wordpress/undo-manager": "^1.41.0",
 				"change-case": "^4.1.2",
 				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
@@ -7712,28 +8474,27 @@
 			}
 		},
 		"node_modules/@wordpress/core-data": {
-			"version": "7.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.30.0.tgz",
-			"integrity": "sha512-mElhJ3Oj/W65bmZhpZP8d4T9pIKrdXwiVqsUQGbfdVyQxgFIarjB7AL8SyvMkqX0MzBghZL5rAoNfvMg8CTRvQ==",
+			"version": "7.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.41.0.tgz",
+			"integrity": "sha512-kRUhiPviI90uOkuTbAFeRwjhjXjnpwUO5QNUVQVG6R28RZG8zcDecIlb56QUNq/vduo4ZbZOz6XLMIb2JRZixQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "^7.30.0",
-				"@wordpress/block-editor": "^15.3.0",
-				"@wordpress/blocks": "^15.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/html-entities": "^4.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/is-shallow-equal": "^5.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/rich-text": "^7.30.0",
-				"@wordpress/sync": "^1.30.0",
-				"@wordpress/undo-manager": "^1.30.0",
-				"@wordpress/url": "^4.30.0",
-				"@wordpress/warning": "^3.30.0",
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/block-editor": "^15.14.0",
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/html-entities": "^4.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/is-shallow-equal": "^5.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/rich-text": "^7.41.0",
+				"@wordpress/sync": "^1.41.0",
+				"@wordpress/undo-manager": "^1.41.0",
+				"@wordpress/url": "^4.41.0",
+				"@wordpress/warning": "^3.41.0",
 				"change-case": "^4.1.2",
 				"equivalent-key-map": "^0.2.2",
 				"fast-deep-equal": "^3.1.3",
@@ -7750,19 +8511,18 @@
 			}
 		},
 		"node_modules/@wordpress/data": {
-			"version": "10.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.30.0.tgz",
-			"integrity": "sha512-lHvL78H6JI56sFVyLRuk+fJTIQ7XKiy14d0/kH2rWStmqKDQnniUXM4kVT3MUUOKtL0Mh59CVoiA9J4dlxJ6Ww==",
+			"version": "10.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.41.0.tgz",
+			"integrity": "sha512-yNp46WoSLkvqSMKKnJZ9xA1n02ITDqASObV5leVNoKnajiUAZbRSR6fBrapacUAg2kYFeGlhBg7IAEFJrwMuqg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/is-shallow-equal": "^5.30.0",
-				"@wordpress/priority-queue": "^3.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/redux-routine": "^5.30.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/is-shallow-equal": "^5.41.0",
+				"@wordpress/priority-queue": "^3.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/redux-routine": "^5.41.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -7780,28 +8540,30 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-8.0.0.tgz",
-			"integrity": "sha512-QbcU5vyEc21LgQk8xXyYjyVZFEn5lYBqs2J99MH3n6yId8Ezii8LblvOsBj5SzJVrel3eCfKwgh+x98Wb1cBLQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-13.0.0.tgz",
+			"integrity": "sha512-E1Xp2VOQD2xtoz83tBVaXFd0OV5liaVlK1mDIcLSn54fGMtsyirR31hFHmrCm3vdspWPOKQh5QFdpkc2b0kCiQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
-				"@babel/runtime": "7.25.7",
-				"@wordpress/base-styles": "^6.6.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/date": "^5.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/keycodes": "^4.30.0",
-				"@wordpress/primitives": "^4.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/url": "^4.30.0",
-				"@wordpress/warning": "^3.30.0",
+				"@ariakit/react": "^0.4.21",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/date": "^5.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/keycodes": "^4.41.0",
+				"@wordpress/primitives": "^4.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/ui": "^0.8.0",
+				"@wordpress/warning": "^3.41.0",
 				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
 				"date-fns": "^4.1.0",
+				"deepmerge": "4.3.1",
 				"fast-deep-equal": "^3.1.3",
 				"remove-accents": "^0.5.0"
 			},
@@ -7825,13 +8587,12 @@
 			}
 		},
 		"node_modules/@wordpress/date": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.30.0.tgz",
-			"integrity": "sha512-btCp3y33ykgZbOkbbbjK+PXXFNo2k3QJhh45e3NQpdSAQV4sFpsqhzRRu58ou/AeBdZRXMIzbhTpT2KcKUcIgw==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.41.0.tgz",
+			"integrity": "sha512-cfFvqlTiLDyhMtTqTMxmujvFfohz6tUxIBVMji5xc2hHyv0z/8XZw1Z0JiGpEr3blBXp/Y0R3E60EQ4G83iU7Q==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.30.0",
+				"@wordpress/deprecated": "^4.41.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -7841,9 +8602,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.30.0.tgz",
-			"integrity": "sha512-sms4yRJriS8vzlwbYHII/xqI64oSY5ALbfQy6HJBSCfLJCNxVOzC/2fCrhdV9ghd8nK3NMAJKhTCe09oMPCnIw==",
+			"version": "6.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.41.0.tgz",
+			"integrity": "sha512-OYg+g+MFmHRRUcjl5hNOrBx56GRkp6MNhHuiAvYP7vFJ8dxwzKmk3AHfqr25QLt3K62ODHK1aaikE1dZt40kNg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7865,13 +8626,12 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.30.0.tgz",
-			"integrity": "sha512-QfzUOCANmcrdsViEpdqh4eD4OTkG2ZGpWDuA7lSJvnVB4rcupzHpDsukmKtz6gr/AZnBDXYBoHLUwZ44G4bx0g==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.41.0.tgz",
+			"integrity": "sha512-AyrWS5AcVqjtzDIPCTmwZCtcXadBhjmlG7HRVtREHD6UX+FkaWMUjkmMOA8i33ExpwEjJ9GK2M/u0b7yhZxSPQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.30.0"
+				"@wordpress/hooks": "^4.41.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -7879,13 +8639,12 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.30.0.tgz",
-			"integrity": "sha512-t+Q4ahm0joocIle1Wb9BpwykXjItk3xsAfIj8yNiCehBRC8z0b9uJHZLzcvs5iP4iDfRooDejAHDeNY26yPP2Q==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.41.0.tgz",
+			"integrity": "sha512-0E0Ps4p9TyiPR0Z6f0L4VmSD9agQBtQ0GIUrijZ9MTArBKbUm7NAUdrJNkbZOg5+AdtmTDjiqxTzwF70EBJhRw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.30.0"
+				"@wordpress/deprecated": "^4.41.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -7893,27 +8652,23 @@
 			}
 		},
 		"node_modules/@wordpress/dom-ready": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.30.0.tgz",
-			"integrity": "sha512-hD5mU0KkgNN4DzBDbBLfRKfZyja4CePK+nRlVTFn8Yo3dGdMAlOjJGaJS1szz7XflDv/ekngj72KoqvJGrrPmg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.41.0.tgz",
+			"integrity": "sha512-cxYJYa4UOmmn4LZibNAREz0RnMmiv2LNxPZl6OcxnZAv8X2fwhU6bbUO//avdhar1cki2bdntISawsc0Rcf0xg==",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.30.0.tgz",
-			"integrity": "sha512-KN/q6359nlb+zh/eamQD0gBgi1616Px7v+03+Hz8HqKUPKozUab1ogxr6Ew751LCYGuh204eG7ImYVM6Aqta0Q==",
+			"version": "1.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.41.0.tgz",
+			"integrity": "sha512-WgWvCMssst//kF1s7sBq92FKMAyQ6epbocNaF8R1i5opCMhEstXlqM9F78Ud15D/8buvbDAmHpumpBufMh93cg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"change-case": "^4.1.2",
-				"form-data": "^4.0.0",
 				"get-port": "^5.1.1",
 				"lighthouse": "^12.2.2",
 				"mime": "^3.0.0",
@@ -7924,44 +8679,47 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": ">=1"
+				"@playwright/test": ">=1",
+				"@types/node": "^20.17.10"
 			}
 		},
 		"node_modules/@wordpress/edit-post": {
-			"version": "8.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.30.0.tgz",
-			"integrity": "sha512-taUZTedJjIlkwArHI8gBmW6BlfICSBNxNdrfgpDtqGg1P4F4x8bOgkR4gaDDB+cFVgeCDajf6Rdf07CCVluxmw==",
+			"version": "8.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.41.0.tgz",
+			"integrity": "sha512-mZjsWUJ5Tgv6Z7u+Z0qu476t0GmqkWd0Nlh72EJ62GTk7L7fAFy+IUve80AcIVrmur8mN4Fk/0HQ+hXyRhFDBA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/a11y": "^4.30.0",
-				"@wordpress/api-fetch": "^7.30.0",
-				"@wordpress/block-editor": "^15.3.0",
-				"@wordpress/block-library": "^9.30.0",
-				"@wordpress/blocks": "^15.3.0",
-				"@wordpress/commands": "^1.30.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/core-data": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/dom": "^4.30.0",
-				"@wordpress/editor": "^14.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/hooks": "^4.30.0",
-				"@wordpress/html-entities": "^4.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/keyboard-shortcuts": "^5.30.0",
-				"@wordpress/keycodes": "^4.30.0",
-				"@wordpress/notices": "^5.30.0",
-				"@wordpress/plugins": "^7.30.0",
-				"@wordpress/preferences": "^4.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/url": "^4.30.0",
-				"@wordpress/viewport": "^6.30.0",
-				"@wordpress/warning": "^3.30.0",
-				"@wordpress/widgets": "^4.30.0",
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/admin-ui": "^1.9.0",
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/block-editor": "^15.14.0",
+				"@wordpress/block-library": "^9.41.0",
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/commands": "^1.41.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/core-data": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/dom": "^4.41.0",
+				"@wordpress/editor": "^14.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/global-styles-engine": "^1.8.0",
+				"@wordpress/hooks": "^4.41.0",
+				"@wordpress/html-entities": "^4.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/keyboard-shortcuts": "^5.41.0",
+				"@wordpress/keycodes": "^4.41.0",
+				"@wordpress/notices": "^5.41.0",
+				"@wordpress/plugins": "^7.41.0",
+				"@wordpress/preferences": "^4.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/url": "^4.41.0",
+				"@wordpress/viewport": "^6.41.0",
+				"@wordpress/warning": "^3.41.0",
+				"@wordpress/widgets": "^4.41.0",
 				"clsx": "^2.1.1",
 				"memize": "^2.1.0"
 			},
@@ -7975,54 +8733,60 @@
 			}
 		},
 		"node_modules/@wordpress/editor": {
-			"version": "14.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.30.0.tgz",
-			"integrity": "sha512-Z4DufUjxe1jgKItQWzG95C5i9VXigSjzyN0hz/obQnebxUwEqvK+Y6dghGlwHWxqjluIVQF4Ss2pfsofAyYWBw==",
+			"version": "14.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.41.0.tgz",
+			"integrity": "sha512-4MRjCgMcgI6Yf3w5EbZjTKbK4H+ZFM2uyP8e5DBTnq5zveuLtLokvVL9sPyHSLrKkwMXWA0Op7NcRWLUX8Rh8A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/a11y": "^4.30.0",
-				"@wordpress/api-fetch": "^7.30.0",
-				"@wordpress/blob": "^4.30.0",
-				"@wordpress/block-editor": "^15.3.0",
-				"@wordpress/blocks": "^15.3.0",
-				"@wordpress/commands": "^1.30.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/core-data": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/dataviews": "^8.0.0",
-				"@wordpress/date": "^5.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/dom": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/fields": "^0.22.0",
-				"@wordpress/hooks": "^4.30.0",
-				"@wordpress/html-entities": "^4.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/interface": "^9.15.0",
-				"@wordpress/keyboard-shortcuts": "^5.30.0",
-				"@wordpress/keycodes": "^4.30.0",
-				"@wordpress/media-utils": "^5.30.0",
-				"@wordpress/notices": "^5.30.0",
-				"@wordpress/patterns": "^2.30.0",
-				"@wordpress/plugins": "^7.30.0",
-				"@wordpress/preferences": "^4.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/reusable-blocks": "^5.30.0",
-				"@wordpress/rich-text": "^7.30.0",
-				"@wordpress/server-side-render": "^6.6.0",
-				"@wordpress/url": "^4.30.0",
-				"@wordpress/warning": "^3.30.0",
-				"@wordpress/wordcount": "^4.30.0",
+				"@floating-ui/react-dom": "2.0.8",
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/blob": "^4.41.0",
+				"@wordpress/block-editor": "^15.14.0",
+				"@wordpress/block-serialization-default-parser": "^5.41.0",
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/commands": "^1.41.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/core-data": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/dataviews": "^13.0.0",
+				"@wordpress/date": "^5.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/dom": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/fields": "^0.33.0",
+				"@wordpress/global-styles-engine": "^1.8.0",
+				"@wordpress/global-styles-ui": "^1.8.0",
+				"@wordpress/hooks": "^4.41.0",
+				"@wordpress/html-entities": "^4.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/interface": "^9.26.0",
+				"@wordpress/keyboard-shortcuts": "^5.41.0",
+				"@wordpress/keycodes": "^4.41.0",
+				"@wordpress/media-editor": "^0.4.0",
+				"@wordpress/media-fields": "^0.6.0",
+				"@wordpress/media-utils": "^5.41.0",
+				"@wordpress/notices": "^5.41.0",
+				"@wordpress/patterns": "^2.41.0",
+				"@wordpress/plugins": "^7.41.0",
+				"@wordpress/preferences": "^4.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/reusable-blocks": "^5.41.0",
+				"@wordpress/rich-text": "^7.41.0",
+				"@wordpress/server-side-render": "^6.17.0",
+				"@wordpress/upload-media": "^0.26.0",
+				"@wordpress/url": "^4.41.0",
+				"@wordpress/warning": "^3.41.0",
+				"@wordpress/wordcount": "^4.41.0",
 				"change-case": "^4.1.2",
 				"client-zip": "^2.4.5",
 				"clsx": "^2.1.1",
 				"date-fns": "^3.6.0",
-				"deepmerge": "^4.3.0",
+				"diff": "^4.0.2",
 				"fast-deep-equal": "^3.1.3",
-				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"react-autosize-textarea": "^7.1.0",
 				"remove-accents": "^0.5.0",
@@ -8038,15 +8802,14 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.30.0.tgz",
-			"integrity": "sha512-hPbnaPcnD1pbLqCmrjNnuFuAIAmyB8JPmD2GpywOXnWaHbtEVX0GaC6iPQSIHShnPqoUBESXXwS3Z8KFz8MBHA==",
+			"version": "6.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.41.0.tgz",
+			"integrity": "sha512-1rM2MhP2epOfsqOz2spOaGmCU/ZtwHdLEF5GkCNEih+Mt2v+oM1xWbSNvt8RoP7Fz7DepBfaDpl6rkVYZgAwkQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.30.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.41.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -8058,32 +8821,30 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.30.0.tgz",
-			"integrity": "sha512-qlyyPKiize/uEyqL1nRMce9GuReZyOum81tOTR14YAngvyRIGz3K3hGwWWf9VrITZrjwuZgqMJc2udSC1uKmKg==",
+			"version": "3.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.41.0.tgz",
+			"integrity": "sha512-xkif63w2OwcOZiJ+YKOmbuUnXAH0PM7YExA6UdQwxDGunED8L/4BY9f0nTEnDN9wFiUCYnqF4MIvMnWEnPwzUA==",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "22.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.16.0.tgz",
-			"integrity": "sha512-1z3rXq2uanCY0m2D1BgimeNGxZOZy87VPwzKRjaf2aPLw/ezoQckiaVGAKYKhbHLt6HFP2EkdKfuD3pmbTJ57g==",
+			"version": "22.22.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.22.0.tgz",
+			"integrity": "sha512-DLGm5i8Gn0vjkZGKF49U2pYME5Jl9AvmoMJB2G508d+sB/oTSkPmM0baUP7G5zxbd1aqfNTaD0KjdyGyWFFKOA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "7.25.7",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.30.0",
-				"@wordpress/prettier-config": "^4.30.0",
+				"@wordpress/babel-preset-default": "^8.36.0",
+				"@wordpress/prettier-config": "^4.36.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
+				"eslint-import-resolver-typescript": "^4.4.4",
 				"eslint-plugin-import": "^2.25.2",
 				"eslint-plugin-jest": "^27.4.3",
 				"eslint-plugin-jsdoc": "^46.4.6",
@@ -8132,35 +8893,36 @@
 			}
 		},
 		"node_modules/@wordpress/fields": {
-			"version": "0.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.22.0.tgz",
-			"integrity": "sha512-Z5srhpvcIPdPXWZVS78SJFc5OPEyrWjMItl8OLB+VYNtDPCi2caY3TvO0kHGO4xpkr3wCxj6kkhDqoszhASpqA==",
+			"version": "0.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.33.0.tgz",
+			"integrity": "sha512-UAinaY8BZXZF7fiOCWvUi5J7OeRtYOMJIQgftoizqQgXu+B7HGCOSmTAL+zQ+JqODQv0iY107EeuwTxq2XfWOw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "^7.30.0",
-				"@wordpress/blob": "^4.30.0",
-				"@wordpress/block-editor": "^15.3.0",
-				"@wordpress/blocks": "^15.3.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/core-data": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/dataviews": "^8.0.0",
-				"@wordpress/date": "^5.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/hooks": "^4.30.0",
-				"@wordpress/html-entities": "^4.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/media-utils": "^5.30.0",
-				"@wordpress/notices": "^5.30.0",
-				"@wordpress/patterns": "^2.30.0",
-				"@wordpress/primitives": "^4.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/router": "^1.30.0",
-				"@wordpress/url": "^4.30.0",
-				"@wordpress/warning": "^3.30.0",
+				"@react-spring/web": "^9.4.5",
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/blob": "^4.41.0",
+				"@wordpress/block-editor": "^15.14.0",
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/core-data": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/dataviews": "^13.0.0",
+				"@wordpress/date": "^5.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/hooks": "^4.41.0",
+				"@wordpress/html-entities": "^4.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/media-utils": "^5.41.0",
+				"@wordpress/notices": "^5.41.0",
+				"@wordpress/patterns": "^2.41.0",
+				"@wordpress/primitives": "^4.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/router": "^1.41.0",
+				"@wordpress/url": "^4.41.0",
+				"@wordpress/warning": "^3.41.0",
 				"change-case": "4.1.2",
 				"client-zip": "^2.4.5",
 				"clsx": "2.1.1",
@@ -8174,41 +8936,90 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/hooks": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.30.0.tgz",
-			"integrity": "sha512-uo3H4KneQSVxFU98jvbw1jN3aYQ/1fPTGqDXZh4NyZx5qras1hE3QhtQU0cO2A8o5/ZNbk/Oek06TnhwsXQPBQ==",
+		"node_modules/@wordpress/global-styles-engine": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.8.0.tgz",
+			"integrity": "sha512-l8eOwkihry/rBwTv50ihNBojhWL9dG/0mztgVMzW7Kp5mh0jiomVGtJRPggfWiYVecOuFg4WkDncEUN9HW8poA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7"
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/style-engine": "^2.41.0",
+				"colord": "^2.9.2",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0"
 			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/global-styles-ui": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/global-styles-ui/-/global-styles-ui-1.8.0.tgz",
+			"integrity": "sha512-P2fM4cO0oK35S1+L+CVxqzdrj97AP6vAFRJLqmJ+Qo4hxJLtZU2aV8DhYON3d3KYTn6kYKdX2xXSXJDnjkoHdw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/block-editor": "^15.14.0",
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/core-data": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/date": "^5.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/global-styles-engine": "^1.8.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/keycodes": "^4.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.0",
+				"colord": "^2.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/hooks": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.41.0.tgz",
+			"integrity": "sha512-WDbLcLA3DOcjDGNLcxHZTPyhltWd/75G2hxFphe/hzcJUNmgysDTSSXO/bBrIWf6rwWD6TS3ejCaGC9J6DwYiw==",
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.30.0.tgz",
-			"integrity": "sha512-SlJ9HM3LYO5cDzLHAP5UytbnI3u2N770JwJkLK1mfCoEIjxa+3cl9faI2ClJp1DvIzGCE4f5LliHdit/D+pARg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.41.0.tgz",
+			"integrity": "sha512-Q+3VNVZiHqzWgrhNNsqrOp+LWt1cDANcP46VuJ6cOOKazA1vA2JcR/0QEoa7HrYCS+KdCCFdwuUpbjQfw2wgrQ==",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.3.0.tgz",
-			"integrity": "sha512-5Dw5JOWlF8JM0hOZnli7MbVshHi9wFPrBkB4CeeJm//arGGYYxw5IYaPJN5jnlMxFAVtCOaXgrxGJoC9mxQBng==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.14.0.tgz",
+			"integrity": "sha512-Rl0zS9eZYxixCpRfQ5pdvStyp9BxZsRgqjE1Ad55ZQl7V8Xv92s/4UG/0FlkBk1wbnrKCmHaaD9lfJJeqEGg0Q==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.30.0",
+				"@wordpress/hooks": "^4.41.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -8222,24 +9033,49 @@
 			}
 		},
 		"node_modules/@wordpress/icons": {
-			"version": "10.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.30.0.tgz",
-			"integrity": "sha512-PT3VGWafx/+XnlftBK8uyrm8XSsFyOJPOnl6v87Om2/I5ihv5+UeCwMLyZP2j2axdSzhcRtkEyBnN7yiOcgBvA==",
+			"version": "11.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.8.0.tgz",
+			"integrity": "sha512-ZMNHApHMmPLpNnNLfPLRf6XWoPhZFNKFKdpMlhA6Lx04J1hLVyLRz8PuM+1o3ByxD2ZiExfSRhdmI+7VvEg6DA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/primitives": "^4.30.0"
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/primitives": "^4.41.0",
+				"change-case": "4.1.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/image-cropper": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.5.0.tgz",
+			"integrity": "sha512-JfysmlASPB0NBdqhDRfOfCkV2zEmonQjg8u3mnBQQka07YL2lzfvH48h2h1PpuyPZqFnZzNJJa0wYKpm805MRQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"clsx": "^2.1.1",
+				"dequal": "^2.0.3",
+				"react-easy-crop": "^5.4.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/interactivity": {
-			"version": "6.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.30.0.tgz",
-			"integrity": "sha512-UbcoXPD3NMeI3r82F0thEHpSF9GdNEePcvQwJ55H6hGjq+eCUO2T47GJ0rsTqjAUzSCaOdC7oCnMi47zsEzrvQ==",
+			"version": "6.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.41.0.tgz",
+			"integrity": "sha512-dFPIP4Yh2WvXkkidy+jIiIOA9AgXiXJABDwrbG+AIfUk/omyma1MX9a2E6winWjNC6IGqcjmr27iaNH93xLWzQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@preact/signals": "^1.3.0",
@@ -8251,13 +9087,13 @@
 			}
 		},
 		"node_modules/@wordpress/interactivity-router": {
-			"version": "2.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.30.0.tgz",
-			"integrity": "sha512-vyOD1wCgN8V5/+UEe/v0oZMWaRiGxGbhUaodmd2YSwGd755FW1LWKlaD9DzUfsxw034hlxJQb3A3Xon9CMN3/g==",
+			"version": "2.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.41.0.tgz",
+			"integrity": "sha512-Y/o0peMhPrgriBPtgW80EkzrasEUDQgKhmDB36HPoMzaVB9sUICR0il/EL2Yo+HgbJKTAzkSuYW5x9E/lJySSg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/a11y": "^4.30.0",
-				"@wordpress/interactivity": "^6.30.0",
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/interactivity": "^6.41.0",
 				"es-module-lexer": "^1.5.4"
 			},
 			"engines": {
@@ -8266,23 +9102,24 @@
 			}
 		},
 		"node_modules/@wordpress/interface": {
-			"version": "9.15.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.15.0.tgz",
-			"integrity": "sha512-IrGy/2nZ2BH3YJAz2DbySCutJYyfqpRsCdI51LTkYjh+8Jv90VDldbCoD1C6ivbTucxSZltF/GfoGq4RRpZXlw==",
+			"version": "9.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.26.0.tgz",
+			"integrity": "sha512-tGF++/+wHqsVTpd+DO/bT/XoJNTu0mV0TdmUar8KXk6Im93JeGbCwlg4CQBCMBVzj1bRjxPEXsI7dL2I8cccdw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/a11y": "^4.30.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/plugins": "^7.30.0",
-				"@wordpress/preferences": "^4.30.0",
-				"@wordpress/viewport": "^6.30.0",
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/admin-ui": "^1.9.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/plugins": "^7.41.0",
+				"@wordpress/preferences": "^4.41.0",
+				"@wordpress/viewport": "^6.41.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -8295,27 +9132,24 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.30.0.tgz",
-			"integrity": "sha512-Q9xoIrxxsNuiaftBciAsHmUU3IVa7V1Es0pzKmwDa3ZFBFeBn3dgrY6iWzeQ4Fe4pBaiG3NagH0qE5Iz3PuG2g==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.41.0.tgz",
+			"integrity": "sha512-1LK5Kr/PoAiBgSxNJysZx3I1cW7MffF8bNnKiauK0+pDhHl1sbDky3rc1wkhQ3QHRrHWscDlVJ7nr01bjQAOFw==",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.30.0.tgz",
-			"integrity": "sha512-Vw7iBqsueb9jCy6RnnjixjLosm+fMi+3iMQDiBB5Pw/yUpr0PUBCR11oQCE/nO3wDl7OOA5Nq3v2qo/wxLBLMg==",
+			"version": "8.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.41.0.tgz",
+			"integrity": "sha512-onUDiCgX11jdgI/Bzy7gqBUBpoeA2zvvLwuTBd943bfJbw+f2rJkBgEeBlxwngqr42tcro/1Sdjx+0LiJuh3BA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"jest-matcher-utils": "^29.6.2"
+				"jest-matcher-utils": "^29.6.2",
+				"jest-mock": "^29.6.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8326,13 +9160,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.30.0.tgz",
-			"integrity": "sha512-nxldSo9luQBfjIFF08hcVT1pEVABe213qBxYWCXMCx3+SPsENRF6pU/yoRb0i7nz6yrd/j5oD92EXXnbQoN8eA==",
+			"version": "12.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.41.0.tgz",
+			"integrity": "sha512-GHH5IzCMVTRHxYPzRbUneXcsh9Y4Tin7B39/FBzvadCcmZDnw4yWqe0VpHF6Zn85b8+mkuq5A6I3/b/FFG48NA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.30.0",
+				"@wordpress/jest-console": "^8.41.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -8345,15 +9179,14 @@
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.30.0.tgz",
-			"integrity": "sha512-X1LGeoqyWFH1lGXUjJ+QUXEBnf5+ty3iO9a5MQecCpSF94ZajPAcN/17LnaftftqF81PantfG2TkXNQ7HydnTg==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.41.0.tgz",
+			"integrity": "sha512-kF/mu1yGWifYX7KjkvnnbufAfTENVuLm24AgW5Yp/3P+kv2s/nbTr5rm4NefXnZOi30/4sipycSe2PhYn1ku2g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/keycodes": "^4.30.0"
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/keycodes": "^4.41.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8364,46 +9197,117 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.30.0.tgz",
-			"integrity": "sha512-IoC7FPADDc5UfjasKRT8YtaLr9WUBDqb8GJpYtiuYjHpDBDgJJPnJwKUMBweCjMl93Zzf7JAHpF7LAkICHDE1A==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.41.0.tgz",
+			"integrity": "sha512-eOdoULyTKXk33CSUxIKTNPRvHvymox1uapyrKFy45rSh+hXMIWhgN/p3jrEfZkZyBS3KTvbVmK5S/wv5OeRfaQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^6.3.0"
+				"@wordpress/i18n": "^6.14.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/latex-to-mathml": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.9.0.tgz",
+			"integrity": "sha512-x7zhVwpwzSCnF9qmS3zGvQp2B4qxZqMi8zcdaxasDoNLGyYDwrW8VBR0kcyLgru5s0QgLbF3WFPS+V+mGWkrnw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"temml": "^0.10.33"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-editor": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/media-editor/-/media-editor-0.4.0.tgz",
+			"integrity": "sha512-MsP3/JkfZZsyFGTmUEXh/nX+YYrfpCVv8y6aB7AYZglvo/u6A4Gwb+nu9DLLzQ6GRQP3UsXnbnDZ9ePMi1NpMg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/dataviews": "^13.0.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-fields": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/media-fields/-/media-fields-0.6.0.tgz",
+			"integrity": "sha512-mjGQZtmyjLt1M1nVaYYML/aZp7nIdQo6yx88CtnZGeZmdvvcUJgNOsOFkFnsIpKV8i/z7GfhYTl9wsgvQSZQMQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/core-data": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/dataviews": "^13.0.0",
+				"@wordpress/date": "^5.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/primitives": "^4.41.0",
+				"@wordpress/url": "^4.41.0",
+				"clsx": "2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/media-utils": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.30.0.tgz",
-			"integrity": "sha512-2wehODR/rrtr9gnBxpcAwrV0aulYlckOV0lGwnASaZZn0vcxMFiy6GADfqQp/UI0hsOk8c/EOwQmnum5GTqVmA==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.41.0.tgz",
+			"integrity": "sha512-v2WmGFFn0TOZa4nu8iVZaYZGOM/PhNEDV4r/Fa6nLsmr/S1Q+SrArtllAibGf+sREpv1f4Z5NQ/YT5LE1T//dA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "^7.30.0",
-				"@wordpress/blob": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/private-apis": "^1.30.0"
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/blob": "^4.41.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/core-data": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/dataviews": "^13.0.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/media-fields": "^0.6.0",
+				"@wordpress/notices": "^5.41.0",
+				"@wordpress/private-apis": "^1.41.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/notices": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.30.0.tgz",
-			"integrity": "sha512-iEIBi7r+3dFPPOXE76WKP6f1Y9gVRr+jqca6LK3erGABvETVOYhrtFVoq0aAyDcpONc1c80TvFdO5OudCepafQ==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.41.0.tgz",
+			"integrity": "sha512-iq/uyu14eWGYY7cv5fSdFwvldL7owOvAg/BRKo8Xer4yxQs1J6yuMDlJ9LnQREvMvSKgyc/ZBeOs4j41NMSX3w==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/a11y": "^4.30.0",
-				"@wordpress/data": "^10.30.0"
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/data": "^10.41.0",
+				"clsx": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8414,9 +9318,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.30.0.tgz",
-			"integrity": "sha512-pJ5XMmj2Osk05/TFrCpf6l6VuxWDU837ISKW1bXAmBfpnLTlUuVUl6pTWbIE4gNZqb2faSBQSN3OPeQqt4RNJg==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.41.0.tgz",
+			"integrity": "sha512-TtPvEh9TFSMlSWscYxnfXpqYc3TiKQKPc48tIgc8IrK8g6UwdKRkEdL6EMBMdeP8XjQ44nwFzpE0v5NwqHNSOg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -8428,26 +9332,26 @@
 			}
 		},
 		"node_modules/@wordpress/patterns": {
-			"version": "2.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.30.0.tgz",
-			"integrity": "sha512-/TnytOpuMsMIE+wFvAkL7A5JWPfYhUQufWECjrYEMPdj210vU1vZN1lxVSCYiZoyOwHDL6dtZ/XNVHnYvPKdQg==",
+			"version": "2.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.41.0.tgz",
+			"integrity": "sha512-daVq75SArgBLqB3CJVkbH9nAVhN5ylEpVYfNq57nRspOD8ll9Mk9Vv1gkboF+uNIUOYtmuyXZ+oh4EJA4SGRBg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/a11y": "^4.30.0",
-				"@wordpress/block-editor": "^15.3.0",
-				"@wordpress/blocks": "^15.3.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/core-data": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/html-entities": "^4.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/notices": "^5.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/url": "^4.30.0"
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/block-editor": "^15.14.0",
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/core-data": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/html-entities": "^4.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/notices": "^5.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/url": "^4.41.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8459,19 +9363,18 @@
 			}
 		},
 		"node_modules/@wordpress/plugins": {
-			"version": "7.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.30.0.tgz",
-			"integrity": "sha512-xD6Fh+EUfrQnbc2c2mae1m42U9AuyAFhu7Azr7TMCECCz5HENKj4rB8wGJ647TAl82D5Apm1xn4kYN3FMUQY/A==",
+			"version": "7.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.41.0.tgz",
+			"integrity": "sha512-FIJPZEYmBnuI9htuImELfAcNb5h9z2CZ/dVpI8a4YqSQWS4U6l+y/w5YHqkpfGbjwtxA5hngt0n30E5UfP/f5A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/hooks": "^4.30.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/is-shallow-equal": "^5.30.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/hooks": "^4.41.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/is-shallow-equal": "^5.41.0",
 				"memize": "^2.0.1"
 			},
 			"engines": {
@@ -8484,14 +9387,15 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.30.0.tgz",
-			"integrity": "sha512-3mB+tqN9uIQ6h1SXtQUFowNeCv/Cy6vWsUBhPkgU3hj7LQrGbCAmMWefDAQeYHyG0lQfSrAD6jctZ2wZmNXwsQ==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.41.0.tgz",
+			"integrity": "sha512-3zWCfuySY6WfLLL3fmO8iJ+g3QNceb7NQXFGvSnPRYhR+tJdWLEC7spo+juho3WX7raYkqsxUjYekUmMcJTF9Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^6.6.0",
-				"autoprefixer": "^10.4.20"
+				"@wordpress/base-styles": "^6.17.0",
+				"autoprefixer": "^10.4.20",
+				"postcss-import": "^16.1.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8502,21 +9406,21 @@
 			}
 		},
 		"node_modules/@wordpress/preferences": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.30.0.tgz",
-			"integrity": "sha512-QzBm0pjBbDH6GufTAPYsi5c4CfJnefS7u7AsRFRVCy0hQScXu+q/hTPrGWg5nsV1xuwLR0KGwlF2p/bX1JUnYg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.41.0.tgz",
+			"integrity": "sha512-IVpbqqn5ZqXhkzwRBf4rTuGFTcxRJyzyqqVHleZNvMNdbpktrF8moUh9pTwCY+0PeSicL9vc1WusOt/TzAmucQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/a11y": "^4.30.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/private-apis": "^1.30.0",
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/private-apis": "^1.41.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -8529,9 +9433,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.30.0.tgz",
-			"integrity": "sha512-b0tOy/H0A1ilsjAGUKqMJ3idMQbe1XS7K2ViqG62ZMJRUYBEZ1x3t+ne3Z2fVbyNVhrMqq3eZK9BSEuxr67cSg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.41.0.tgz",
+			"integrity": "sha512-Zzy+ZvxV6JoUptL2J88w7CNjJbdG/ouILJYWSIm3PWoQQnLgNtGLXqquS2YVfOnOhqdIlcXvMrAFZ0ASQ70B4w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -8543,13 +9447,12 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.30.0.tgz",
-			"integrity": "sha512-xKstIDGv0dG35X9kX65ZPCtAe4s06gUqJVbOf3oFD9b5PXoL2vjC3/kc5GG2jO56pLahKPLoqitH9maCJcGQEQ==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.41.0.tgz",
+			"integrity": "sha512-ohPpBUkjkYQPki6Nl2BneFYapJE5xpxONVJfGMg0FGBqvzbuyR8pmGeH4PVfQGeGJ4xUwSdNcxfQ6nzyoT4bLA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.30.0",
+				"@wordpress/element": "^6.41.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -8561,12 +9464,11 @@
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.30.0.tgz",
-			"integrity": "sha512-XScxqCjlLnijcZdoon9tUpBqw7BDBqNZQT1pgLcy0Pe661hDDvhsQ7fSapZ/KjrNnecE1uuxKQXQBXDNoJA0Eg==",
+			"version": "3.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.41.0.tgz",
+			"integrity": "sha512-vOUvDin0/rHkHxyaF8ccuL/AToLOUKxJOP0WDI+Ne6VrBthTYC+xAhHhA1AEWV5SyJkpoOx74W6DQK4mLNabdA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"requestidlecallback": "^0.3.0"
 			},
 			"engines": {
@@ -8575,25 +9477,21 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.30.0.tgz",
-			"integrity": "sha512-0EaWB+JxJ4t3Bylzk3xXu7Khqi0TOXYX9qDOm9W0Wy+J6xGzlkz8rSF73MvT+6JQTNNwietWHqkkHcn6dFGIXQ==",
+			"version": "1.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.41.0.tgz",
+			"integrity": "sha512-5bVOGCJGJyD+5IhGtdLxLBsbJd+B1Ohx93COLbqMY4pGAnhNifNgt1rgsYWUjqHVLh80EnvL4HQeMzEncydNLA==",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.30.0.tgz",
-			"integrity": "sha512-1cabT7u4pryjnsAe5uG6hV1Rwhh1HC+VIMz41wuMQCZ3Te1xYIjj4uWAf+u1H2Vrcz6an0pijh4OLXq/S/AB5A==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.41.0.tgz",
+			"integrity": "sha512-Zqwb8gkls/2EpiiLqnrrCiWKl9cTDD43ewpOamvel6pbdiB5MKDzGJCmz8UW6aL/PpqiVcoom5KMseY8PhoraQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
 				"rungen": "^0.3.2"
@@ -8607,23 +9505,23 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.30.0.tgz",
-			"integrity": "sha512-Vp+gGWV+PxX1lRqv6DzfScQr4wrol4AzMhWOFTa98Umy2ubqrwBwtQm20t9S2ss18qqiCKq1C7Wwud6rYRA3MA==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.41.0.tgz",
+			"integrity": "sha512-wSIpneUQB/zgwYJQSfxet9IxfkIe6sV/Ax9r/JDWfpLkG1yL9ziECN73YNYku3Tdo/53rlJ8ZbNdMCFgv4MMUg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/block-editor": "^15.3.0",
-				"@wordpress/blocks": "^15.3.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/core-data": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/notices": "^5.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/url": "^4.30.0"
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/block-editor": "^15.14.0",
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/core-data": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/notices": "^5.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/url": "^4.41.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8635,20 +9533,21 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.30.0.tgz",
-			"integrity": "sha512-2aQRtxWslGd7FUqKbBHFHuVefwi3jnFp5WWJD/gxSVGEWJ3i48XuLtXLGK6V9XiutuoUbG+8C1Bx2lq3WaPMXg==",
+			"version": "7.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.41.0.tgz",
+			"integrity": "sha512-JJn63a5XXqrQkKBiJX22zkmuDo7Mk7es35I5y5aP3dsVpNyMHLujXk3CjaMVtZ3ye6j20jjOXWoR0KLViiREQw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/a11y": "^4.30.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/escape-html": "^3.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/keycodes": "^4.30.0",
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/dom": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/escape-html": "^3.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/keycodes": "^4.41.0",
+				"@wordpress/private-apis": "^1.41.0",
 				"colord": "2.9.3",
 				"memize": "^2.1.0"
 			},
@@ -8660,17 +9559,34 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/router": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.30.0.tgz",
-			"integrity": "sha512-Fmpcnqj8/L17q9f3/pejNLoGnUMl8zMkG8qO8n/x9dZUYnDmznQxWNnsOnnvEmidu85Kwl8/SySMYMe4mj/zVQ==",
+		"node_modules/@wordpress/route": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/route/-/route-0.7.0.tgz",
+			"integrity": "sha512-6gv0hXb+bhGNK7bLAdcbMoDOdrXFRfsJfSN1P8hm429myZESmhYrh0mEV4at4y44C06zGPTqyzSKH0sR0eCMkg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/url": "^4.30.0",
+				"@tanstack/history": "^1.133.28",
+				"@tanstack/react-router": "^1.120.5",
+				"@wordpress/private-apis": "^1.41.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/router": {
+			"version": "1.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.41.0.tgz",
+			"integrity": "sha512-AUd8EnUzACx8f1fJ6z4pssUgBQzFPQRRABgbsiWGrn911mntq15MHpssYIx/Uae2+IHa2Vm5ZZjmWNpfnw78bQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/url": "^4.41.0",
 				"history": "^5.3.0",
 				"route-recognizer": "^0.3.4"
 			},
@@ -8683,25 +9599,25 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "30.23.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.23.0.tgz",
-			"integrity": "sha512-IVMv4GvSxZQuj/JybHMHA0BbScv2//tELUQSHMe7IHRxvaqzd8WDJgMfnwaqQWOmtw8d4739w7kAEo26kh6zWA==",
+			"version": "30.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.27.0.tgz",
+			"integrity": "sha512-gXGptazCxAaR7g8kcN5joj7B5fCm0VeBHOmnDBs2dbQ4W4F3tfzdg6CTEj8LonF9bWQXlSy3ku8EqWCdkSG9Xw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.30.0",
-				"@wordpress/browserslist-config": "^6.30.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.30.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.30.0",
-				"@wordpress/eslint-plugin": "^22.16.0",
-				"@wordpress/jest-preset-default": "^12.30.0",
-				"@wordpress/npm-package-json-lint-config": "^5.30.0",
-				"@wordpress/postcss-plugins-preset": "^5.30.0",
-				"@wordpress/prettier-config": "^4.30.0",
-				"@wordpress/stylelint-config": "^23.22.0",
+				"@wordpress/babel-preset-default": "^8.34.0",
+				"@wordpress/browserslist-config": "^6.34.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.34.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.34.0",
+				"@wordpress/eslint-plugin": "^22.20.0",
+				"@wordpress/jest-preset-default": "^12.34.0",
+				"@wordpress/npm-package-json-lint-config": "^5.34.0",
+				"@wordpress/postcss-plugins-preset": "^5.34.0",
+				"@wordpress/prettier-config": "^4.34.0",
+				"@wordpress/stylelint-config": "^23.26.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",
@@ -8757,7 +9673,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.55.0",
+				"@playwright/test": "^1.56.1",
 				"@wordpress/env": "^10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
@@ -8816,21 +9732,20 @@
 			}
 		},
 		"node_modules/@wordpress/server-side-render": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.6.0.tgz",
-			"integrity": "sha512-TeSbLhNYGX6xYkNDAKQ/l9GTkCx93AlIndrkdZiVtG535NWolYFxV6CDN7g/nFBMYIqd19vKiez/aUUtrKkPyw==",
+			"version": "6.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.17.0.tgz",
+			"integrity": "sha512-CjiC1a0ghZgctKhJPtjMG/sbUXzj99tJCHv7Te6Fc9Ix5CqtucO5hAPGH7x8L48wWjWbB8gulSQWvOkalZMidw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "^7.30.0",
-				"@wordpress/blocks": "^15.3.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/deprecated": "^4.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/url": "^4.30.0"
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/deprecated": "^4.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/url": "^4.41.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8842,12 +9757,11 @@
 			}
 		},
 		"node_modules/@wordpress/shortcode": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.30.0.tgz",
-			"integrity": "sha512-x7bw8NX+4tw3XauuvkM4s8SvgYVF81FiaS31YmFQ3J+g8oKokx6x+7WnrO4HHELTUNbUw6RSI/cfFSw+Xua/pg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.41.0.tgz",
+			"integrity": "sha512-OpeBbl4o5Xp/5cAyvG7ObYo01Of/vLHJPf+Dh8VcFsKuH7zEz0uHaHj5YmS0dHl30mnjrZVVX5eX30Y3JrWFkQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"memize": "^2.0.1"
 			},
 			"engines": {
@@ -8856,12 +9770,11 @@
 			}
 		},
 		"node_modules/@wordpress/style-engine": {
-			"version": "2.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.30.0.tgz",
-			"integrity": "sha512-YpMuMx76x2IhYjOZbljVgxJEgX/FduBJleMsMMvciPGCBsvcjfPxqliwGaauofnk7/kN4E7LFyT1o9cErqiw3g==",
+			"version": "2.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.41.0.tgz",
+			"integrity": "sha512-wqj31IMQWsKGuZZfhYfaShtDFuzyH6xk7oQRGemgnULeTcuZLks4pxQye9IF6/0yEnCeUdDmng3nX9t+scb7VA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"change-case": "^4.1.2"
 			},
 			"engines": {
@@ -8870,13 +9783,14 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.22.0.tgz",
-			"integrity": "sha512-d1aEVn6jbMFFJh3SqpGKoNsnm0DcYD6TwgzLLlIL11kslyFEn6mfiKJVeVNIgWQe7sBDEtUkE7h4qEOSDbxO8A==",
+			"version": "23.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.33.0.tgz",
+			"integrity": "sha512-DSz76UQakmNvhv9OuI8/Ym8dhqUMYcJ4LP4Hy29pNobrcmaLMu1bwxGFGLVDfv9yyLxic001TBn9leZXPbqliA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/stylelint-plugin": "^3.0.1",
+				"@wordpress/theme": "^0.8.0",
 				"stylelint-config-recommended": "^14.0.1",
 				"stylelint-config-recommended-scss": "^14.1.0"
 			},
@@ -8890,48 +9804,105 @@
 			}
 		},
 		"node_modules/@wordpress/sync": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.30.0.tgz",
-			"integrity": "sha512-gbCnWHsrgGA4G2rdCTldrkauFBeB1kZCj6Rvzpf97FVX2xiagt3/LP5u8tW96qBB5qsJhx/uJ1Wv0uhuiBX/tg==",
+			"version": "1.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.41.0.tgz",
+			"integrity": "sha512-mLSlFYEoBkD72NOXT82k1xzLXFYUFxtV8TR/qc0XoTM3H3E8b8K6X1Xd2ITQKx47JB9dwJncROVWtK5Y9+DCmQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/simple-peer": "^9.11.5",
-				"@wordpress/url": "^4.30.0",
-				"import-locals": "^2.0.0",
-				"lib0": "^0.2.42",
-				"simple-peer": "^9.11.0",
-				"y-indexeddb": "~9.0.11",
-				"y-protocols": "^1.0.5",
-				"y-webrtc": "~10.2.5",
-				"yjs": "~13.6.6"
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/hooks": "^4.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/undo-manager": "^1.41.0",
+				"diff": "^8.0.3",
+				"fast-deep-equal": "^3.1.3",
+				"lib0": "0.2.99",
+				"y-protocols": "^1.0.7",
+				"yjs": "13.6.29"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/sync/node_modules/diff": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/@wordpress/theme": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.8.0.tgz",
+			"integrity": "sha512-xXGjWNFHICBuMNfjCjTui5ChkiKmmPTJtsF5tPXnUBXJaw43xxGlL0y7lpCNPJQxz+NPMJ01KlGfxhRsHXjKrQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/token-list": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.30.0.tgz",
-			"integrity": "sha512-zK4MJd2y7bvzuyMhGPeiErbwZDvXjQwodkTwUM/KiJVgfXjR98O2YBc70ZGOrhpzPeIb81PZljwiNTIx7NI6dA==",
+			"version": "3.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.41.0.tgz",
+			"integrity": "sha512-yeAp2BTDsSMBxdl1AjB8rxD3JiIFHC8LKy4XclspBC3vIjl0OUw4I5Hi2xBtrLR4P9o8nEGp4KQPzkt9g9uZZA==",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/undo-manager": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.30.0.tgz",
-			"integrity": "sha512-pbvkzMLJrozAoaB+KOVSiRFvKvfxDrSt0jWmWCDnobbDRsmrSJRQaANw4RcoNShHuMOzd1wJ1KruK4Dtypf5MQ==",
+		"node_modules/@wordpress/ui": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.8.0.tgz",
+			"integrity": "sha512-tAlCQ3uO+rnqPwVFzPEmSUqyADk3Gp0KnnSrYGzBadjEx474hattHsLkyhGHi+DD5Txx94b582gDcL9w9siHVQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/is-shallow-equal": "^5.30.0"
+				"@base-ui/react": "^1.2.0",
+				"@wordpress/a11y": "^4.41.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/keycodes": "^4.41.0",
+				"@wordpress/primitives": "^4.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/theme": "^0.8.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/undo-manager": {
+			"version": "1.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.41.0.tgz",
+			"integrity": "sha512-z7HgqaBeL24NZe3vvaj9VE3W9ODUEhclkpCwIiMawaA5d5RIOzR9SIEwG4wY01jnOro/GXXSmbvku51SbZyB2Q==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/is-shallow-equal": "^5.41.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8939,21 +9910,21 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.15.0.tgz",
-			"integrity": "sha512-bIQKxGczbI3DMam1+lLuQiQdP+quen1OATIoVJzW1v/pYfcumZUueOQTmkhFPB/8RpxnGVyFJonTyqMWg49vjw==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.26.0.tgz",
+			"integrity": "sha512-YwIVBm01XndJI5abMoePaj5HybUv8uYKr2SjZ4JG8eKnquKTX7Q9GOHojsNeLlg+Y9Go6orD8d0CkbJU1luk3g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "^7.30.0",
-				"@wordpress/blob": "^4.30.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/preferences": "^4.30.0",
-				"@wordpress/private-apis": "^1.30.0",
-				"@wordpress/url": "^4.30.0",
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/blob": "^4.41.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/preferences": "^4.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"@wordpress/url": "^4.41.0",
+				"@wordpress/vips": "^1.1.0",
 				"uuid": "^9.0.1"
 			},
 			"engines": {
@@ -8966,12 +9937,11 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.30.0.tgz",
-			"integrity": "sha512-oFiQQBy/2G9fct1Df52ypu3d2nYiq2k2GkOdfMHRFYI1N3k0JP7rinwyePU+37mHPCzYuJK6TuMDxoKh8oMpKg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.41.0.tgz",
+			"integrity": "sha512-vmCnp1PLowAwisnUSHH2x2p5zg5RtENx+Vl9gmc9B5BiHkNWhEXcU4PpsaOcRRhCadjDToNiTsOm9v1lHF3n4A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
@@ -8980,15 +9950,14 @@
 			}
 		},
 		"node_modules/@wordpress/viewport": {
-			"version": "6.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.30.0.tgz",
-			"integrity": "sha512-L0b+lMkm9aLYF+a08YDcEPgtWhKavQLjarmI4W2MtplvRNh4i4/+ehMouqVlbLyrR3vdGTWW5M8/NgK4gVHBUA==",
+			"version": "6.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.41.0.tgz",
+			"integrity": "sha512-awCsEas+T5405pnNlWCE/Y1yzj9gtBpBOr3UJoCFgRV25iH3+kzS4nYvBFy6dI32504XQpvbpG3gKrP++u62xw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/element": "^6.30.0"
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/element": "^6.41.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8998,10 +9967,24 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/vips": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-1.1.0.tgz",
+			"integrity": "sha512-6oE+aWbvfS98orugNPPuXmC9H197QgUkUkC/4YH4xnRdACmtp7s9mVTNIRc53dsXbKi2ZaE5YgeYoN5D2llatg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/worker-threads": "^1.1.0",
+				"wasm-vips": "^0.0.16"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.30.0.tgz",
-			"integrity": "sha512-ZtkpSe3DhtUzIrwf+5slGkJJCxy1xn56fZ6atUaJWRbjsKnIZlTcPgahPUJZ2bugsGS5BlmDEuVI8C4NUdbwvQ==",
+			"version": "3.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.41.0.tgz",
+			"integrity": "sha512-WhyGL1y6y18cZwOQeCOI9K+kWc8F9KAni9YQKZVYSriazbSPNOQGWpUdeKZVGbimBEjEspK7FQBE4pUW3q+D8w==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -9009,23 +9992,23 @@
 			}
 		},
 		"node_modules/@wordpress/widgets": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.30.0.tgz",
-			"integrity": "sha512-X8OJow1AULOqc+hUKpG2MiCpz/lM6ZKqRWdDxPsjhvyO4tBoquQBLZskeC2agwX8YuogC+jiHNG0uKMoE58z0w==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.41.0.tgz",
+			"integrity": "sha512-sRv5d7a9z3BuYfBm4gWC46WRL3KdLxwA5e56s/qgNVEbvV7TFiXHZSnBp/PoO2GWF7CUdQz6DI20e5vnp4+X6A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "^7.30.0",
-				"@wordpress/block-editor": "^15.3.0",
-				"@wordpress/blocks": "^15.3.0",
-				"@wordpress/components": "^30.3.0",
-				"@wordpress/compose": "^7.30.0",
-				"@wordpress/core-data": "^7.30.0",
-				"@wordpress/data": "^10.30.0",
-				"@wordpress/element": "^6.30.0",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/icons": "^10.30.0",
-				"@wordpress/notices": "^5.30.0",
+				"@wordpress/api-fetch": "^7.41.0",
+				"@wordpress/base-styles": "^6.17.0",
+				"@wordpress/block-editor": "^15.14.0",
+				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/components": "^32.3.0",
+				"@wordpress/compose": "^7.41.0",
+				"@wordpress/core-data": "^7.41.0",
+				"@wordpress/data": "^10.41.0",
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/i18n": "^6.14.0",
+				"@wordpress/icons": "^11.8.0",
+				"@wordpress/notices": "^5.41.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -9038,12 +10021,22 @@
 			}
 		},
 		"node_modules/@wordpress/wordcount": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.30.0.tgz",
-			"integrity": "sha512-WGALjfdw0/Cl8BiJiTCM9hlGRmSErubqM9IWSKkcHNwxFV5FoOdZOzWB6xxMhxR4u9TL0QXCDkR9p6DoJEzBYw==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.41.0.tgz",
+			"integrity": "sha512-/22Fon1owjl4VnSD6ewReUZ+wEcNUsxEcZoKF/ew0CqOaprMwog3kPWq3Jub6Mt0aBWmjtrJ7Nhuo+wVkQ3Kog==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/worker-threads": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.1.0.tgz",
+			"integrity": "sha512-rtYENJzqb0ioLmQ+GY0yxUt0vEtkys3TlopYOAAOZIUTODfzPvm1+NQybntF9nWZGipmAVQl8bDmPlHU9n+96Q==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7"
+				"comctx": "^1.4.3"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9092,10 +10085,11 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -9176,10 +10170,11 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-			"dev": true,
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"devOptional": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -9285,7 +10280,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -9294,7 +10289,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -9332,7 +10327,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/aria-hidden": {
 			"version": "1.2.6",
@@ -9414,7 +10409,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -9554,6 +10549,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9581,7 +10577,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -9604,19 +10600,20 @@
 			"dev": true
 		},
 		"node_modules/atomically": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
-			"integrity": "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+			"integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"stubborn-fs": "^1.2.5",
-				"when-exit": "^2.1.1"
+				"stubborn-fs": "^2.0.0",
+				"when-exit": "^2.1.4"
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.21",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-			"integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+			"version": "10.4.27",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+			"integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
 			"dev": true,
 			"funding": [
 				{
@@ -9634,10 +10631,9 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.24.4",
-				"caniuse-lite": "^1.0.30001702",
-				"fraction.js": "^4.3.7",
-				"normalize-range": "^0.1.2",
+				"browserslist": "^4.28.1",
+				"caniuse-lite": "^1.0.30001774",
+				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -9674,9 +10670,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
-			"integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+			"integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"engines": {
@@ -9988,6 +10984,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -10002,6 +10999,19 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.7",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
+			"integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/basic-ftp": {
 			"version": "5.0.5",
@@ -10135,7 +11145,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"fill-range": "^7.1.1"
 			},
@@ -10144,9 +11154,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.25.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
-			"integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
 			"dev": true,
 			"funding": [
 				{
@@ -10162,11 +11172,13 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001737",
-				"electron-to-chromium": "^1.5.211",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.3"
+				"baseline-browser-mapping": "^2.9.0",
+				"caniuse-lite": "^1.0.30001759",
+				"electron-to-chromium": "^1.5.263",
+				"node-releases": "^2.0.27",
+				"update-browserslist-db": "^1.2.0"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -10183,30 +11195,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"node-int64": "^0.4.0"
-			}
-		},
-		"node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/buffer-crc32": {
@@ -10250,6 +11238,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
 			"integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+			"license": "MIT",
 			"dependencies": {
 				"bytewise-core": "^1.2.2",
 				"typewise": "^1.0.3"
@@ -10259,29 +11248,33 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
 			"integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+			"license": "MIT",
 			"dependencies": {
 				"typewise-core": "^1.2"
 			}
 		},
 		"node_modules/cacheable": {
-			"version": "1.10.4",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.4.tgz",
-			"integrity": "sha512-Gd7ccIUkZ9TE2odLQVS+PDjIvQCdJKUlLdJRVvZu0aipj07Qfx+XIej7hhDrKGGoIxV5m5fT/kOJNJPQhQneRg==",
-			"dev": true,
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.3.tgz",
+			"integrity": "sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"hookified": "^1.11.0",
-				"keyv": "^5.5.0"
+				"@cacheable/memory": "^2.0.8",
+				"@cacheable/utils": "^2.4.0",
+				"hookified": "^1.15.0",
+				"keyv": "^5.6.0",
+				"qified": "^0.6.0"
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.0.tgz",
-			"integrity": "sha512-QG7qR2tijh1ftOvClut4YKKg1iW6cx3GZsKoGyJPxHkGWK9oJhG9P3j5deP0QQOGDowBMVQFaP+Vm4NpGYvmIQ==",
-			"dev": true,
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@keyv/serialize": "^1.1.0"
+				"@keyv/serialize": "^1.1.1"
 			}
 		},
 		"node_modules/call-bind": {
@@ -10402,9 +11395,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001739",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz",
-			"integrity": "sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==",
+			"version": "1.0.30001778",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
+			"integrity": "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==",
 			"dev": true,
 			"funding": [
 				{
@@ -10419,7 +11412,8 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			]
+			],
+			"license": "CC-BY-4.0"
 		},
 		"node_modules/capital-case": {
 			"version": "1.0.4",
@@ -10570,9 +11564,9 @@
 			}
 		},
 		"node_modules/chrome-launcher": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.0.tgz",
-			"integrity": "sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+			"integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -10788,9 +11782,9 @@
 			}
 		},
 		"node_modules/collect-v8-coverage": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-			"integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+			"integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10798,7 +11792,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -10810,7 +11804,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/color-parse": {
 			"version": "2.0.2",
@@ -10841,6 +11835,16 @@
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
 		},
+		"node_modules/colorjs.io": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
+			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/color"
+			}
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -10852,6 +11856,12 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/comctx": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/comctx/-/comctx-1.6.1.tgz",
+			"integrity": "sha512-ZMRGAYASYRdVfEoB7oxH8Nqu5Ay8I+YvAsQni+td0pYV9eww/PrtSFVyvc2JkNQyHXGDknCB4wJfxFYP6fuqZg==",
+			"license": "MIT"
 		},
 		"node_modules/comma-separated-tokens": {
 			"version": "2.0.3",
@@ -10945,9 +11955,9 @@
 			"dev": true
 		},
 		"node_modules/configstore": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.0.0.tgz",
-			"integrity": "sha512-yk7/5PN5im4qwz0WFZW3PXnzHgPu9mX29Y8uZ3aefe2lBPC1FYttWZRcaW9fKkT0pBCJyuQ2HfbmPVaODi9jcQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+			"integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -10960,7 +11970,7 @@
 				"node": ">=18"
 			},
 			"funding": {
-				"url": "https://github.com/yeoman/configstore?sponsor=1"
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/connect-history-api-fallback": {
@@ -11017,6 +12027,12 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/cookie-es": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
+			"integrity": "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==",
+			"license": "MIT"
 		},
 		"node_modules/cookie-signature": {
 			"version": "1.0.6",
@@ -11105,9 +12121,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.45.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
-			"integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+			"integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -11236,29 +12252,30 @@
 			}
 		},
 		"node_modules/css-functions-list": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
-			"integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
-			"dev": true,
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+			"integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12 || >=16"
+				"node": ">=12"
 			}
 		},
 		"node_modules/css-loader": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
-			"integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.4.tgz",
+			"integrity": "sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"icss-utils": "^5.1.0",
-				"postcss": "^8.4.33",
+				"postcss": "^8.4.40",
 				"postcss-modules-extract-imports": "^3.1.0",
 				"postcss-modules-local-by-default": "^4.0.5",
 				"postcss-modules-scope": "^3.2.0",
 				"postcss-modules-values": "^4.0.0",
 				"postcss-value-parser": "^4.2.0",
-				"semver": "^7.5.4"
+				"semver": "^7.6.3"
 			},
 			"engines": {
 				"node": ">= 18.12.0"
@@ -11268,7 +12285,7 @@
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"@rspack/core": "0.x || 1.x",
+				"@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
 				"webpack": "^5.27.0"
 			},
 			"peerDependenciesMeta": {
@@ -11342,7 +12359,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-			"dev": true,
+			"devOptional": true,
 			"bin": {
 				"cssesc": "bin/cssesc"
 			},
@@ -11484,9 +12501,10 @@
 			"dev": true
 		},
 		"node_modules/csstype": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"license": "MIT"
 		},
 		"node_modules/cwd": {
 			"version": "0.10.0",
@@ -11607,9 +12625,10 @@
 			"dev": true
 		},
 		"node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -11678,9 +12697,9 @@
 			}
 		},
 		"node_modules/dedent": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
-			"integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -11886,9 +12905,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
@@ -11908,7 +12927,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"path-type": "^4.0.0"
 			},
@@ -11945,7 +12964,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
 			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.2",
@@ -11959,7 +12977,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
 			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -11984,7 +13001,6 @@
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
 			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
 			"dependencies": {
 				"domelementtype": "^2.3.0"
 			},
@@ -11999,7 +13015,6 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
 			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-			"dev": true,
 			"dependencies": {
 				"dom-serializer": "^2.0.0",
 				"domelementtype": "^2.3.0",
@@ -12066,10 +13081,11 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.212",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.212.tgz",
-			"integrity": "sha512-gE7ErIzSW+d8jALWMcOIgf+IB6lpfsg6NwOhPVwKzDtN2qcBix47vlin4yzSregYDxTCXOUqAZjVY/Z3naS7ww==",
-			"dev": true
+			"version": "1.5.313",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
+			"integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/emittery": {
 			"version": "0.13.1",
@@ -12088,7 +13104,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/emojis-list": {
 			"version": "3.0.0",
@@ -12127,13 +13143,14 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.3",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
-			"integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+			"integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.3.0"
 			},
 			"engines": {
 				"node": ">=10.13.0"
@@ -12157,7 +13174,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
 			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -12169,7 +13185,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
 			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -12193,12 +13209,6 @@
 			"integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
 			"license": "MIT"
 		},
-		"node_modules/err-code": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-			"integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
-			"license": "MIT"
-		},
 		"node_modules/error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -12217,9 +13227,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-			"integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+			"version": "1.24.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+			"integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12304,27 +13314,28 @@
 			}
 		},
 		"node_modules/es-iterator-helpers": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
-			"integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
+			"integrity": "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
+				"call-bound": "^1.0.4",
 				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.6",
+				"es-abstract": "^1.24.1",
 				"es-errors": "^1.3.0",
-				"es-set-tostringtag": "^2.0.3",
+				"es-set-tostringtag": "^2.1.0",
 				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.6",
+				"get-intrinsic": "^1.3.0",
 				"globalthis": "^1.0.4",
 				"gopd": "^1.2.0",
 				"has-property-descriptors": "^1.0.2",
 				"has-proto": "^1.2.0",
 				"has-symbols": "^1.1.0",
 				"internal-slot": "^1.1.0",
-				"iterator.prototype": "^1.1.4",
+				"iterator.prototype": "^1.1.5",
+				"math-intrinsics": "^1.1.0",
 				"safe-array-concat": "^1.1.3"
 			},
 			"engines": {
@@ -12334,7 +13345,8 @@
 		"node_modules/es-module-lexer": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -12421,7 +13433,8 @@
 		"node_modules/escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"dev": true
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -12535,6 +13548,31 @@
 				"eslint": ">=7.0.0"
 			}
 		},
+		"node_modules/eslint-import-context": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+			"integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-tsconfig": "^4.10.1",
+				"stable-hash-x": "^0.2.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-import-context"
+			},
+			"peerDependencies": {
+				"unrs-resolver": "^1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"unrs-resolver": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/eslint-import-resolver-node": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -12555,6 +13593,41 @@
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-import-resolver-typescript": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
+			"integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"debug": "^4.4.1",
+				"eslint-import-context": "^0.1.8",
+				"get-tsconfig": "^4.10.1",
+				"is-bun-module": "^2.0.0",
+				"stable-hash-x": "^0.2.0",
+				"tinyglobby": "^0.2.14",
+				"unrs-resolver": "^1.7.11"
+			},
+			"engines": {
+				"node": "^16.17.0 || >=18.6.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-import-resolver-typescript"
+			},
+			"peerDependencies": {
+				"eslint": "*",
+				"eslint-plugin-import": "*",
+				"eslint-plugin-import-x": "*"
+			},
+			"peerDependenciesMeta": {
+				"eslint-plugin-import": {
+					"optional": true
+				},
+				"eslint-plugin-import-x": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/eslint-module-utils": {
@@ -12654,9 +13727,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-import/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -12811,9 +13884,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -12848,9 +13921,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -12909,9 +13982,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -12938,14 +14011,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "5.5.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
-			"integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+			"version": "5.5.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"prettier-linter-helpers": "^1.0.0",
-				"synckit": "^0.11.7"
+				"prettier-linter-helpers": "^1.0.1",
+				"synckit": "^0.11.12"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -13039,9 +14112,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -13052,18 +14125,24 @@
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/resolve": {
-			"version": "2.0.0-next.5",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+			"version": "2.0.0-next.6",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+			"integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.13.0",
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.1",
+				"node-exports-info": "^1.6.0",
+				"object-keys": "^1.1.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
 			"bin": {
 				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -13102,9 +14181,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13213,9 +14292,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -13315,9 +14394,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -13536,6 +14615,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"license": "MIT",
 			"dependencies": {
 				"is-extendable": "^0.1.0"
 			},
@@ -13609,7 +14689,7 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
 			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -13637,7 +14717,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
 			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -13653,7 +14733,7 @@
 			"version": "1.0.16",
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
 			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">= 4.9.1"
 			}
@@ -13662,7 +14742,7 @@
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
 			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
 			}
@@ -13741,7 +14821,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -13896,10 +14976,10 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-			"dev": true,
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+			"integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/follow-redirects": {
@@ -13992,16 +15072,16 @@
 			"license": "MIT"
 		},
 		"node_modules/fraction.js": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-			"integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+			"integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "*"
 			},
 			"funding": {
-				"type": "patreon",
+				"type": "github",
 				"url": "https://github.com/sponsors/rawify"
 			}
 		},
@@ -14121,6 +15201,16 @@
 			"integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
 			"license": "MIT"
 		},
+		"node_modules/generator-function": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+			"integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -14134,12 +15224,6 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
 			"integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A=="
-		},
-		"node_modules/get-browser-rtc": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
-			"integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
-			"license": "MIT"
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
@@ -14234,6 +15318,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
 			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -14259,6 +15344,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-tsconfig": {
+			"version": "4.13.6",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+			"integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
 		"node_modules/get-uri": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
@@ -14277,6 +15375,7 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -14321,7 +15420,7 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"is-glob": "^4.0.1"
 			},
@@ -14333,7 +15432,8 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
 			"version": "1.1.12",
@@ -14447,7 +15547,7 @@
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"array-union": "^2.1.0",
@@ -14468,7 +15568,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
 			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/good-listener": {
@@ -14566,7 +15666,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -14625,6 +15725,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hashery": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
+			"integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"hookified": "^1.14.0"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/hasown": {
@@ -14913,10 +16026,10 @@
 			}
 		},
 		"node_modules/hookified": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.0.tgz",
-			"integrity": "sha512-hMr1Y9TCLshScrBbV2QxJ9BROddxZ12MX9KsCtuGGy/3SmmN5H1PllKerrVlSotur9dlE8hmUKAOSa3WDzsZmQ==",
-			"dev": true,
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+			"integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/hosted-git-info": {
@@ -15006,6 +16119,16 @@
 			"integrity": "sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==",
 			"license": "MIT"
 		},
+		"node_modules/html-dom-parser": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.2.tgz",
+			"integrity": "sha512-9nD3Rj3/FuQt83AgIa1Y3ruzspwFFA54AJbQnohXN+K6fL1/bhcDQJJY5Ne4L4A163ADQFVESd/0TLyNoV0mfg==",
+			"license": "MIT",
+			"dependencies": {
+				"domhandler": "5.0.3",
+				"htmlparser2": "10.0.0"
+			}
+		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -15040,11 +16163,32 @@
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
 		},
+		"node_modules/html-react-parser": {
+			"version": "5.2.11",
+			"resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.11.tgz",
+			"integrity": "sha512-WnSQVn/D1UTj64nSz5y8MriL+MrbsZH80Ytr1oqKqs8DGZnphWY1R1pl3t7TY3rpqTSu+FHA21P80lrsmrdNBA==",
+			"license": "MIT",
+			"dependencies": {
+				"domhandler": "5.0.3",
+				"html-dom-parser": "5.1.2",
+				"react-property": "2.0.2",
+				"style-to-js": "1.1.21"
+			},
+			"peerDependencies": {
+				"@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+				"react": "0.14 || 15 || 16 || 17 || 18 || 19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/html-tags": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
 			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -15061,6 +16205,37 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/htmlparser2": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+			"integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.2.1",
+				"entities": "^6.0.0"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/http-deceiver": {
@@ -15201,6 +16376,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -15220,7 +16396,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -15267,10 +16443,11 @@
 			"license": "MIT"
 		},
 		"node_modules/immutable": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
-			"integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
-			"dev": true
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+			"integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.1",
@@ -15296,9 +16473,9 @@
 			}
 		},
 		"node_modules/import-in-the-middle": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.2.tgz",
-			"integrity": "sha512-5tCuY9BV8ujfOpwtAGgsTx9CGUapcFMEEyByLv1B+v2+6DhAcw+Zr0nhQT7uwaZ7DiourxFEscghOR8e1aPLQw==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+			"integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -15339,17 +16516,11 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/import-locals": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/import-locals/-/import-locals-2.0.0.tgz",
-			"integrity": "sha512-1/bPE89IZhyf7dr5Pkz7b4UyVXy5pEt7PTEfye15UEn3AK8+2zwcDCfKk9Pwun4ltfhOSszOrReSsFcDKw/yoA==",
-			"license": "MIT"
-		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
@@ -15379,13 +16550,20 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"node_modules/ini": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true
+			"devOptional": true
+		},
+		"node_modules/inline-style-parser": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+			"license": "MIT"
 		},
 		"node_modules/internal-slot": {
 			"version": "1.1.0",
@@ -15412,15 +16590,15 @@
 			}
 		},
 		"node_modules/intl-messageformat": {
-			"version": "10.7.16",
-			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
-			"integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+			"version": "10.7.18",
+			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+			"integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@formatjs/ecma402-abstract": "2.3.4",
+				"@formatjs/ecma402-abstract": "2.3.6",
 				"@formatjs/fast-memoize": "2.2.7",
-				"@formatjs/icu-messageformat-parser": "2.11.2",
+				"@formatjs/icu-messageformat-parser": "2.11.4",
 				"tslib": "^2.8.0"
 			}
 		},
@@ -15562,6 +16740,29 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-bun-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+			"integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.7.1"
+			}
+		},
+		"node_modules/is-bun-module/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/is-callable": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -15651,7 +16852,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -15676,7 +16877,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -15692,14 +16893,15 @@
 			}
 		},
 		"node_modules/is-generator-function": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-			"integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+			"integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bound": "^1.0.3",
-				"get-proto": "^1.0.0",
+				"call-bound": "^1.0.4",
+				"generator-function": "^2.0.0",
+				"get-proto": "^1.0.1",
 				"has-tostringtag": "^1.0.2",
 				"safe-regex-test": "^1.1.0"
 			},
@@ -15714,7 +16916,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"is-extglob": "^2.1.1"
 			},
@@ -15752,7 +16954,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -16014,11 +17216,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/isbot": {
+			"version": "5.1.36",
+			"resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.36.tgz",
+			"integrity": "sha512-C/ZtXyJqDPZ7G7JPr06ApWyYoHjYexQbS6hPYD4WYCzpv2Qes6Z+CCEfTX4Owzf+1EJ933PoI2p+B9v7wpGZBQ==",
+			"license": "Unlicense",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/isobject": {
 			"version": "3.0.1",
@@ -16750,9 +17961,9 @@
 			}
 		},
 		"node_modules/jest-snapshot/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -16893,7 +18104,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -17022,7 +18233,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -17034,7 +18245,8 @@
 		"node_modules/json-stringify-pretty-compact": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
-			"integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q=="
+			"integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+			"license": "MIT"
 		},
 		"node_modules/json2php": {
 			"version": "0.0.9",
@@ -17125,7 +18337,7 @@
 			"version": "0.37.0",
 			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
 			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/language-subtag-registry": {
@@ -17204,9 +18416,9 @@
 			}
 		},
 		"node_modules/lib0": {
-			"version": "0.2.114",
-			"resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
-			"integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
+			"version": "0.2.99",
+			"resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
+			"integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
 			"license": "MIT",
 			"dependencies": {
 				"isomorphic.js": "^0.2.4"
@@ -17287,27 +18499,28 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.19.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.19.0.tgz",
-			"integrity": "sha512-qsEys4OIb2VGC2tNWKAs4U0mnjkIAxueMOOzk2nEFM9g4Y8QuvYkEMtmwsEdvzNGsUFd7DprOQfABmlN7WBOlg==",
+			"version": "24.39.1",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.39.1.tgz",
+			"integrity": "sha512-AMqQIKoEhPS6CilDzw0Gd1brLri3emkC+1N2J6ZCCuY1Cglo56M63S0jOeBZDQlemOiRd686MYVMl9ELJBzN3A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.10.8",
-				"chromium-bidi": "8.0.0",
-				"debug": "^4.4.1",
-				"devtools-protocol": "0.0.1495869",
-				"typed-query-selector": "^2.12.0",
-				"ws": "^8.18.3"
+				"@puppeteer/browsers": "2.13.0",
+				"chromium-bidi": "14.0.0",
+				"debug": "^4.4.3",
+				"devtools-protocol": "0.0.1581282",
+				"typed-query-selector": "^2.12.1",
+				"webdriver-bidi-protocol": "0.4.1",
+				"ws": "^8.19.0"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/chromium-bidi": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-8.0.0.tgz",
-			"integrity": "sha512-d1VmE0FD7lxZQHzcDUCKZSNRtRwISXDsdg4HjdTR5+Ll5nQ/vzU12JeNmupD6VWffrPSlrnGhEWlLESKH3VO+g==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+			"integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -17319,16 +18532,16 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1495869",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
-			"integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
+			"version": "0.0.1581282",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
+			"integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -17408,12 +18621,17 @@
 			}
 		},
 		"node_modules/loader-runner": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+			"integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.11.5"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/loader-utils": {
@@ -17448,9 +18666,10 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+			"license": "MIT"
 		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
@@ -17475,7 +18694,7 @@
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
 			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.uniq": {
@@ -17576,9 +18795,9 @@
 			}
 		},
 		"node_modules/make-dir/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -17623,9 +18842,16 @@
 			"dev": true
 		},
 		"node_modules/mapbox-gl": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.14.0.tgz",
-			"integrity": "sha512-KYhi9ZOQL4BB0J061admPH8O5ZZhhxsyiJ6DQCOkCaps0JEB4HF3SbJwu8S0pJKaQUxNS33sSbzW8iDSSauHPQ==",
+			"version": "3.20.0",
+			"resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.20.0.tgz",
+			"integrity": "sha512-+rVQkf6ymUlAEJiQBZy0OiamJvQN4Uk15mRHI98PRUSmRS40GOoLJyEZEG39LEUtvmzc7qGh+4ygZfJ//O5VnQ==",
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"workspaces": [
+				"src/style-spec",
+				"test/build/vite",
+				"test/build/webpack",
+				"test/build/typings"
+			],
 			"dependencies": {
 				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
 				"@mapbox/mapbox-gl-supported": "^3.0.0",
@@ -17633,55 +18859,50 @@
 				"@mapbox/tiny-sdf": "^2.0.6",
 				"@mapbox/unitbezier": "^0.0.1",
 				"@mapbox/vector-tile": "^2.0.4",
-				"@mapbox/whoots-js": "^3.1.0",
 				"@types/geojson": "^7946.0.16",
 				"@types/geojson-vt": "^3.2.5",
-				"@types/mapbox__point-geometry": "^0.1.4",
 				"@types/pbf": "^3.0.5",
 				"@types/supercluster": "^7.1.3",
 				"cheap-ruler": "^4.0.0",
 				"csscolorparser": "~1.0.3",
 				"earcut": "^3.0.1",
 				"geojson-vt": "^4.0.2",
-				"gl-matrix": "^3.4.3",
+				"gl-matrix": "^3.4.4",
 				"grid-index": "^1.1.0",
 				"kdbush": "^4.0.2",
-				"martinez-polygon-clipping": "^0.7.4",
+				"martinez-polygon-clipping": "^0.8.1",
 				"murmurhash-js": "^1.0.0",
 				"pbf": "^4.0.1",
 				"potpack": "^2.0.0",
 				"quickselect": "^3.0.0",
-				"serialize-to-js": "^3.1.2",
 				"supercluster": "^8.0.1",
 				"tinyqueue": "^3.0.0"
 			}
 		},
 		"node_modules/maplibre-gl": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.6.2.tgz",
-			"integrity": "sha512-SEqYThhUCFf6Lm0TckpgpKnto5u4JsdPYdFJb6g12VtuaFsm3nYdBO+fOmnUYddc8dXihgoGnuXvPPooUcRv5w==",
+			"version": "5.20.1",
+			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.20.1.tgz",
+			"integrity": "sha512-57YIgfRct+rrk78ldoWRuLWRnXV/1vM2Rk0QYfEDQmsXdpgbACwvGoREIOZtyDIaq/GJK/ORYEriaAdVZuNfvw==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@mapbox/geojson-rewind": "^0.5.2",
 				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
 				"@mapbox/point-geometry": "^1.1.0",
 				"@mapbox/tiny-sdf": "^2.0.7",
 				"@mapbox/unitbezier": "^0.0.1",
 				"@mapbox/vector-tile": "^2.0.4",
 				"@mapbox/whoots-js": "^3.1.0",
-				"@maplibre/maplibre-gl-style-spec": "^23.3.0",
-				"@maplibre/vt-pbf": "^4.0.3",
+				"@maplibre/geojson-vt": "^6.0.2",
+				"@maplibre/maplibre-gl-style-spec": "^24.7.0",
+				"@maplibre/mlt": "^1.1.7",
+				"@maplibre/vt-pbf": "^4.3.0",
 				"@types/geojson": "^7946.0.16",
-				"@types/geojson-vt": "3.2.5",
-				"@types/supercluster": "^7.1.3",
 				"earcut": "^3.0.2",
-				"geojson-vt": "^4.0.2",
-				"gl-matrix": "^3.4.3",
+				"gl-matrix": "^3.4.4",
 				"kdbush": "^4.0.2",
 				"murmurhash-js": "^1.0.0",
 				"pbf": "^4.0.1",
 				"potpack": "^2.1.0",
 				"quickselect": "^3.0.0",
-				"supercluster": "^8.0.1",
 				"tinyqueue": "^3.0.0"
 			},
 			"engines": {
@@ -17822,19 +19043,15 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/martinez-polygon-clipping": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.7.4.tgz",
-			"integrity": "sha512-jBEwrKtA0jTagUZj2bnmb4Yg2s4KnJGRePStgI7bAVjtcipKiF39R4LZ2V/UT61jMYWrTcBhPazexeqd6JAVtw==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.8.1.tgz",
+			"integrity": "sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==",
+			"license": "MIT",
 			"dependencies": {
 				"robust-predicates": "^2.0.4",
 				"splaytree": "^0.1.4",
-				"tinyqueue": "^1.2.0"
+				"tinyqueue": "3.0.0"
 			}
-		},
-		"node_modules/martinez-polygon-clipping/node_modules/tinyqueue": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
-			"integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
@@ -17849,7 +19066,7 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
 			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -18218,7 +19435,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -18806,7 +20023,7 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
@@ -19078,6 +20295,22 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/napi-postinstall": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+			"integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"napi-postinstall": "lib/cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/napi-postinstall"
+			}
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -19125,6 +20358,25 @@
 			"dev": true,
 			"optional": true
 		},
+		"node_modules/node-exports-info": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+			"integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array.prototype.flatmap": "^1.3.3",
+				"es-errors": "^1.3.0",
+				"object.entries": "^1.1.9",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/node-forge": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -19142,10 +20394,11 @@
 			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-			"dev": true
+			"version": "2.0.36",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+			"integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/normalize-package-data": {
 			"version": "3.0.3",
@@ -19164,9 +20417,9 @@
 			}
 		},
 		"node_modules/normalize-package-data/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -19180,17 +20433,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/normalize-range": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-			"dev": true,
-			"license": "MIT",
+			"devOptional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -19250,9 +20493,9 @@
 			}
 		},
 		"node_modules/npm-package-json-lint/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19281,9 +20524,9 @@
 			"license": "MIT"
 		},
 		"node_modules/npm-package-json-lint/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -19874,9 +21117,9 @@
 			}
 		},
 		"node_modules/pg-protocol": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-			"integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+			"integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -19906,12 +21149,22 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8.6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/pirates": {
@@ -20010,14 +21263,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
-			"integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.55.0"
+				"playwright-core": "1.58.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -20030,9 +21283,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
-			"integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -20086,9 +21339,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -20103,6 +21356,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -20208,6 +21462,24 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-import": {
+			"version": "16.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.1.tgz",
+			"integrity": "sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.0.0",
+				"read-cache": "^1.0.0",
+				"resolve": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.0"
 			}
 		},
 		"node_modules/postcss-loader": {
@@ -20643,14 +21915,14 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
 			"integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/postcss-safe-parser": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
 			"integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -20772,9 +22044,9 @@
 			}
 		},
 		"node_modules/postgres-bytea": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-			"integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+			"integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -20810,9 +22082,9 @@
 			"integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ=="
 		},
 		"node_modules/preact": {
-			"version": "10.27.1",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.27.1.tgz",
-			"integrity": "sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==",
+			"version": "10.29.0",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
+			"integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -20847,9 +22119,9 @@
 			}
 		},
 		"node_modules/prettier-linter-helpers": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+			"integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -21125,6 +22397,19 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/qified": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+			"integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"hookified": "^1.14.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
 		"node_modules/qs": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -21150,6 +22435,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -21189,6 +22475,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -21343,14 +22630,15 @@
 			}
 		},
 		"node_modules/react-day-picker": {
-			"version": "9.9.0",
-			"resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.9.0.tgz",
-			"integrity": "sha512-NtkJbuX6cl/VaGNb3sVVhmMA6LSMnL5G3xNL+61IyoZj0mUZFWTg4hmj7PHjIQ8MXN9dHWhUHFoJWG6y60DKSg==",
+			"version": "9.14.0",
+			"resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+			"integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
 			"license": "MIT",
 			"dependencies": {
 				"@date-fns/tz": "^1.4.1",
+				"@tabby_ai/hijri-converter": "1.0.5",
 				"date-fns": "^4.1.0",
-				"date-fns-jalali": "^4.1.0-0"
+				"date-fns-jalali": "4.1.0-0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -21386,9 +22674,9 @@
 			}
 		},
 		"node_modules/react-easy-crop": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.0.tgz",
-			"integrity": "sha512-OZzU+yXMhe69vLkDex+5QxcfT94FdcgVCyW2dBUw35ZoC3Is42TUxUy04w8nH1mfMKaizVdC3rh/wUfNW1mK4w==",
+			"version": "5.5.6",
+			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.6.tgz",
+			"integrity": "sha512-Jw3/ozs8uXj3NpL511Suc4AHY+mLRO23rUgipXvNYKqezcFSYHxe4QXibBymkOoY6oOtLVMPO2HNPRHYvMPyTw==",
 			"license": "MIT",
 			"dependencies": {
 				"normalize-wheel": "^1.0.1",
@@ -21472,12 +22760,13 @@
 			}
 		},
 		"node_modules/react-map-gl": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-8.0.4.tgz",
-			"integrity": "sha512-SHdpvFIvswsZBg6BCPcwY/nbKuCo3sJM1Cj7Sd+gA3gFRFOixD+KtZ2XSuUWq2WySL2emYEXEgrLZoXsV4Ut4Q==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-8.1.0.tgz",
+			"integrity": "sha512-vDx/QXR3Tb+8/ap/z6gdMjJQ8ZEyaZf6+uMSPz7jhWF5VZeIsKsGfPvwHVPPwGF43Ryn+YR4bd09uEFNR5OPdg==",
+			"license": "MIT",
 			"dependencies": {
-				"@vis.gl/react-mapbox": "8.0.4",
-				"@vis.gl/react-maplibre": "8.0.4"
+				"@vis.gl/react-mapbox": "8.1.0",
+				"@vis.gl/react-maplibre": "8.1.0"
 			},
 			"peerDependencies": {
 				"mapbox-gl": ">=1.13.0",
@@ -21502,6 +22791,12 @@
 				"react": "*",
 				"react-dom": "*"
 			}
+		},
+		"node_modules/react-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+			"integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+			"license": "MIT"
 		},
 		"node_modules/react-redux": {
 			"version": "7.2.9",
@@ -21542,9 +22837,9 @@
 			}
 		},
 		"node_modules/react-remove-scroll": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
-			"integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+			"integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
 			"license": "MIT",
 			"dependencies": {
 				"react-remove-scroll-bar": "^2.3.7",
@@ -21624,6 +22919,16 @@
 			"integrity": "sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/read-cache": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pify": "^2.3.0"
 			}
 		},
 		"node_modules/read-pkg": {
@@ -21714,6 +23019,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -21808,11 +23114,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
 		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.4",
@@ -22025,7 +23326,8 @@
 		"node_modules/remove-accents": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
+			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+			"license": "MIT"
 		},
 		"node_modules/requestidlecallback": {
 			"version": "0.3.0",
@@ -22045,7 +23347,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -22086,6 +23388,12 @@
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
 			"dev": true
+		},
+		"node_modules/reselect": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+			"integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+			"license": "MIT"
 		},
 		"node_modules/resolve": {
 			"version": "1.22.10",
@@ -22144,9 +23452,19 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
 			}
 		},
 		"node_modules/resolve-protobuf-schema": {
@@ -22180,7 +23498,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
 			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
@@ -22216,7 +23534,8 @@
 		"node_modules/robust-predicates": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
-			"integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg=="
+			"integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+			"license": "Unlicense"
 		},
 		"node_modules/route-recognizer": {
 			"version": "0.3.4",
@@ -22270,7 +23589,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -22298,7 +23617,8 @@
 		"node_modules/rw": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/rxjs": {
 			"version": "7.8.2",
@@ -22389,13 +23709,14 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"node_modules/sass": {
-			"version": "1.90.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.90.0.tgz",
-			"integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
+			"version": "1.98.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
+			"integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^4.0.0",
-				"immutable": "^5.0.2",
+				"immutable": "^5.1.5",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			},
 			"bin": {
@@ -22409,10 +23730,11 @@
 			}
 		},
 		"node_modules/sass-loader": {
-			"version": "16.0.5",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.5.tgz",
-			"integrity": "sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw==",
+			"version": "16.0.7",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.7.tgz",
+			"integrity": "sha512-w6q+fRHourZ+e+xA1kcsF27iGM6jdB8teexYCfdUw0sYgcDNeZESnDNT9sUmmPm3ooziwUJXGwZJSTF3kOdBfA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"neo-async": "^2.6.2"
 			},
@@ -22424,7 +23746,7 @@
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"@rspack/core": "0.x || 1.x",
+				"@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
 				"node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
 				"sass": "^1.3.0",
 				"sass-embedded": "*",
@@ -22469,10 +23791,11 @@
 			}
 		},
 		"node_modules/schema-utils": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-			"integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"ajv": "^8.9.0",
@@ -22610,12 +23933,25 @@
 				"randombytes": "^2.1.0"
 			}
 		},
-		"node_modules/serialize-to-js": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.1.2.tgz",
-			"integrity": "sha512-owllqNuDDEimQat7EPG0tH7JjO090xKNzUtYz6X+Sk2BXDnOCilDdNLwjWeFywG9xkJul1ULvtUQa9O4pUaY0w==",
+		"node_modules/seroval": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
+			"integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=4.0.0"
+				"node": ">=10"
+			}
+		},
+		"node_modules/seroval-plugins": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.1.tgz",
+			"integrity": "sha512-4FbuZ/TMl02sqv0RTFexu0SP6V+ywaIe5bAWCCEik0fk17BhALgwvUDVF7e3Uvf9pxmwCEJsRPmlkUE6HdzLAw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"seroval": "^1.0"
 			}
 		},
 		"node_modules/serve-index": {
@@ -22770,6 +24106,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
 			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+			"license": "MIT",
 			"dependencies": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -22784,6 +24121,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"license": "MIT",
 			"dependencies": {
 				"isobject": "^3.0.1"
 			},
@@ -23174,35 +24512,6 @@
 			"integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
 			"license": "MIT"
 		},
-		"node_modules/simple-peer": {
-			"version": "9.11.1",
-			"resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.11.1.tgz",
-			"integrity": "sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"debug": "^4.3.2",
-				"err-code": "^3.0.1",
-				"get-browser-rtc": "^1.1.0",
-				"queue-microtask": "^1.2.3",
-				"randombytes": "^2.1.0",
-				"readable-stream": "^3.6.0"
-			}
-		},
 		"node_modules/sirv": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -23227,7 +24536,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -23236,7 +24545,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
 			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -23321,6 +24630,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
 			"integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -23329,6 +24639,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
 			"integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -23337,6 +24648,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
 			"integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+			"license": "MIT",
 			"dependencies": {
 				"bytewise": "^1.1.0",
 				"get-value": "^2.0.2",
@@ -23484,9 +24796,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.22",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+			"integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -23538,12 +24850,14 @@
 		"node_modules/splaytree": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
-			"integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ=="
+			"integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
+			"license": "MIT"
 		},
 		"node_modules/split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"license": "MIT",
 			"dependencies": {
 				"extend-shallow": "^3.0.0"
 			},
@@ -23555,6 +24869,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+			"license": "MIT",
 			"dependencies": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -23567,6 +24882,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+			"license": "MIT",
 			"dependencies": {
 				"is-plain-object": "^2.0.4"
 			},
@@ -23578,6 +24894,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"license": "MIT",
 			"dependencies": {
 				"isobject": "^3.0.1"
 			},
@@ -23591,6 +24908,16 @@
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/stable-hash-x": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+			"integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/stack-utils": {
 			"version": "2.0.6",
@@ -23659,6 +24986,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -23681,7 +25009,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -23822,7 +25150,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -23896,10 +25224,21 @@
 			}
 		},
 		"node_modules/stubborn-fs": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
-			"integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==",
-			"dev": true
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+			"integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"stubborn-utils": "^1.0.1"
+			}
+		},
+		"node_modules/stubborn-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+			"integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/style-loader": {
 			"version": "4.0.0",
@@ -23924,6 +25263,24 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/style-to-js": {
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+			"integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"style-to-object": "1.0.14"
+			}
+		},
+		"node_modules/style-to-object": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+			"license": "MIT",
+			"dependencies": {
+				"inline-style-parser": "0.2.7"
+			}
+		},
 		"node_modules/stylehacks": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.1.1.tgz",
@@ -23941,10 +25298,10 @@
 			}
 		},
 		"node_modules/stylelint": {
-			"version": "16.23.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.23.1.tgz",
-			"integrity": "sha512-dNvDTsKV1U2YtiUDfe9d2gp902veFeo3ecCWdGlmLm2WFrAV0+L5LoOj/qHSBABQwMsZPJwfC4bf39mQm1S5zw==",
-			"dev": true,
+			"version": "16.26.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -23958,19 +25315,20 @@
 			"license": "MIT",
 			"dependencies": {
 				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.19",
 				"@csstools/css-tokenizer": "^3.0.4",
 				"@csstools/media-query-list-parser": "^4.0.3",
 				"@csstools/selector-specificity": "^5.0.0",
-				"@dual-bundle/import-meta-resolve": "^4.1.0",
+				"@dual-bundle/import-meta-resolve": "^4.2.1",
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
 				"cosmiconfig": "^9.0.0",
 				"css-functions-list": "^3.2.3",
 				"css-tree": "^3.1.0",
-				"debug": "^4.4.1",
+				"debug": "^4.4.3",
 				"fast-glob": "^3.3.3",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^10.1.3",
+				"file-entry-cache": "^11.1.1",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
@@ -24051,67 +25409,53 @@
 			}
 		},
 		"node_modules/stylelint-scss": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.1.tgz",
-			"integrity": "sha512-UJUfBFIvXfly8WKIgmqfmkGKPilKB4L5j38JfsDd+OCg2GBdU0vGUV08Uw82tsRZzd4TbsUURVVNGeOhJVF7pA==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.14.0.tgz",
+			"integrity": "sha512-ZKmHMZolxeuYsnB+PCYrTpFce0/QWX9i9gh0hPXzp73WjuIMqUpzdQaBCrKoLWh6XtCFSaNDErkMPqdjy1/8aA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"css-tree": "^3.0.1",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.36.0",
-				"mdn-data": "^2.21.0",
+				"known-css-properties": "^0.37.0",
+				"mdn-data": "^2.25.0",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.6",
-				"postcss-selector-parser": "^7.1.0",
+				"postcss-selector-parser": "^7.1.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
 				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^16.0.2"
+				"stylelint": "^16.8.2"
 			}
 		},
 		"node_modules/stylelint-scss/node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
-		"node_modules/stylelint-scss/node_modules/css-tree/node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-			"dev": true,
-			"license": "CC0-1.0"
-		},
-		"node_modules/stylelint-scss/node_modules/known-css-properties": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
-			"integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/stylelint-scss/node_modules/mdn-data": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.24.0.tgz",
-			"integrity": "sha512-i97fklrJl03tL1tdRVw0ZfLLvuDsdb6wxL+TrJ+PKkCbLrp2PCu2+OYdCKychIUm19nSM/35S6qz7pJpnXttoA==",
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -24126,7 +25470,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
 			"integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -24150,7 +25494,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
 			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -24173,14 +25517,14 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
 			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/stylelint/node_modules/cosmiconfig": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-			"dev": true,
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.1",
@@ -24204,46 +25548,46 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-			"dev": true,
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
-			"version": "10.1.4",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
-			"integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
-			"dev": true,
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+			"integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^6.1.13"
+				"flat-cache": "^6.1.20"
 			}
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
-			"version": "6.1.13",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.13.tgz",
-			"integrity": "sha512-gmtS2PaUjSPa4zjObEIn4WWliKyZzYljgxODBfxugpK6q6HU9ClXzgCJ+nlcPKY9Bt090ypTOLIFWkV0jbKFjw==",
-			"dev": true,
+			"version": "6.1.20",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
+			"integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"cacheable": "^1.10.4",
+				"cacheable": "^2.3.2",
 				"flatted": "^3.3.3",
-				"hookified": "^1.11.0"
+				"hookified": "^1.15.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/global-modules": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
 			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"global-prefix": "^3.0.0"
@@ -24256,7 +25600,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
 			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ini": "^1.3.5",
@@ -24271,7 +25615,7 @@
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
 			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -24281,24 +25625,24 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-			"dev": true,
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"devOptional": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/stylelint/node_modules/meow": {
 			"version": "13.2.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
 			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -24308,10 +25652,10 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -24325,7 +25669,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -24338,7 +25682,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -24351,7 +25695,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
 			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
@@ -24379,7 +25723,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -24391,7 +25735,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
 			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0",
@@ -24425,7 +25769,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
 			"integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/svgo": {
 			"version": "3.3.2",
@@ -24459,9 +25803,9 @@
 			"dev": true
 		},
 		"node_modules/synckit": {
-			"version": "0.11.11",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-			"integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+			"version": "0.11.12",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -24475,15 +25819,16 @@
 			}
 		},
 		"node_modules/tabbable": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-			"integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+			"license": "MIT"
 		},
 		"node_modules/table": {
 			"version": "6.9.0",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
 			"integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"ajv": "^8.0.1",
@@ -24506,10 +25851,11 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
-			"integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+			"integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			},
@@ -24519,10 +25865,11 @@
 			}
 		},
 		"node_modules/tar-fs": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-			"integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+			"integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0",
 				"tar-stream": "^3.1.5"
@@ -24541,6 +25888,15 @@
 				"b4a": "^1.6.4",
 				"fast-fifo": "^1.2.0",
 				"streamx": "^2.15.0"
+			}
+		},
+		"node_modules/temml": {
+			"version": "0.10.34",
+			"resolved": "https://registry.npmjs.org/temml/-/temml-0.10.34.tgz",
+			"integrity": "sha512-f3b5CaPwPvMviA+CtHy0qoIGWvzpRrNpXmGRc/Y1jc9gAYy+xOlndJFyn7Vfcz7cBcS8QRvv8z0EEH59sHCQxg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.13.0"
 			}
 		},
 		"node_modules/terser": {
@@ -24562,15 +25918,15 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-			"integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+			"integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^4.3.0",
-				"serialize-javascript": "^6.0.2",
 				"terser": "^5.31.1"
 			},
 			"engines": {
@@ -24676,9 +26032,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -24734,26 +26090,80 @@
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
 			"integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
 		},
+		"node_modules/tiny-warning": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+			"integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+			"license": "MIT"
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/tinyqueue": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
 			"integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g=="
 		},
 		"node_modules/tldts-core": {
-			"version": "7.0.12",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.12.tgz",
-			"integrity": "sha512-3K76aXywJFduGRsOYoY5JzINLs/WMlOkeDwPL+8OCPq2Rh39gkSDtWAxdJQlWjpun/xF/LHf29yqCi6VC/rHDA==",
+			"version": "7.0.25",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
+			"integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tldts-icann": {
-			"version": "7.0.12",
-			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.12.tgz",
-			"integrity": "sha512-Lk1sJ3Soq97iG6gFj95YQWMWCNQD9b9LkZMooM6ojnTdmo8xpGBv6J+ycwTpY98Xz1RTqdzR/tCYpW7e/g+2xw==",
+			"version": "7.0.25",
+			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.25.tgz",
+			"integrity": "sha512-Ybq7DE8uWaqSQlFsQXfagIxVnpn7YTu7XYCJC61BDdCR3SRqHIrTkjFwbBEclm0H+wUxP2BX687OB7T3S6LCRw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.0.12"
+				"tldts-core": "^7.0.25"
 			}
 		},
 		"node_modules/tmpl": {
@@ -24767,7 +26177,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -25093,16 +26503,17 @@
 			}
 		},
 		"node_modules/typed-query-selector": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-			"integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
-			"dev": true
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+			"integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/typescript": {
 			"version": "5.9.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"bin": {
@@ -25117,6 +26528,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
 			"integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+			"license": "MIT",
 			"dependencies": {
 				"typewise-core": "^1.2.0"
 			}
@@ -25124,7 +26536,8 @@
 		"node_modules/typewise-core": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg=="
+			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+			"license": "MIT"
 		},
 		"node_modules/uc.micro": {
 			"version": "1.0.6",
@@ -25186,9 +26599,11 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-			"integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.1",
@@ -25265,6 +26680,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
 			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+			"license": "MIT",
 			"dependencies": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -25375,10 +26791,45 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/unrs-resolver": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"napi-postinstall": "^0.3.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unrs-resolver"
+			},
+			"optionalDependencies": {
+				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+				"@unrs/resolver-binding-android-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-x64": "1.11.1",
+				"@unrs/resolver-binding-freebsd-x64": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+				"@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+			}
+		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"funding": [
 				{
@@ -25394,6 +26845,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"escalade": "^3.2.0",
 				"picocolors": "^1.1.1"
@@ -25537,9 +26989,10 @@
 			}
 		},
 		"node_modules/use-debounce": {
-			"version": "10.0.5",
-			"resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.5.tgz",
-			"integrity": "sha512-Q76E3lnIV+4YT9AHcrHEHYmAd9LKwUAbPXDm7FlqVGDHiSOhX3RDjT8dm0AxbJup6WgOb1YEcKyCr11kBJR5KQ==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.0.tgz",
+			"integrity": "sha512-lu87Za35V3n/MyMoEpD5zJv0k7hCn0p+V/fK2kWD+3k2u3kOCwO593UArbczg1fhfs2rqPEnHpULJ3KmGdDzvg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 16.0.0"
 			},
@@ -25578,9 +27031,9 @@
 			}
 		},
 		"node_modules/use-sync-external-store": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-			"integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -25589,7 +27042,8 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"devOptional": true
 		},
 		"node_modules/utils-merge": {
 			"version": "1.0.1",
@@ -25608,6 +27062,7 @@
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
+			"license": "MIT",
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
@@ -25750,11 +27205,21 @@
 				"makeerror": "1.0.12"
 			}
 		},
+		"node_modules/wasm-vips": {
+			"version": "0.0.16",
+			"resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.16.tgz",
+			"integrity": "sha512-4/bEq8noAFt7DX3VT+Vt5AgNtnnOLwvmrDbduWfiv9AV+VYkbUU4f9Dam9e6khRqPinyClFHCqiwATTTJEiGwA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.4.0"
+			}
+		},
 		"node_modules/watchpack": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-			"integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+			"integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -25789,6 +27254,13 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/webdriver-bidi-protocol": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+			"integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/webidl-conversions": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -25799,10 +27271,11 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.101.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.2.tgz",
-			"integrity": "sha512-4JLXU0tD6OZNVqlwzm3HGEhAHufSiyv+skb7q0d2367VDMzrU1Q/ZeepvkcHH0rZie6uqEtTQQe0OEOOluH3Mg==",
+			"version": "5.105.4",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
+			"integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -25810,25 +27283,25 @@
 				"@webassemblyjs/ast": "^1.14.1",
 				"@webassemblyjs/wasm-edit": "^1.14.1",
 				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.15.0",
+				"acorn": "^8.16.0",
 				"acorn-import-phases": "^1.0.3",
-				"browserslist": "^4.24.0",
+				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.3",
-				"es-module-lexer": "^1.2.1",
+				"enhanced-resolve": "^5.20.0",
+				"es-module-lexer": "^2.0.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
 				"json-parse-even-better-errors": "^2.3.1",
-				"loader-runner": "^4.2.0",
+				"loader-runner": "^4.3.1",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^4.3.2",
-				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.3.11",
-				"watchpack": "^2.4.1",
-				"webpack-sources": "^3.3.3"
+				"schema-utils": "^4.3.3",
+				"tapable": "^2.3.0",
+				"terser-webpack-plugin": "^5.3.17",
+				"watchpack": "^2.5.1",
+				"webpack-sources": "^3.3.4"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -26139,13 +27612,21 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-			"integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+			"integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"
 			}
+		},
+		"node_modules/webpack/node_modules/es-module-lexer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/websocket-driver": {
 			"version": "0.7.4",
@@ -26205,9 +27686,9 @@
 			}
 		},
 		"node_modules/when-exit": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.4.tgz",
-			"integrity": "sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+			"integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -26300,9 +27781,9 @@
 			"license": "ISC"
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.19",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -26378,7 +27859,7 @@
 			"version": "8.18.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
 			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-			"devOptional": true,
+			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -26433,30 +27914,10 @@
 				"node": ">=0.4"
 			}
 		},
-		"node_modules/y-indexeddb": {
-			"version": "9.0.12",
-			"resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
-			"integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
-			"license": "MIT",
-			"dependencies": {
-				"lib0": "^0.2.74"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=8.0.0"
-			},
-			"funding": {
-				"type": "GitHub Sponsors ❤",
-				"url": "https://github.com/sponsors/dmonad"
-			},
-			"peerDependencies": {
-				"yjs": "^13.0.0"
-			}
-		},
 		"node_modules/y-protocols": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
-			"integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+			"integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
 			"license": "MIT",
 			"dependencies": {
 				"lib0": "^0.2.85"
@@ -26471,33 +27932,6 @@
 			},
 			"peerDependencies": {
 				"yjs": "^13.0.0"
-			}
-		},
-		"node_modules/y-webrtc": {
-			"version": "10.2.6",
-			"resolved": "https://registry.npmjs.org/y-webrtc/-/y-webrtc-10.2.6.tgz",
-			"integrity": "sha512-1kZ4YYwksFZi8+l8mTebVX9vW6Q5MnqxMkvNU700X5dBE38usurt/JgeXSIQRpK3NwUYYb9y63Jn9FMpMH6/vA==",
-			"license": "MIT",
-			"dependencies": {
-				"lib0": "^0.2.42",
-				"simple-peer": "^9.11.0",
-				"y-protocols": "^1.0.6"
-			},
-			"bin": {
-				"y-webrtc-signaling": "bin/server.js"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "GitHub Sponsors ❤",
-				"url": "https://github.com/sponsors/dmonad"
-			},
-			"optionalDependencies": {
-				"ws": "^8.14.2"
-			},
-			"peerDependencies": {
-				"yjs": "^13.6.8"
 			}
 		},
 		"node_modules/y18n": {
@@ -26561,9 +27995,9 @@
 			}
 		},
 		"node_modules/yjs": {
-			"version": "13.6.27",
-			"resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
-			"integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+			"version": "13.6.29",
+			"resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
+			"integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
 			"license": "MIT",
 			"dependencies": {
 				"lib0": "^0.2.99"

--- a/package.json
+++ b/package.json
@@ -23,18 +23,18 @@
 	"dependencies": {
 		"@ckeditor/ckeditor5-react": "^9.5.0",
 		"@nazka/map-gl-js-spiderfy": "^1.2.10",
-		"@wordpress/edit-post": "^8.16.0",
-		"@wordpress/editor": "^14.18.0",
-		"@wordpress/plugins": "^7.16.0",
+		"@wordpress/edit-post": "^8.41.0",
+		"@wordpress/editor": "^14.41.0",
+		"@wordpress/plugins": "^7.41.0",
 		"bootstrap-daterangepicker": "^3.1.0",
 		"ckeditor5": "^47.6.1",
 		"classnames": "^2.5.1",
 		"eta": "^3.5.0",
 		"leaflet": "^1.9.4",
-		"lodash-es": "^4.17.21",
+		"lodash-es": "^4.17.23",
 		"map-gl-utils": "^0.50.4",
-		"mapbox-gl": "^3.9.4",
-		"maplibre-gl": "^5.6.2",
+		"mapbox-gl": "^3.20.0",
+		"maplibre-gl": "^5.20.1",
 		"maplibregl-mapbox-request-transformer": "^0.0.3",
 		"react-autosuggest": "^10.1.0",
 		"react-beautiful-dnd": "^13.1.1",
@@ -42,19 +42,19 @@
 		"react-datepicker": "^7.6.0",
 		"react-jsonschema-form": "2.0.0-alpha.1",
 		"react-leaflet": "^4.2.1",
-		"react-map-gl": "^8.0.4",
+		"react-map-gl": "^8.1.0",
 		"react-movable": "^3.4.0",
 		"scrollama": "^3.2.0",
-		"use-debounce": "^10.0.4"
+		"use-debounce": "^10.1.0"
 	},
 	"devDependencies": {
-		"@wordpress/scripts": "^30.21.0",
-		"ajv": "^8.17.1",
-		"css-loader": "^7.1.2",
-		"postcss": "^8.5.1",
-		"sass": "^1.83.4",
-		"sass-loader": "^16.0.4",
+		"@wordpress/scripts": "^30.27.0",
+		"ajv": "^8.18.0",
+		"css-loader": "^7.1.4",
+		"postcss": "^8.5.8",
+		"sass": "^1.98.0",
+		"sass-loader": "^16.0.7",
 		"style-loader": "^4.0.0",
-		"webpack": "^5.101.1"
+		"webpack": "^5.105.4"
 	}
 }

--- a/scripts/check-php-compat.php
+++ b/scripts/check-php-compat.php
@@ -285,6 +285,11 @@ function collect_declared_properties( array $tokens, int $start, int $end ): arr
 	$brace_depth = 0;
 	$function_depth = 0;
 	$expect_property = false;
+	$property_modifier_tokens = array( T_PUBLIC, T_PROTECTED, T_PRIVATE, T_VAR, T_STATIC );
+
+	if ( defined( 'T_READONLY' ) ) {
+		$property_modifier_tokens[] = T_READONLY;
+	}
 
 	for ( $index = $start; $index <= $end; $index++ ) {
 		$token = $tokens[ $index ];
@@ -317,7 +322,7 @@ function collect_declared_properties( array $tokens, int $start, int $end ): arr
 			continue;
 		}
 
-		if ( is_array( $token ) && in_array( $token[0], array( T_PUBLIC, T_PROTECTED, T_PRIVATE, T_VAR, T_STATIC, T_READONLY ), true ) ) {
+		if ( is_array( $token ) && in_array( $token[0], $property_modifier_tokens, true ) ) {
 			$expect_property = true;
 			continue;
 		}

--- a/scripts/check-php-compat.php
+++ b/scripts/check-php-compat.php
@@ -1,0 +1,617 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$repositoryRoot = dirname(__DIR__);
+$targets = array(
+	$repositoryRoot . '/src',
+	$repositoryRoot . '/trunk',
+);
+
+$files = collect_php_files( $targets );
+sort( $files );
+
+$report = array(
+	'target_range'         => 'PHP 8.0-8.4',
+	'primary_support'      => 'PHP 8.2-8.4',
+	'backward_compat'      => 'PHP 8.0-8.1',
+	'analyzer_php'         => PHP_VERSION,
+	'php_binary'           => PHP_BINARY,
+	'file_count'           => count( $files ),
+	'checks'               => array(),
+	'notes'                => array(),
+);
+
+$lint_findings = lint_php_files( $files );
+$report['checks'][] = summarize_check( 'Syntax lint', $lint_findings );
+
+$removed_function_findings = scan_removed_or_deprecated_functions( $files );
+$report['checks'][] = summarize_check( 'Removed/deprecated function scan', $removed_function_findings );
+
+$parameter_findings = scan_optional_before_required_parameters( $files );
+$report['checks'][] = summarize_check( 'Optional-before-required parameter scan', $parameter_findings );
+
+$dynamic_property_findings = scan_dynamic_this_property_assignments( $files );
+$report['checks'][] = summarize_check( 'Dynamic $this property assignment scan', $dynamic_property_findings );
+
+$metadata_notes = scan_readme_metadata( $repositoryRoot );
+$report['notes'] = array_merge( $report['notes'], $metadata_notes );
+
+print_report( $report );
+
+$has_errors = false;
+foreach ( $report['checks'] as $check ) {
+	if ( ! empty( $check['findings'] ) ) {
+		$has_errors = true;
+		break;
+	}
+}
+
+exit( $has_errors ? 1 : 0 );
+
+function collect_php_files( array $targets ): array {
+	$files = array();
+
+	foreach ( $targets as $target ) {
+		if ( ! is_dir( $target ) ) {
+			continue;
+		}
+
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $target, FilesystemIterator::SKIP_DOTS )
+		);
+
+		foreach ( $iterator as $file ) {
+			if ( $file->isFile() && 'php' === strtolower( $file->getExtension() ) ) {
+				$files[] = $file->getPathname();
+			}
+		}
+	}
+
+	return $files;
+}
+
+function lint_php_files( array $files ): array {
+	$findings = array();
+
+	foreach ( $files as $file ) {
+		$command = escapeshellarg( PHP_BINARY ) . ' -d display_errors=1 -d error_reporting=32767 -l ' . escapeshellarg( $file ) . ' 2>&1';
+		$output = array();
+		$status = 0;
+		exec( $command, $output, $status );
+
+		if ( 0 !== $status ) {
+			$findings[] = array(
+				'file'    => relative_path( $file ),
+				'line'    => null,
+				'message' => trim( implode( "\n", $output ) ),
+			);
+		}
+	}
+
+	return $findings;
+}
+
+function scan_removed_or_deprecated_functions( array $files ): array {
+	$functions = array(
+		'create_function'         => 'removed in PHP 8.0',
+		'each'                    => 'removed in PHP 8.0',
+		'utf8_encode'             => 'deprecated in PHP 8.2 and removed in PHP 8.4',
+		'utf8_decode'             => 'deprecated in PHP 8.2 and removed in PHP 8.4',
+		'money_format'            => 'removed in PHP 8.0',
+		'strftime'                => 'deprecated in PHP 8.1',
+		'gmstrftime'              => 'deprecated in PHP 8.1',
+		'hebrev'                  => 'deprecated in PHP 8.3',
+		'hebrevc'                 => 'deprecated in PHP 8.3',
+		'mbereg_replace'          => 'deprecated in PHP 8.4 when using the eval option',
+		'set_magic_quotes_runtime'=> 'removed in PHP 8.0',
+		'ezmlm_hash'              => 'removed in PHP 8.0',
+	);
+
+	$findings = array();
+
+	foreach ( $files as $file ) {
+		$tokens = token_get_all( file_get_contents( $file ) );
+		$count  = count( $tokens );
+
+		for ( $index = 0; $index < $count; $index++ ) {
+			$token = $tokens[ $index ];
+			if ( ! is_array( $token ) || T_STRING !== $token[0] ) {
+				continue;
+			}
+
+			$name = strtolower( $token[1] );
+			if ( ! isset( $functions[ $name ] ) ) {
+				continue;
+			}
+
+			$previous_index = previous_meaningful_token_index( $tokens, $index );
+			$previous = null !== $previous_index ? $tokens[ $previous_index ] : null;
+			if ( is_array( $previous ) && in_array( $previous[0], array( T_FUNCTION, T_NEW, T_OBJECT_OPERATOR, T_DOUBLE_COLON ), true ) ) {
+				continue;
+			}
+
+			$next_index = next_meaningful_token_index( $tokens, $index );
+			$next = null !== $next_index ? $tokens[ $next_index ] : null;
+			if ( '(' !== token_text( $next ) ) {
+				continue;
+			}
+
+			$findings[] = array(
+				'file'    => relative_path( $file ),
+				'line'    => $token[2],
+				'message' => sprintf( 'Uses %s(), %s.', $name, $functions[ $name ] ),
+			);
+		}
+	}
+
+	return $findings;
+}
+
+function scan_optional_before_required_parameters( array $files ): array {
+	$findings = array();
+
+	foreach ( $files as $file ) {
+		$tokens = token_get_all( file_get_contents( $file ) );
+		$count  = count( $tokens );
+
+		for ( $index = 0; $index < $count; $index++ ) {
+			$token = $tokens[ $index ];
+			if ( ! is_array( $token ) || T_FUNCTION !== $token[0] ) {
+				continue;
+			}
+
+			$function_name = 'anonymous';
+			$name_index = next_meaningful_token_index( $tokens, $index );
+			$name_token = null !== $name_index ? $tokens[ $name_index ] : null;
+			if ( is_array( $name_token ) && T_STRING === $name_token[0] ) {
+				$function_name = $name_token[1];
+			}
+
+			$open_index = find_next_token_index_by_text( $tokens, $index, '(' );
+			if ( null === $open_index ) {
+				continue;
+			}
+
+			$close_index = find_matching_parenthesis( $tokens, $open_index );
+			if ( null === $close_index ) {
+				continue;
+			}
+
+			$parameters = parse_parameters( $tokens, $open_index + 1, $close_index - 1 );
+			$seen_optional = false;
+
+			foreach ( $parameters as $parameter ) {
+				if ( empty( $parameter['name'] ) ) {
+					continue;
+				}
+
+				if ( $parameter['has_default'] ) {
+					$seen_optional = true;
+					continue;
+				}
+
+				if ( $seen_optional && ! $parameter['is_variadic'] ) {
+					$findings[] = array(
+						'file'    => relative_path( $file ),
+						'line'    => $parameter['line'],
+						'message' => sprintf(
+							'Function %s() declares required parameter $%s after an optional parameter.',
+							$function_name,
+							$parameter['name']
+						),
+					);
+				}
+			}
+
+			$index = $close_index;
+		}
+	}
+
+	return $findings;
+}
+
+function scan_dynamic_this_property_assignments( array $files ): array {
+	$findings = array();
+
+	foreach ( $files as $file ) {
+		$tokens  = token_get_all( file_get_contents( $file ) );
+		$classes = extract_class_like_structures( $tokens );
+
+		foreach ( $classes as $class ) {
+			foreach ( $class['assignments'] as $assignment ) {
+				if ( isset( $class['properties'][ $assignment['property'] ] ) ) {
+					continue;
+				}
+
+				$findings[] = array(
+					'file'    => relative_path( $file ),
+					'line'    => $assignment['line'],
+					'message' => sprintf(
+						'Class %s assigns $this->%s without declaring the property.',
+						$class['name'],
+						$assignment['property']
+					),
+				);
+			}
+		}
+	}
+
+	return $findings;
+}
+
+function extract_class_like_structures( array $tokens ): array {
+	$structures = array();
+	$count      = count( $tokens );
+
+	for ( $index = 0; $index < $count; $index++ ) {
+		$token = $tokens[ $index ];
+		if ( ! is_array( $token ) || ! in_array( $token[0], array( T_CLASS, T_TRAIT ), true ) ) {
+			continue;
+		}
+
+		$name = 'anonymous';
+		$name_index = next_meaningful_token_index( $tokens, $index );
+		$name_token = null !== $name_index ? $tokens[ $name_index ] : null;
+		if ( is_array( $name_token ) && T_STRING === $name_token[0] ) {
+			$name = $name_token[1];
+		}
+
+		$open_index = find_next_token_index_by_text( $tokens, $index, '{' );
+		if ( null === $open_index ) {
+			continue;
+		}
+
+		$close_index = find_matching_brace( $tokens, $open_index );
+		if ( null === $close_index ) {
+			continue;
+		}
+
+		$structures[] = array(
+			'name'        => $name,
+			'properties'  => collect_declared_properties( $tokens, $open_index + 1, $close_index - 1 ),
+			'assignments' => collect_this_property_assignments( $tokens, $open_index + 1, $close_index - 1 ),
+		);
+
+		$index = $close_index;
+	}
+
+	return $structures;
+}
+
+function collect_declared_properties( array $tokens, int $start, int $end ): array {
+	$properties = array();
+	$brace_depth = 0;
+	$function_depth = 0;
+	$expect_property = false;
+
+	for ( $index = $start; $index <= $end; $index++ ) {
+		$token = $tokens[ $index ];
+		$text  = token_text( $token );
+
+		if ( '{' === $text ) {
+			++$brace_depth;
+			continue;
+		}
+
+		if ( '}' === $text ) {
+			$brace_depth = max( 0, $brace_depth - 1 );
+			if ( 0 === $brace_depth ) {
+				$function_depth = 0;
+			}
+			continue;
+		}
+
+		if ( 0 !== $brace_depth ) {
+			continue;
+		}
+
+		if ( is_array( $token ) && T_FUNCTION === $token[0] ) {
+			++$function_depth;
+			$expect_property = false;
+			continue;
+		}
+
+		if ( $function_depth > 0 ) {
+			continue;
+		}
+
+		if ( is_array( $token ) && in_array( $token[0], array( T_PUBLIC, T_PROTECTED, T_PRIVATE, T_VAR, T_STATIC, T_READONLY ), true ) ) {
+			$expect_property = true;
+			continue;
+		}
+
+		if ( $expect_property && is_array( $token ) && T_VARIABLE === $token[0] ) {
+			$properties[ ltrim( $token[1], '$' ) ] = true;
+			continue;
+		}
+
+		if ( ';' === $text ) {
+			$expect_property = false;
+		}
+	}
+
+	return $properties;
+}
+
+function collect_this_property_assignments( array $tokens, int $start, int $end ): array {
+	$assignments = array();
+	$count       = count( $tokens );
+
+	for ( $index = $start; $index <= $end && $index < $count; $index++ ) {
+		$token = $tokens[ $index ];
+
+		if ( ! is_array( $token ) || T_VARIABLE !== $token[0] || '$this' !== $token[1] ) {
+			continue;
+		}
+
+		$operator_index = next_meaningful_token_index( $tokens, $index );
+		$operator = null !== $operator_index ? $tokens[ $operator_index ] : null;
+		if ( '->' !== token_text( $operator ) ) {
+			continue;
+		}
+
+		$property_index = null !== $operator_index ? next_meaningful_token_index( $tokens, $operator_index ) : null;
+		$property = null !== $property_index ? $tokens[ $property_index ] : null;
+		if ( ! is_array( $property ) || T_STRING !== $property[0] ) {
+			continue;
+		}
+
+		$next_index = null !== $property_index ? next_meaningful_token_index( $tokens, $property_index ) : null;
+		$next = null !== $next_index ? $tokens[ $next_index ] : null;
+		$assignment_operators = array( '=', '+=', '-=', '*=', '/=', '.=', '%=', '&=', '|=', '^=', '??=' );
+		if ( ! in_array( token_text( $next ), $assignment_operators, true ) ) {
+			continue;
+		}
+
+		$assignments[] = array(
+			'property' => $property[1],
+			'line'     => $property[2],
+		);
+	}
+
+	return $assignments;
+}
+
+function parse_parameters( array $tokens, int $start, int $end ): array {
+	$parameters = array();
+	$current    = array(
+		'name'        => null,
+		'line'        => null,
+		'has_default' => false,
+		'is_variadic' => false,
+	);
+	$depth = 0;
+
+	for ( $index = $start; $index <= $end; $index++ ) {
+		$token = $tokens[ $index ];
+		$text  = token_text( $token );
+
+		if ( in_array( $text, array( '(', '[', '{' ), true ) ) {
+			++$depth;
+			continue;
+		}
+
+		if ( in_array( $text, array( ')', ']', '}' ), true ) ) {
+			$depth = max( 0, $depth - 1 );
+			continue;
+		}
+
+		if ( 0 === $depth && ',' === $text ) {
+			$parameters[] = $current;
+			$current = array(
+				'name'        => null,
+				'line'        => null,
+				'has_default' => false,
+				'is_variadic' => false,
+			);
+			continue;
+		}
+
+		if ( is_array( $token ) && T_ELLIPSIS === $token[0] ) {
+			$current['is_variadic'] = true;
+			continue;
+		}
+
+		if ( is_array( $token ) && T_VARIABLE === $token[0] ) {
+			$current['name'] = ltrim( $token[1], '$' );
+			$current['line'] = $token[2];
+			continue;
+		}
+
+		if ( 0 === $depth && '=' === $text ) {
+			$current['has_default'] = true;
+		}
+	}
+
+	if ( null !== $current['name'] ) {
+		$parameters[] = $current;
+	}
+
+	return $parameters;
+}
+
+function scan_readme_metadata( string $repositoryRoot ): array {
+	$notes = array();
+	$files = array(
+		$repositoryRoot . '/src/README.txt',
+		$repositoryRoot . '/trunk/readme.txt',
+	);
+
+	foreach ( $files as $file ) {
+		if ( ! is_file( $file ) ) {
+			continue;
+		}
+
+		$content = file_get_contents( $file );
+		if ( preg_match( '/^Requires PHP:\s*(.+)$/mi', $content, $matches ) ) {
+			$notes[] = sprintf(
+				'%s declares "Requires PHP: %s". This admits PHP 8.2-8.4 but does not explicitly document 8.3/8.4 validation.',
+				relative_path( $file ),
+				trim( $matches[1] )
+			);
+		}
+	}
+
+	return $notes;
+}
+
+function summarize_check( string $name, array $findings ): array {
+	return array(
+		'name'     => $name,
+		'status'   => empty( $findings ) ? 'PASS' : 'FAIL',
+		'findings' => $findings,
+	);
+}
+
+function print_report( array $report ): void {
+	printf( "PHP compatibility review\n" );
+	printf( "Target range: %s\n", $report['target_range'] );
+	printf( "Primary support: %s\n", $report['primary_support'] );
+	printf( "Backward-compat coverage: %s\n", $report['backward_compat'] );
+	printf( "Analyzer PHP: %s\n", $report['analyzer_php'] );
+	printf( "PHP binary: %s\n", $report['php_binary'] );
+	printf( "Files checked: %d\n\n", $report['file_count'] );
+
+	foreach ( $report['checks'] as $check ) {
+		printf( "[%s] %s\n", $check['status'], $check['name'] );
+		foreach ( $check['findings'] as $finding ) {
+			$location = $finding['file'];
+			if ( null !== $finding['line'] ) {
+				$location .= ':' . $finding['line'];
+			}
+			printf( "  - %s: %s\n", $location, $finding['message'] );
+		}
+	}
+
+	if ( ! empty( $report['notes'] ) ) {
+		printf( "\nNotes\n" );
+		foreach ( $report['notes'] as $note ) {
+			printf( "  - %s\n", $note );
+		}
+	}
+
+	printf( "\nPolicy\n" );
+	printf( "  - Static compatibility checks cover PHP 8.0-8.4.\n" );
+	printf( "  - The stricter deprecation heuristics in this script are focused on PHP 8.2-8.4.\n" );
+	printf( "  - Runtime compatibility for WordPress/PHP combinations should be enforced by the WordPress smoke-test workflow.\n" );
+
+	if ( all_checks_passed( $report['checks'] ) ) {
+		printf( "\nResult: no blocking PHP 8.0-8.4 compatibility issues were found by the static checks.\n" );
+	} else {
+		printf( "\nResult: one or more compatibility issues need review before claiming PHP 8.0-8.4 support.\n" );
+	}
+
+	printf( "Limitations: static source review only; it does not boot WordPress or exercise runtime behavior.\n" );
+}
+
+function all_checks_passed( array $checks ): bool {
+	foreach ( $checks as $check ) {
+		if ( 'PASS' !== $check['status'] ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+function previous_meaningful_token_index( array $tokens, int $index ): ?int {
+	for ( $current = $index - 1; $current >= 0; $current-- ) {
+		$token = $tokens[ $current ];
+		if ( is_array( $token ) && in_array( $token[0], array( T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ), true ) ) {
+			continue;
+		}
+
+		return $current;
+	}
+
+	return null;
+}
+
+function next_meaningful_token_index( array $tokens, int $index ): ?int {
+	$count = count( $tokens );
+	for ( $current = $index + 1; $current < $count; $current++ ) {
+		$token = $tokens[ $current ];
+		if ( is_array( $token ) && in_array( $token[0], array( T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ), true ) ) {
+			continue;
+		}
+
+		return $current;
+	}
+
+	return null;
+}
+
+function find_next_token_index_by_text( array $tokens, int $index, string $text ): ?int {
+	$count = count( $tokens );
+	for ( $current = $index + 1; $current < $count; $current++ ) {
+		if ( $text === token_text( $tokens[ $current ] ) ) {
+			return $current;
+		}
+	}
+
+	return null;
+}
+
+function find_matching_parenthesis( array $tokens, int $open_index ): ?int {
+	$depth = 0;
+	$count = count( $tokens );
+
+	for ( $index = $open_index; $index < $count; $index++ ) {
+		$text = token_text( $tokens[ $index ] );
+		if ( '(' === $text ) {
+			++$depth;
+			continue;
+		}
+
+		if ( ')' === $text ) {
+			--$depth;
+			if ( 0 === $depth ) {
+				return $index;
+			}
+		}
+	}
+
+	return null;
+}
+
+function find_matching_brace( array $tokens, int $open_index ): ?int {
+	$depth = 0;
+	$count = count( $tokens );
+
+	for ( $index = $open_index; $index < $count; $index++ ) {
+		$text = token_text( $tokens[ $index ] );
+		if ( '{' === $text ) {
+			++$depth;
+			continue;
+		}
+
+		if ( '}' === $text ) {
+			--$depth;
+			if ( 0 === $depth ) {
+				return $index;
+			}
+		}
+	}
+
+	return null;
+}
+
+function token_text( $token ): string {
+	return is_array( $token ) ? $token[1] : $token;
+}
+
+function relative_path( string $path ): string {
+	static $root = null;
+
+	if ( null === $root ) {
+		$root = dirname(__DIR__) . DIRECTORY_SEPARATOR;
+	}
+
+	if ( 0 === strpos( $path, $root ) ) {
+		return substr( $path, strlen( $root ) );
+	}
+
+	return $path;
+}

--- a/scripts/wordpress-smoke-check.php
+++ b/scripts/wordpress-smoke-check.php
@@ -1,0 +1,33 @@
+<?php
+
+if ( ! function_exists( 'jeo' ) ) {
+	fwrite( STDERR, "Missing jeo() bootstrap function.\n" );
+	exit( 1 );
+}
+
+$plugin = jeo();
+if ( ! $plugin instanceof Jeo ) {
+	fwrite( STDERR, "jeo() did not return the expected Jeo instance.\n" );
+	exit( 1 );
+}
+
+$required_post_types = array(
+	'map',
+	'map-layer',
+	'storymap',
+);
+
+foreach ( $required_post_types as $post_type ) {
+	if ( ! post_type_exists( $post_type ) ) {
+		fwrite( STDERR, sprintf( "Missing registered post type: %s\n", $post_type ) );
+		exit( 1 );
+	}
+}
+
+$active_plugins = (array) get_option( 'active_plugins', array() );
+if ( ! in_array( 'jeo/jeo.php', $active_plugins, true ) ) {
+	fwrite( STDERR, "Plugin jeo/jeo.php is not active.\n" );
+	exit( 1 );
+}
+
+fwrite( STDOUT, "WordPress smoke checks passed.\n" );

--- a/scripts/wordpress-smoke.sh
+++ b/scripts/wordpress-smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+WP_CLI="${WP_CLI:-wp}"
+WP_DIR="${WP_DIR:-${REPO_ROOT}/.tmp/wordpress}"
+WP_VERSION="${WP_VERSION:-latest}"
+WP_LOCALE="${WP_LOCALE:-en_US}"
+WP_SITE_URL="${WP_SITE_URL:-http://127.0.0.1}"
+WP_TITLE="${WP_TITLE:-JEO Smoke Test}"
+WP_ADMIN_USER="${WP_ADMIN_USER:-admin}"
+WP_ADMIN_PASSWORD="${WP_ADMIN_PASSWORD:-admin}"
+WP_ADMIN_EMAIL="${WP_ADMIN_EMAIL:-admin@example.com}"
+WP_DB_NAME="${WP_DB_NAME:-wordpress}"
+WP_DB_USER="${WP_DB_USER:-wordpress}"
+WP_DB_PASSWORD="${WP_DB_PASSWORD:-wordpress}"
+WP_DB_HOST="${WP_DB_HOST:-127.0.0.1:3306}"
+PLUGIN_SLUG="${PLUGIN_SLUG:-jeo}"
+PLUGIN_SOURCE="${PLUGIN_SOURCE:-${REPO_ROOT}/src}"
+
+mkdir -p "${WP_DIR}"
+
+"${WP_CLI}" core download \
+	--path="${WP_DIR}" \
+	--version="${WP_VERSION}" \
+	--locale="${WP_LOCALE}" \
+	--force \
+	--skip-content
+
+mkdir -p "${WP_DIR}/wp-content/plugins"
+ln -sfn "${PLUGIN_SOURCE}" "${WP_DIR}/wp-content/plugins/${PLUGIN_SLUG}"
+
+"${WP_CLI}" config create \
+	--path="${WP_DIR}" \
+	--dbname="${WP_DB_NAME}" \
+	--dbuser="${WP_DB_USER}" \
+	--dbpass="${WP_DB_PASSWORD}" \
+	--dbhost="${WP_DB_HOST}" \
+	--dbprefix=wp_ \
+	--skip-check \
+	--force
+
+if ! "${WP_CLI}" db check --path="${WP_DIR}" >/dev/null 2>&1; then
+	"${WP_CLI}" db create --path="${WP_DIR}"
+fi
+
+if ! "${WP_CLI}" core is-installed --path="${WP_DIR}" >/dev/null 2>&1; then
+	"${WP_CLI}" core install \
+		--path="${WP_DIR}" \
+		--url="${WP_SITE_URL}" \
+		--title="${WP_TITLE}" \
+		--admin_user="${WP_ADMIN_USER}" \
+		--admin_password="${WP_ADMIN_PASSWORD}" \
+		--admin_email="${WP_ADMIN_EMAIL}" \
+		--skip-email
+fi
+
+"${WP_CLI}" plugin activate "${PLUGIN_SLUG}" --path="${WP_DIR}"
+"${WP_CLI}" plugin list --path="${WP_DIR}"
+"${WP_CLI}" post-type list --field=name --path="${WP_DIR}"
+"${WP_CLI}" eval-file "${SCRIPT_DIR}/wordpress-smoke-check.php" --path="${WP_DIR}"

--- a/src/README.txt
+++ b/src/README.txt
@@ -1,6 +1,6 @@
 === JEO ===
-Contributors: earthjournalism
-Tested up to: 6.8.2
+Contributors: infoamazonia
+Tested up to: 6.9.4
 Stable tag: 2.15.2
 Requires PHP: 8.0
 Requires at least: 6.6
@@ -15,6 +15,15 @@ The JEO plugin acts as a geojournalism platform that allows news organizations, 
 With JEO, creating the interaction between data layers and contextual information is intuitive and interactive. You can post geotagged stories and create richly designed pages for each one of the featured stories.
 
 At the same time, by simply imputing the ids of layers hosted on [Mapbox](https://www.mapbox.com/), you can manage sophisticated maps without losing performance, add legends directly with HTML and set the map parameters. All directly at the WordPress dashboard.
+
+== Compatibility ==
+
+Compatibility snapshot validated on March 13, 2026:
+
+* Primary support: PHP 8.2, 8.3, and 8.4;
+* Stable WordPress gate: WordPress 6.9.4 on PHP 8.2, 8.3, and 8.4;
+* Backward-compatibility smoke tests: WordPress 6.6 on PHP 8.0 and 8.1;
+* Forward-compatibility smoke tests: WordPress 7.0-beta4 on PHP 8.2, 8.3, and 8.4.
 
 = Features =
 

--- a/src/css/jeo-map.scss
+++ b/src/css/jeo-map.scss
@@ -911,6 +911,20 @@
 	}
 }
 
+:is(
+	.mapboxgl-ctrl-fullscreen,
+	.mapboxgl-ctrl-zoom-in,
+	.mapboxgl-ctrl-zoom-out,
+	.mapboxgl-ctrl-shrink
+) {
+	background-image: none !important;
+
+	&:hover,
+	&:focus {
+		background-image: none !important;
+	}
+}
+
 .editor-styles-wrapper {
 	ul {
 		list-style-type: none !important;

--- a/src/jeo.php
+++ b/src/jeo.php
@@ -6,6 +6,8 @@
  * Plugin Name:       JEO WP
  * Description:       Interactive Map blocks for WordPress Gutenberg
  * Version:           3.0.0-rc.3
+ * Requires at least: 6.6
+ * Requires PHP:      8.0
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       jeo
@@ -32,5 +34,18 @@ define( 'JEO_BASEURL', plugins_url( '', __FILE__ ) );
  * admin-specific hooks, and public-facing site hooks.
  */
 require JEO_BASEPATH . 'includes/loaders.php';
+
+/**
+ * Register custom rewrites before flushing them on activation.
+ */
+function jeo_activate() {
+	jeo_maps()->register_post_type();
+	jeo_storymap()->register_post_type();
+	jeo()->register_embed_rewrite();
+
+	flush_rewrite_rules();
+}
+
+register_activation_hook( __FILE__, 'jeo_activate' );
 
 jeo();

--- a/src/js/src/map-blocks/map-editor-preview.js
+++ b/src/js/src/map-blocks/map-editor-preview.js
@@ -39,12 +39,14 @@ export default function MapEditorPreview() {
 			const { current: map } = mapRef;
 			if ( map ) {
 				const bounds = map.getBounds();
+				const northEast = bounds.getNorthEast();
+				const southWest = bounds.getSouthWest();
 				setPostMeta( {
 					pan_limits: {
-						east: bounds._ne.lat,
-						north: bounds._ne.lng,
-						south: bounds._sw.lng,
-						west: bounds._sw.lat,
+						east: northEast.lng,
+						north: northEast.lat,
+						south: southWest.lat,
+						west: southWest.lng,
 					},
 				} );
 			}

--- a/src/js/src/map-blocks/map-panel.js
+++ b/src/js/src/map-blocks/map-panel.js
@@ -1,4 +1,4 @@
-import { useEffect } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import MapSettings from './map-settings';
@@ -33,13 +33,41 @@ export default function MapPanel( {
 		}
 	}, [] );
 
+	const handleSetPanLimitsFromMap = useCallback( () => {
+		if ( typeof setPanLimitsFromMap === 'function' ) {
+			setPanLimitsFromMap();
+			return;
+		}
+
+		if ( typeof window.__jeoSetPanLimitsFromMap === 'function' ) {
+			window.__jeoSetPanLimitsFromMap();
+			return;
+		}
+
+		const iframeWindow = Array.from( document.querySelectorAll( 'iframe' ) )
+			.map( ( iframe ) => iframe.contentWindow )
+			.find(
+				( frame ) =>
+					frame &&
+					typeof frame.__jeoSetPanLimitsFromMap === 'function'
+			);
+
+		if ( iframeWindow ) {
+			iframeWindow.__jeoSetPanLimitsFromMap();
+		}
+	}, [ setPanLimitsFromMap ] );
+
 	return (
 		<Panel
 			name="map-settings"
 			title={ __( 'Map settings', 'jeo' ) }
 			className="jeo-map-panel"
 		>
-			<MapSettings attributes={ attributes } setAttributes={ setAttributes } setPanLimitsFromMap={setPanLimitsFromMap} />
+			<MapSettings
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				setPanLimitsFromMap={ handleSetPanLimitsFromMap }
+			/>
 		</Panel>
 	);
 }

--- a/src/js/src/map-blocks/map-settings.js
+++ b/src/js/src/map-blocks/map-settings.js
@@ -210,7 +210,15 @@ export default ( { attributes, setAttributes, setPanLimitsFromMap } ) => {
 					</div>
 					</p>
 					<p>
-						<Button variant="primary" isLarge onClick={ setPanLimitsFromMap }>
+						<Button
+							variant="primary"
+							isLarge
+							type="button"
+							onClick={ ( event ) => {
+								event.preventDefault();
+								setPanLimitsFromMap();
+							} }
+						>
 							{ __( 'Set current as map settings', 'jeo' ) }
 						</Button>
 					</p>

--- a/src/js/src/map-blocks/onetime-map-editor.js
+++ b/src/js/src/map-blocks/onetime-map-editor.js
@@ -50,14 +50,16 @@ export default function OnetimeMapEditor ( { attributes, setAttributes } ) {
 	const setPanLimitsFromMap = () => {
 		const { current: map } = mapRef;
 		if ( map ) {
-			const boundries = map.getBounds();
+			const bounds = map.getBounds();
+			const northEast = bounds.getNorthEast();
+			const southWest = bounds.getSouthWest();
 			setAttributes(
 				{	...attributes,
 					'pan_limits': {
-						east: boundries._ne.lat,
-						north: boundries._ne.lng,
-						south: boundries._sw.lng,
-						west: boundries._sw.lat,
+						east: northEast.lng,
+						north: northEast.lat,
+						south: southWest.lat,
+						west: southWest.lng,
 					}
 				} )
 		}

--- a/src/js/src/posts-selector/tokens-selector.js
+++ b/src/js/src/posts-selector/tokens-selector.js
@@ -1,5 +1,6 @@
-import { FormTokenField } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
+
+import { FormTokenField } from '../shared/wp-form-controls';
 
 export function TokensSelector( {
 	collection,

--- a/src/js/src/shared/wp-form-controls.js
+++ b/src/js/src/shared/wp-form-controls.js
@@ -1,5 +1,6 @@
 import {
 	CheckboxControl as WPCheckboxControl,
+	FormTokenField as WPFormTokenField,
 	RangeControl as WPRangeControl,
 	SelectControl as WPSelectControl,
 	TextControl as WPTextControl,
@@ -28,4 +29,8 @@ export function TextControl( props ) {
 
 export function RangeControl( props ) {
 	return <WPRangeControl { ...nextInputControlProps } { ...props } />;
+}
+
+export function FormTokenField( props ) {
+	return <WPFormTokenField { ...nextInputControlProps } { ...props } />;
 }

--- a/trunk/readme.txt
+++ b/trunk/readme.txt
@@ -1,6 +1,6 @@
 === JEO ===
-Contributors: earthjournalism
-Tested up to: 6.8.2
+Contributors: infoamazonia
+Tested up to: 6.9.4
 Stable tag: 2.15.2
 Requires PHP: 8.0
 Requires at least: 6.6
@@ -15,6 +15,15 @@ The JEO plugin acts as a geojournalism platform that allows news organizations, 
 With JEO, creating the interaction between data layers and contextual information is intuitive and interactive. You can post geotagged stories and create richly designed pages for each one of the featured stories.
 
 At the same time, by simply imputing the ids of layers hosted on [Mapbox](https://www.mapbox.com/), you can manage sophisticated maps without losing performance, add legends directly with HTML and set the map parameters. All directly at the WordPress dashboard.
+
+== Compatibility ==
+
+Compatibility snapshot validated on March 13, 2026:
+
+* Primary support: PHP 8.2, 8.3, and 8.4;
+* Stable WordPress gate: WordPress 6.9.4 on PHP 8.2, 8.3, and 8.4;
+* Backward-compatibility smoke tests: WordPress 6.6 on PHP 8.0 and 8.1;
+* Forward-compatibility smoke tests: WordPress 7.0-beta4 on PHP 8.2, 8.3, and 8.4.
 
 = Features =
 


### PR DESCRIPTION
Supersedes #495.

This replacement PR preserves the original commit organization and branch stacking, and only normalizes the Codex co-author trailers after the original PR was closed by a history rewrite.

This branch remains stacked on top of the replacement for #492: https://github.com/InfoAmazonia/jeo-plugin/pull/498

---

## Summary
- add PHP compatibility coverage with a static scanner, CI workflow, and WordPress smoke-test automation
- fix the PHP 8.0 compatibility scanner token handling so the new checker runs cleanly on the lowest supported runtime
- update minor Composer and npm dependencies, including regenerated lockfiles and related stylesheet adjustments
- restore map settings synchronization from the preview flow, prevent the settings action from submitting forms, and map bounds consistently in both map editors
- opt FormTokenField into the shared WordPress control wrapper so the editor follows upcoming spacing and size defaults without deprecation warnings

## Testing
- php -l src/jeo.php
- php -l scripts/check-php-compat.php
- php -l scripts/wordpress-smoke-check.php
- bash -n scripts/wordpress-smoke.sh
- local smoke tests on PHP 8.0 + WordPress 6.6
- local smoke tests on PHP 8.1 + WordPress 6.6
- local smoke tests on PHP 8.2 + WordPress 7.0-beta4
- local smoke tests on PHP 8.3 + WordPress 7.0-beta4
- local smoke tests on PHP 8.4 + WordPress 7.0-beta4