### PR TITLE
Standardize JEO public metadata and sync prerelease package manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,21 @@ rsync --archive --progress --human-readable --delete ./src/ /path/to/wordpress/w
 WordPress.org releases are built from `src/`, not from the repository root.
 The deploy workflow also publishes assets from `.wordpress-org/`.
 
-Before creating a release tag, keep these files aligned:
+Prerelease branches may carry a SemVer prerelease such as `3.0.0-rc.3` while
+WordPress.org stays on the latest stable release. Before creating a stable
+release tag, run `npm run sync:version` and keep these files aligned:
 
 - `src/jeo.php`
 - `src/readme.txt`
+- `package.json`
+- `package-lock.json`
 - `.wordpress-org/`
 
 The deploy workflow now validates that:
 
 - the plugin version in `src/jeo.php` matches `JEO_VERSION`
-- the `Stable tag` in `src/readme.txt` matches the plugin version
+- `package.json` and the root package entry in `package-lock.json` match the plugin version
+- the `Stable tag` in `src/readme.txt` matches the plugin version for the tagged stable release
 - the release tag is a stable `x.y.z` version
 
 Pre-release tags such as `-rc` are intentionally blocked from the WordPress.org deploy pipeline.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,14 @@
 {
     "name": "infoamazonia/jeo-plugin",
     "type": "project",
+    "homepage": "https://www.jeowp.org/",
+    "authors": [
+        {
+            "name": "InfoAmazonia",
+            "email": "contact@infoamazonia.org",
+            "homepage": "https://www.jeowp.org/"
+        }
+    ],
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.13.5",
         "wp-coding-standards/wpcs": "^3.3.0"
@@ -12,4 +20,3 @@
         }
     }
 }
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-# JEO WordPress Theme
+# JEO Documentation
 
-JEO WordPress Theme acts as a geojournalism platform which allows news organizations, bloggers and NGOs to publish news stories as layers of information on digital maps. With JEO, creating the interaction between data layers and contextual information is much more intuitive and interactive. The theme is ready for multilingual content and facilitates the publishing tasks.
+JEO acts as a geojournalism platform which allows news organizations, bloggers and NGOs to publish news stories as layers of information on digital maps. With JEO, creating the interaction between data layers and contextual information is much more intuitive and interactive.
 
-You can post geotagged stories and create richly designed pages for each one of the featured stories. At same time, by simply imputing the ids of layers hosted on MapBox, you can manage sophisticated maps without loosing perfomance, add legends directly with HTML and set the map paramethers. All direct at the WordPress dashboard.
+You can post geotagged stories and create richly designed pages for each one of the featured stories. At the same time, by configuring layers hosted on Mapbox and choosing between MapboxGL and MapLibreGL, you can manage sophisticated maps without losing performance, add legends directly with HTML and set the map parameters. All directly at the WordPress dashboard.
 
 JEO wants to help journalists and NGOs to improve storytelling with maps. Creating a child theme with all its functionality is easy since it contains all the necessary hooks to customize layouts and data visualization.
 
@@ -10,17 +10,14 @@ JEO wants to help journalists and NGOs to improve storytelling with maps. Creati
 
 ## Features
 
-- Leaflet map library
+- MapboxGL and MapLibreGL map rendering
 - Custom tile layers
-- [MapBox](http://mapbox.com/) maps
-- [CartoDB](http://cartodb.com/) maps
-- Layer filtering options, allowing you to mix tile layer, MapBox and CartoDB.
-- Geocoding WordPress posts using OpenStreetMaps or Google Maps supporting custom post types.
-- Google Street View support for Google Maps geocoding.
+- [Mapbox](https://www.mapbox.com/) maps
+- Layer filtering options, allowing you to mix tile layers.
+- Geocoding WordPress posts using OpenStreetMap (Nominatim), with extensibility for additional geocoders via hook.
 - Customizable marker icons that can be associated to categories, custom taxonomies or posts directly.
 - Map markers query integrated to posts query.
-- GeoJSON API (any content /?geojson gives the geojson output). E.g.: yourwebsite.com/category/one/?geojson
-- Support [qTranslate](https://wordpress.org/plugins/qtranslate/) multilanguage plugin
+- Support [WPML](https://wpml.org/pt-br/) and [Polylang](https://br.wordpress.org/plugins/polylang/) multilingual plugins
 
 ## User tutorials
 

--- a/docs/dev/geocoders.md
+++ b/docs/dev/geocoders.md
@@ -4,7 +4,7 @@ A Geocoder is a service that finds geographical coordinates from a search by add
 
 JEO needs a geocoder service in a few situations, such as when users indicate to where on a map a story (posts) is related.
 
-JEO comes with two native geocoder services users can choose from: Nominatim and Google. But new services can easily be added by plugins. This page documents how to do this.
+JEO ships with Nominatim as its native geocoder. Additional geocoders can be added by plugins through the `jeo_register_geocoders` hook. This page documents how to do this.
 
 ## Registering a Geocoder
 

--- a/docs/index-plugin.md
+++ b/docs/index-plugin.md
@@ -2,18 +2,18 @@
 
 The JEO plugin acts as a geojournalism platform that allows news organizations, bloggers and NGOs to publish news stories as layers of information on digital maps. With JEO, creating the interaction between data layers and contextual information is intuitive and interactive.
 
-You can post geotagged stories and create richly designed pages for each one of the featured stories. At the same time, by simply imputing the ids of layers hosted on MapBox, you can manage sophisticated maps without losing performance, add legends directly with HTML and set the map parameters. All direct at the WordPress dashboard.
+You can post geotagged stories and create richly designed pages for each one of the featured stories. At the same time, by configuring layers hosted on Mapbox and choosing between MapboxGL and MapLibreGL, you can manage sophisticated maps without losing performance, add legends directly with HTML and set the map parameters. All directly at the WordPress dashboard.
 
 ## Features
 
-- [MapBox](http://mapbox.com/) maps
+- [Mapbox](https://www.mapbox.com/) and [MapLibre](https://maplibre.org/) maps
 - [react-map-gl](https://visgl.github.io/react-map-gl/) library
 - Custom tile layers
 - Layer filtering options, allowing you to mix tile layer.
-- Geocoding WordPress posts using OpenStreetMaps (Nominatim), suporting the post type `Post`.
+- Geocoding WordPress posts using OpenStreetMap (Nominatim), supporting the post type `Post`, with extensibility for additional geocoders via hook.
 - Customizable marker icons that can be associated to categories, custom taxonomies or posts directly.
 - Map markers query integrated to posts query.
-- Support [WPML](https://wpml.org/pt-br/) and [Polylang](https://br.wordpress.org/plugins/polylang/) multilanguages plugins
+- Support [WPML](https://wpml.org/pt-br/) and [Polylang](https://br.wordpress.org/plugins/polylang/) multilingual plugins
 
 ## User tutorials
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,18 +2,18 @@
 
 The JEO WordPress geojournalism platform allows news organizations, bloggers and NGOs to publish news stories as layers of information on digital maps. With JEO, creating the interaction between data layers and contextual information is intuitive and interactive.
 
-## JEO WordPress Plugin
+## JEO Plugin
 
 Features:
 
-- [MapBox](http://mapbox.com/) maps
+- [Mapbox](https://www.mapbox.com/) and [MapLibre](https://maplibre.org/) maps
 - [react-map-gl](https://visgl.github.io/react-map-gl/) library
 - Custom tile layers
 - Layer filtering options, allowing you to mix tile layer.
-- Geocoding WordPress posts using OpenStreetMaps (Nominatim), suporting the post type `Post`.
+- Geocoding WordPress posts using OpenStreetMap (Nominatim), supporting the post type `Post`, with extensibility for additional geocoders via hook.
 - Customizable marker icons that can be associated to categories, custom taxonomies or posts directly.
 - Map markers query integrated to posts query.
-- Support [WPML](https://wpml.org/pt-br/) and [Polylang](https://br.wordpress.org/plugins/polylang/) multilanguages plugins
+- Support [WPML](https://wpml.org/pt-br/) and [Polylang](https://br.wordpress.org/plugins/polylang/) multilingual plugins
 
 Projects using JEO:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jeo",
-	"version": "1.0.0",
+	"version": "3.0.0-rc.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jeo",
-			"version": "1.0.0",
+			"version": "3.0.0-rc.3",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jeo",
-	"version": "1.0.0",
+	"version": "3.0.0-rc.3",
 	"description": "Jeo plugin",
 	"main": "index.js",
 	"directories": {
@@ -13,6 +13,7 @@
 	"scripts": {
 		"check:env": "node scripts/check-node-version.mjs",
 		"preinstall": "node scripts/check-node-version.mjs",
+		"sync:version": "node scripts/sync-plugin-version.mjs",
 		"start": "wp-scripts start",
 		"build": "wp-scripts build",
 		"build:report": "node scripts/report-bundle-sizes.mjs",
@@ -25,12 +26,16 @@
 		"type": "git",
 		"url": "git+https://github.com/InfoAmazonia/jeo-plugin.git"
 	},
-	"author": "",
+	"author": {
+		"name": "InfoAmazonia",
+		"email": "contact@infoamazonia.org",
+		"url": "https://www.jeowp.org/"
+	},
 	"license": "ISC",
 	"bugs": {
 		"url": "https://github.com/InfoAmazonia/jeo-plugin/issues"
 	},
-	"homepage": "https://github.com/InfoAmazonia/jeo-plugin#readme",
+	"homepage": "https://www.jeowp.org/",
 	"overrides": {
 		"react-autosize-textarea": "file:npm-overrides/react-autosize-textarea",
 		"js-yaml": "^4.1.1",

--- a/scripts/sync-plugin-version.mjs
+++ b/scripts/sync-plugin-version.mjs
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve( path.dirname( fileURLToPath( import.meta.url ) ), '..' );
+const PLUGIN_FILE = path.join( ROOT, 'src', 'jeo.php' );
+const PACKAGE_JSON_FILE = path.join( ROOT, 'package.json' );
+const PACKAGE_LOCK_FILE = path.join( ROOT, 'package-lock.json' );
+const TRANSLATION_FILES = [
+	path.join( ROOT, 'src', 'languages', 'jeo.pot' ),
+	path.join( ROOT, 'src', 'languages', 'jeo-pt_BR.po' ),
+	path.join( ROOT, 'src', 'languages', 'jeo-es_ES.po' ),
+];
+
+function fail( message ) {
+	console.error( `Version sync failed: ${ message }` );
+	process.exit( 1 );
+}
+
+function extract( content, pattern, label ) {
+	const match = content.match( pattern );
+	if ( ! match ) {
+		fail( `Unable to find ${ label }.` );
+	}
+
+	return match[ 1 ].trim();
+}
+
+const pluginContents = fs.readFileSync( PLUGIN_FILE, 'utf8' );
+const headerVersion = extract( pluginContents, /^\s*\*\s+Version:\s+(.+)$/m, 'plugin header version' );
+const constantVersion = extract(
+	pluginContents,
+	/define\(\s*'JEO_VERSION',\s*'([^']+)'\s*\)/,
+	'JEO_VERSION constant'
+);
+
+if ( headerVersion !== constantVersion ) {
+	fail( `Plugin header version (${ headerVersion }) does not match JEO_VERSION (${ constantVersion }).` );
+}
+
+const packageJson = JSON.parse( fs.readFileSync( PACKAGE_JSON_FILE, 'utf8' ) );
+packageJson.version = headerVersion;
+fs.writeFileSync( PACKAGE_JSON_FILE, `${ JSON.stringify( packageJson, null, '\t' ) }\n` );
+
+const packageLock = JSON.parse( fs.readFileSync( PACKAGE_LOCK_FILE, 'utf8' ) );
+packageLock.version = headerVersion;
+
+if ( ! packageLock.packages?.[''] ) {
+	fail( 'Unable to find the root package entry in package-lock.json.' );
+}
+
+packageLock.packages[''].version = headerVersion;
+fs.writeFileSync( PACKAGE_LOCK_FILE, `${ JSON.stringify( packageLock, null, '\t' ) }\n` );
+
+for ( const file of TRANSLATION_FILES ) {
+	const contents = fs.readFileSync( file, 'utf8' );
+	let matched = false;
+	const nextContents = contents.replace(
+		/"Project-Id-Version:\s*.+\\n"/,
+		() => {
+			matched = true;
+			return `"Project-Id-Version: JEO ${ headerVersion }\\n"`;
+		}
+	);
+
+	if ( ! matched ) {
+		fail( `Unable to update Project-Id-Version in ${ path.relative( ROOT, file ) }.` );
+	}
+
+	if ( contents !== nextContents ) {
+		fs.writeFileSync( file, nextContents );
+	}
+}
+
+console.log( `Synchronized package manifests and translation headers to ${ headerVersion }.` );

--- a/scripts/validate-release-meta.mjs
+++ b/scripts/validate-release-meta.mjs
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url';
 const ROOT = path.resolve( path.dirname( fileURLToPath( import.meta.url ) ), '..' );
 const PLUGIN_FILE = path.join( ROOT, 'src', 'jeo.php' );
 const README_FILE = path.join( ROOT, 'src', 'readme.txt' );
+const PACKAGE_JSON_FILE = path.join( ROOT, 'package.json' );
+const PACKAGE_LOCK_FILE = path.join( ROOT, 'package-lock.json' );
 
 function fail( message ) {
 	console.error( `Release metadata validation failed: ${ message }` );
@@ -26,6 +28,8 @@ function isStableVersion( value ) {
 
 const pluginContents = fs.readFileSync( PLUGIN_FILE, 'utf8' );
 const readmeContents = fs.readFileSync( README_FILE, 'utf8' );
+const packageJson = JSON.parse( fs.readFileSync( PACKAGE_JSON_FILE, 'utf8' ) );
+const packageLock = JSON.parse( fs.readFileSync( PACKAGE_LOCK_FILE, 'utf8' ) );
 
 const headerVersion = extract( pluginContents, /^\s*\*\s+Version:\s+(.+)$/m, 'plugin header version' );
 const constantVersion = extract(
@@ -44,6 +48,20 @@ if ( headerVersion !== constantVersion ) {
 if ( readmeVersionMatch && readmeVersionMatch[ 1 ].trim() !== headerVersion ) {
 	fail(
 		`src/readme.txt version (${ readmeVersionMatch[ 1 ].trim() }) does not match src/jeo.php version (${ headerVersion }).`
+	);
+}
+
+if ( packageJson.version !== headerVersion ) {
+	fail( `package.json version (${ packageJson.version }) does not match src/jeo.php version (${ headerVersion }).` );
+}
+
+if ( packageLock.version !== headerVersion ) {
+	fail( `package-lock.json version (${ packageLock.version }) does not match src/jeo.php version (${ headerVersion }).` );
+}
+
+if ( packageLock.packages?.['']?.version !== headerVersion ) {
+	fail(
+		`package-lock.json root package version (${ packageLock.packages?.['']?.version }) does not match src/jeo.php version (${ headerVersion }).`
 	);
 }
 

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -5,7 +5,7 @@
  * A class definition that includes attributes and functions used across both the
  * public-facing side of the site and the admin area.
  *
- * @link       leo.com
+ * @link       https://www.jeowp.org/
  * @since      1.0.0
  *
  * @package    Jeo
@@ -24,7 +24,7 @@
  * @since      1.0.0
  * @package    Jeo
  * @subpackage Jeo/includes
- * @author     Leo <leo@Leo.leo>
+ * @author     InfoAmazonia <contact@infoamazonia.org>
  */
 class Jeo {
 

--- a/src/jeo.php
+++ b/src/jeo.php
@@ -5,9 +5,12 @@
  * @package           Jeo
  *
  * @wordpress-plugin
- * Plugin Name:       JEO WP
+ * Plugin Name:       JEO
+ * Plugin URI:        https://www.jeowp.org/
  * Description:       Interactive Map blocks for WordPress Gutenberg
  * Version:           3.0.0-rc.3
+ * Author:            InfoAmazonia
+ * Author URI:        https://www.jeowp.org/
  * Requires at least: 6.6
  * Requires PHP:      8.0
  * License:           GPL-2.0+

--- a/src/languages/jeo-es_ES.po
+++ b/src/languages/jeo-es_ES.po
@@ -1,8 +1,8 @@
 # Copyright (C) 2021
-# This file is distributed under the same license as the JEO WP plugin.
+# This file is distributed under the same license as the JEO plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: JEO WP 1.2.1\n"
+"Project-Id-Version: JEO 3.0.0-rc.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/jeowp\n"
 "POT-Creation-Date: 2025-09-04T19:08:18+00:00\n"
 "PO-Revision-Date: 2025-09-04 16:20-0300\n"
@@ -19,8 +19,8 @@ msgstr ""
 
 #. Plugin Name of the plugin
 #: jeo.php
-msgid "JEO WP"
-msgstr "JEO WP"
+msgid "JEO"
+msgstr "JEO"
 
 #. Description of the plugin
 #: jeo.php

--- a/src/languages/jeo-pt_BR.po
+++ b/src/languages/jeo-pt_BR.po
@@ -1,8 +1,8 @@
 # Copyright (C) 2021
-# This file is distributed under the same license as the JEO WP plugin.
+# This file is distributed under the same license as the JEO plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: JEO WP 1.2.1\n"
+"Project-Id-Version: JEO 3.0.0-rc.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/jeowp\n"
 "POT-Creation-Date: 2025-09-04T19:08:18+00:00\n"
 "PO-Revision-Date: 2025-09-04 16:20-0300\n"
@@ -19,8 +19,8 @@ msgstr ""
 
 #. Plugin Name of the plugin
 #: jeo.php
-msgid "JEO WP"
-msgstr "JEO WP"
+msgid "JEO"
+msgstr "JEO"
 
 #. Description of the plugin
 #: jeo.php

--- a/src/languages/jeo.pot
+++ b/src/languages/jeo.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: JEO WP 2.15.2\n"
+"Project-Id-Version: JEO 3.0.0-rc.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/jeowp\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 
 #. Plugin Name of the plugin
 #: jeo.php
-msgid "JEO WP"
+msgid "JEO"
 msgstr ""
 
 #. Description of the plugin

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -43,7 +43,7 @@ Compatibility snapshot validated on March 17, 2026:
 
 1. Upload `jeo.php` to the `/wp-content/plugins/` directory;
 2. Activate the plugin through the 'Plugins' menu in WordPress;
-3. Select Jeo on the admin menu.
+3. Select JEO on the admin menu.
 
 There, you can configure:
 * The map rendering library (either MapboxGL or MapLibreGL);
@@ -708,7 +708,7 @@ A Geocoder is a service that finds geographical coordinates from a search by add
 
 JEO needs a geocoder service in a few situations, such as when users indicate to where on a map a story (posts) is related.
 
-JEO comes with two native geocoder services users can choose from: Nominatim and Google. But new services can easily be added by plugins. This page documents how to do this.
+JEO ships with Nominatim as its native geocoder. Additional geocoders can be added by plugins through the `jeo_register_geocoders` hook. This page documents how to do this.
 
 ## Registering a Geocoder
 


### PR DESCRIPTION
## Summary
- standardize the public plugin name as JEO and align InfoAmazonia ownership metadata in the plugin headers, translations, Composer, and npm manifests
- refresh the user-facing and developer documentation so it reflects the current Mapbox/MapLibre runtime, Nominatim support, and hook-based geocoder extensibility
- add an explicit prerelease metadata sync workflow that mirrors the plugin version into package manifests and release validation without changing the WordPress.org stable-release behavior

## Commit structure
- `refactor: standardize JEO public metadata and translation headers`
- `docs: align JEO documentation with current supported integrations`
- `chore: automate prerelease metadata sync for package manifests`

## Validation
- `node scripts/sync-plugin-version.mjs`
- `git diff --check`
- `php -l src/jeo.php`
- `php -l src/includes/class-jeo.php`

## Stack
- Stacked on #512
- Base branch: `codex/clean-release-tree-and-docs-sync`
- Keeps prerelease versions such as `3.0.0-rc.3` out of the WordPress.org stable deploy flow while still syncing local package metadata
