### PR TITLE
Restore storymap layer selections after editor hydration

### DIFF
--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -752,15 +752,30 @@ class Jeo {
 	 * @return bool
 	 */
 	private function layer_still_exists( array $map_layers, $selected_layer ) {
-		$layer_status = get_post_status( $selected_layer->id );
+		if ( ! is_object( $selected_layer ) || ! isset( $selected_layer->id ) ) {
+			return false;
+		}
+
+		$selected_layer_id = absint( $selected_layer->id );
+		if ( ! $selected_layer_id ) {
+			return false;
+		}
+
+		$layer_status = get_post_status( $selected_layer_id );
 		if ( 'trash' === $layer_status || false === $layer_status || 'private' === $layer_status ) {
 			return false;
 		}
 
 		foreach ( $map_layers as $layer ) {
-			if ( $layer['id'] === $selected_layer->id ) {
-				$selected_layer->meta->type               = get_post_meta( $layer['id'], 'type', true );
-				$selected_layer->meta->layer_type_options = (object) get_post_meta( $layer['id'], 'layer_type_options', true );
+			$map_layer_id = absint( $layer['id'] ?? 0 );
+			if ( $map_layer_id === $selected_layer_id ) {
+				if ( ! isset( $selected_layer->meta ) || ! is_object( $selected_layer->meta ) ) {
+					$selected_layer->meta = new \stdClass();
+				}
+
+				$selected_layer->id                       = $selected_layer_id;
+				$selected_layer->meta->type               = get_post_meta( $selected_layer_id, 'type', true );
+				$selected_layer->meta->layer_type_options = (object) get_post_meta( $selected_layer_id, 'layer_type_options', true );
 				return true;
 			}
 		}
@@ -830,7 +845,7 @@ class Jeo {
 
 			foreach ( $map_layers as $layer ) {
 				foreach ( $selected_layers as $selected_layer ) {
-					if ( $selected_layer->id === $layer['id'] ) {
+					if ( absint( $selected_layer->id ?? 0 ) === absint( $layer['id'] ?? 0 ) ) {
 						$selected_layers_order[] = $selected_layer;
 					}
 				}
@@ -846,7 +861,7 @@ class Jeo {
 
 		foreach ( $map_layers as $layer ) {
 			foreach ( $navigate_map_layers as $index => $navigate_layer ) {
-				if ( $navigate_layer->id === $layer['id'] ) {
+				if ( absint( $navigate_layer->id ?? 0 ) === absint( $layer['id'] ?? 0 ) ) {
 					// Update the saved metadata and layer types.
 					if ( ! $this->layer_still_exists( $map_layers, $navigate_layer ) ) {
 						array_splice( $navigate_map_layers, $index, 1 );

--- a/src/js/src/map-blocks/index.js
+++ b/src/js/src/map-blocks/index.js
@@ -89,27 +89,40 @@ const storyMapCleanUp = (props) => {
 	}
 
 	function removeYoastTagsFromObject(object) {
-		if(Object.hasOwn( object, 'yoast_head') ) {
-			delete object.yoast_head;
+		if(! object || typeof object !== 'object') {
+			return;
 		}
+
+		delete object.yoast_head;
+		delete object.yoast_head_json;
 	}
 
-	attributesStructure.navigateMapLayers.forEach( item => {
-		removeYoastTagsFromObject(item);
-		delete item.content;
-	})
-
-	attributesStructure.slides.forEach( slide => {
-		slide.selectedLayers.forEach( layer => {
-			// Remove yoast tags that are unecessary
-			removeYoastTagsFromObject(layer);
-
-			// Remove slide content from future JSON
-			if(layer.content) {
-				delete layer.content;
+	if(Array.isArray(attributesStructure.navigateMapLayers)) {
+		attributesStructure.navigateMapLayers.forEach( item => {
+			removeYoastTagsFromObject(item);
+			if(item && typeof item === 'object') {
+				delete item.content;
 			}
-		} )
-	})
+		})
+	}
+
+	if(Array.isArray(attributesStructure.slides)) {
+		attributesStructure.slides.forEach( slide => {
+			if(! slide || ! Array.isArray(slide.selectedLayers)) {
+				return;
+			}
+
+			slide.selectedLayers.forEach( layer => {
+				// Remove yoast tags that are unecessary
+				removeYoastTagsFromObject(layer);
+
+				// Remove slide content from future JSON
+				if(layer && typeof layer === 'object' && layer.content) {
+					delete layer.content;
+				}
+			} )
+		})
+	}
 
 	// Loaded layers aren't used properly
 	attributesStructure.loadedLayers = [];

--- a/src/js/src/map-blocks/index.js
+++ b/src/js/src/map-blocks/index.js
@@ -68,8 +68,9 @@ registerBlockType( 'jeo/onetime-map', {
 	],
 } );
 
-const storyMapCleanUp = (props) => {
+const storyMapCleanUp = (props, options = {}) => {
 	const propsCopy = cloneDeep(props);
+	const { removeYoastHeadJson = true } = options;
 
 	const attributesStructure = {
 		map_id: null,
@@ -94,7 +95,10 @@ const storyMapCleanUp = (props) => {
 		}
 
 		delete object.yoast_head;
-		delete object.yoast_head_json;
+
+		if(removeYoastHeadJson) {
+			delete object.yoast_head_json;
+		}
 	}
 
 	if(Array.isArray(attributesStructure.navigateMapLayers)) {
@@ -129,6 +133,8 @@ const storyMapCleanUp = (props) => {
 
 	return attributesStructure;
 }
+
+const legacyStoryMapCleanUp = (props) => storyMapCleanUp(props, { removeYoastHeadJson: false });
 
 const storymapAttributes = {
 	map_id: {
@@ -180,10 +186,24 @@ registerBlockType( 'jeo/storymap', {
 		);
 	},
 	deprecated: [
+		// Compatibility for storymaps saved before PR #564 started stripping
+		// yoast_head_json; Gutenberg needs this exact legacy markup to validate.
+		{
+			attributes: storymapAttributes,
+			save: ( { attributes } ) => {
+				const blockProps = useBlockProps.save();
+				const attributesStructure = legacyStoryMapCleanUp( { attributes } );
+				return (
+					<div { ...blockProps }>
+						{ JSON.stringify( attributesStructure ) }
+					</div>
+				);
+			},
+		},
 		{
 			attributes: storymapAttributes,
 			save: ( props ) => {
-				const attributesStructure = storyMapCleanUp(props);
+				const attributesStructure = legacyStoryMapCleanUp(props);
 				return JSON.stringify(attributesStructure)
 			},
 		},

--- a/src/js/src/map-blocks/storymap-editor.js
+++ b/src/js/src/map-blocks/storymap-editor.js
@@ -41,9 +41,11 @@ import { renderLayer } from './map-preview-layer';
 import JeoAutosuggest from './jeo-autosuggest';
 import JeoGeoAutoComplete from '../posts-sidebar/geo-auto-complete';
 import {
+	getLayerId,
+	layerIdsMatch,
 	moveActiveIndex,
+	reconcileSelectedLayersWithAvailableLayers,
 	reorderSlides,
-	sortSelectedLayersByMapOrder,
 } from './storymap-ordering';
 import { useRecordsByIds } from '../shared/rest-records';
 import { computeInlineEnd } from '../shared/direction';
@@ -467,7 +469,12 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 		return loadedMap.meta.layers.map( ( layer ) => layer.id );
 	}, [ loadedMap?.meta.layers ] );
 
-	const { records: loadedLayers = [] } = useRecordsByIds( {
+	const {
+		records: loadedLayers = [],
+		isLoading: loadingLayers,
+		error: layersError,
+		hasResolved: layersResolved,
+	} = useRecordsByIds( {
 		path: '/jeo/v1/map-layer',
 		ids: layerIds,
 		enabled: layerIds.length > 0,
@@ -479,7 +486,7 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 				selectedLayers:
 					attributes.slides?.[ currentSlideIndex ]?.selectedLayers || [],
 				navigateLayers:
-					attributes.navigateMapLayers?.map( ( layer ) => layer.id ) || [],
+					attributes.navigateMapLayers?.map( getLayerId ) || [],
 			} ),
 		[ attributes.slides, attributes.navigateMapLayers, currentSlideIndex ]
 	);
@@ -541,26 +548,24 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 	}, [ highlightedSlideKey ] );
 
 	useEffect( () => {
-		// Post already exists
-		if ( attributes.slides && loadedMap && loadedLayers ) {
-			const loadedMapLayerIds = new Set(
-				loadedMap.meta.layers.map( ( layer ) => layer.id )
-			);
-			const availableLayerIds = new Set(
-				loadedLayers.map( ( layer ) => layer.id )
-			);
-			const newSlides = attributes.slides.map( ( slide ) => {
-				const selectedLayers = ( slide.selectedLayers ?? [] ).filter(
-					( selectedLayer ) =>
-						loadedMapLayerIds.has( selectedLayer.id ) &&
-						availableLayerIds.has( selectedLayer.id )
-				);
+		if ( ! loadedMap || ! layersResolved || loadingLayers || layersError ) {
+			return;
+		}
 
+		if ( layerIds.length > 0 && loadedLayers.length === 0 ) {
+			return;
+		}
+
+		// Post already exists
+		if ( attributes.slides ) {
+			const loadedMapLayers = loadedMap.meta.layers ?? [];
+			const newSlides = attributes.slides.map( ( slide ) => {
 				return {
 					...slide,
-					selectedLayers: sortSelectedLayersByMapOrder(
-						selectedLayers,
-						loadedMap.meta.layers
+					selectedLayers: reconcileSelectedLayersWithAvailableLayers(
+						slide.selectedLayers,
+						loadedMapLayers,
+						loadedLayers
 					),
 				};
 			} );
@@ -581,7 +586,7 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 			loadedLayers: [],
 			navigateMapLayers: loadedLayers ?? [],
 		} );
-	}, [ loadedMap, loadedLayers ] );
+	}, [ loadedMap, loadedLayers, layerIds.length, layersResolved, loadingLayers, layersError ] );
 
 	const editorConfig = useMemo( () => {
 		const layerColors = (loadedLayers ?? []).flatMap( ( layer ) => {
@@ -735,7 +740,7 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 								( layer ) => {
 									if(attributes.navigateMapLayers) {
 										const layerOptions = attributes.navigateMapLayers.find(
-											( { id } ) => id === layer.id
+											( item ) => layerIdsMatch( item, layer )
 										);
 										if ( layerOptions ) {
 											return renderLayer( {
@@ -876,15 +881,15 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 																	background: 'rgb(240, 240, 240)',
 																};
 
-																attributes.slides[ slideIndex ].selectedLayers.map(
-																	( selectedLayer ) => {
-																		if ( selectedLayer.id === item.id ) {
-																			layerButtonStyle = {
-																				background: 'rgb(200, 200, 200)',
-																			};
+																	attributes.slides[ slideIndex ].selectedLayers.map(
+																		( selectedLayer ) => {
+																			if ( layerIdsMatch( selectedLayer, item ) ) {
+																				layerButtonStyle = {
+																					background: 'rgb(200, 200, 200)',
+																				};
+																			}
 																		}
-																	}
-																);
+																	);
 
 																if ( ! item ) {
 																	return null;
@@ -892,45 +897,45 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 
 																return (
 																	<Button
-																		style={ layerButtonStyle }
-																		className="layer"
-																		key={ item.id }
-																		onClick={ () => {
-																			setCurrentSlideIndex( slideIndex );
+																			style={ layerButtonStyle }
+																			className="layer"
+																			key={ item.id }
+																			onClick={ () => {
+																				setCurrentSlideIndex( slideIndex );
 
-																			const oldSlides = JSON.parse(JSON.stringify(attributes.slides));
-																			let hasBeenRemoved = false;
+																				const oldSlides = JSON.parse(JSON.stringify(attributes.slides));
+																				let hasBeenRemoved = false;
 
-																			oldSlides[ slideIndex ].selectedLayers.map(
-																				( selectedLayer, indexOfLayer ) => {
-																					if ( selectedLayer.id === item.id ) {
-																						oldSlides[
-																							slideIndex
-																						].selectedLayers.splice(
-																							indexOfLayer,
-																							1
-																						);
-																						hasBeenRemoved = true;
-																					}
-																				}
-																			);
-
-																			if ( ! hasBeenRemoved ) {
-
-																				let defaultOrder = Array(loadedMap.meta.layers.length).fill(null);
-																				let itemPosition = false;
-
-																				const findItemPostion = (item) => {
-																					let itemPosition = -1;
-
-																					loadedMap.meta.layers.forEach( (layer, index) => {
-																						if( item.id === layer.id ) {
-																							itemPosition = index;
+																				oldSlides[ slideIndex ].selectedLayers.map(
+																					( selectedLayer, indexOfLayer ) => {
+																						if ( layerIdsMatch( selectedLayer, item ) ) {
+																							oldSlides[
+																								slideIndex
+																							].selectedLayers.splice(
+																								indexOfLayer,
+																								1
+																							);
+																							hasBeenRemoved = true;
 																						}
-																					})
+																					}
+																				);
 
-																					return itemPosition;
-																				}
+																				if ( ! hasBeenRemoved ) {
+
+																					let defaultOrder = Array(loadedMap.meta.layers.length).fill(null);
+																					let itemPosition = false;
+
+																					const findItemPostion = (item) => {
+																						let itemPosition = -1;
+
+																						loadedMap.meta.layers.forEach( (layer, index) => {
+																							if( layerIdsMatch( item, layer ) ) {
+																								itemPosition = index;
+																							}
+																						})
+
+																						return itemPosition;
+																					}
 
 																				oldSlides[ slideIndex ].selectedLayers.map( (layer) => {
 																					const position = findItemPostion(layer);

--- a/src/js/src/map-blocks/storymap-ordering.js
+++ b/src/js/src/map-blocks/storymap-ordering.js
@@ -48,20 +48,71 @@ export function reorderSlides( slides, currentSlideIndex, startIndex, endIndex )
 	};
 }
 
+export function getLayerId( layer ) {
+	const id = Number.parseInt( layer?.id, 10 );
+	return Number.isFinite( id ) && id > 0 ? id : null;
+}
+
+export function layerIdsMatch( leftLayer, rightLayer ) {
+	const leftLayerId = getLayerId( leftLayer );
+	return leftLayerId !== null && leftLayerId === getLayerId( rightLayer );
+}
+
+export function createLayerIdSet( layers = [] ) {
+	return new Set(
+		( layers ?? [] )
+			.map( getLayerId )
+			.filter( ( layerId ) => layerId !== null )
+	);
+}
+
+export function normalizeLayerReference( layer ) {
+	const layerId = getLayerId( layer );
+	if ( layerId === null || typeof layer !== 'object' || layer === null ) {
+		return null;
+	}
+
+	return {
+		...layer,
+		id: layerId,
+	};
+}
+
 export function sortSelectedLayersByMapOrder( selectedLayers = [], orderedLayers = [] ) {
 	const selectedById = new Map(
-		( selectedLayers ?? [] ).map( ( layer ) => [ layer.id, layer ] )
+		( selectedLayers ?? [] )
+			.map( ( layer ) => [ getLayerId( layer ), layer ] )
+			.filter( ( [ layerId ] ) => layerId !== null )
 	);
 	const orderedSelectedLayers = [];
 
 	( orderedLayers ?? [] ).forEach( ( layer ) => {
-		if ( selectedById.has( layer.id ) ) {
-			orderedSelectedLayers.push( selectedById.get( layer.id ) );
-			selectedById.delete( layer.id );
+		const layerId = getLayerId( layer );
+		if ( selectedById.has( layerId ) ) {
+			orderedSelectedLayers.push( selectedById.get( layerId ) );
+			selectedById.delete( layerId );
 		}
 	} );
 
 	return [ ...orderedSelectedLayers, ...selectedById.values() ];
+}
+
+export function reconcileSelectedLayersWithAvailableLayers(
+	selectedLayers = [],
+	mapLayers = [],
+	availableLayers = []
+) {
+	const mapLayerIds = createLayerIdSet( mapLayers );
+	const availableLayerIds = createLayerIdSet( availableLayers );
+	const normalizedSelectedLayers = ( selectedLayers ?? [] )
+		.map( normalizeLayerReference )
+		.filter( Boolean )
+		.filter(
+			( layer ) =>
+				mapLayerIds.has( layer.id ) && availableLayerIds.has( layer.id )
+		);
+
+	return sortSelectedLayersByMapOrder( normalizedSelectedLayers, mapLayers );
 }
 
 export function reorderStorymapLayers(

--- a/src/js/src/map-blocks/storymap-ordering.test.js
+++ b/src/js/src/map-blocks/storymap-ordering.test.js
@@ -1,5 +1,9 @@
 import {
+	createLayerIdSet,
+	getLayerId,
+	layerIdsMatch,
 	moveActiveIndex,
+	reconcileSelectedLayersWithAvailableLayers,
 	reorderList,
 	reorderSlides,
 	reorderStorymapLayers,
@@ -15,6 +19,16 @@ describe( 'storymap ordering helpers', () => {
 		expect( moveActiveIndex( 1, 0, 2 ) ).toBe( 0 );
 		expect( moveActiveIndex( 1, 2, 0 ) ).toBe( 2 );
 		expect( moveActiveIndex( 2, 2, 0 ) ).toBe( 0 );
+	} );
+
+	it( 'normalizes layer IDs from saved storymap data', () => {
+		expect( getLayerId( { id: '12' } ) ).toBe( 12 );
+		expect( getLayerId( { id: 12 } ) ).toBe( 12 );
+		expect( getLayerId( { id: 'missing' } ) ).toBeNull();
+		expect( layerIdsMatch( { id: '12' }, { id: 12 } ) ).toBe( true );
+		expect( createLayerIdSet( [ { id: '12' }, { id: 13 } ] ) ).toEqual(
+			new Set( [ 12, 13 ] )
+		);
 	} );
 
 	it( 'reorders slides and preserves the active slide identity', () => {
@@ -41,6 +55,35 @@ describe( 'storymap ordering helpers', () => {
 			{ id: 1, name: 'Layer 1' },
 			{ id: 2, name: 'Layer 2' },
 			{ id: 999, name: 'Detached' },
+		] );
+	} );
+
+	it( 'sorts selected layers when saved IDs are strings', () => {
+		expect(
+			sortSelectedLayersByMapOrder(
+				[ { id: '2', name: 'Layer 2' }, { id: '1', name: 'Layer 1' } ],
+				[ { id: 1 }, { id: 2 } ]
+			)
+		).toEqual( [
+			{ id: '1', name: 'Layer 1' },
+			{ id: '2', name: 'Layer 2' },
+		] );
+	} );
+
+	it( 'reconciles selected layers against available map-layer records', () => {
+		expect(
+			reconcileSelectedLayersWithAvailableLayers(
+				[
+					{ id: '2', name: 'Layer 2' },
+					{ id: '1', name: 'Layer 1' },
+					{ id: '999', name: 'Detached' },
+				],
+				[ { id: 1 }, { id: 2 }, { id: 3 } ],
+				[ { id: 1 }, { id: 2 } ]
+			)
+		).toEqual( [
+			{ id: 1, name: 'Layer 1' },
+			{ id: 2, name: 'Layer 2' },
 		] );
 	} );
 

--- a/src/js/src/shared/rest-records.js
+++ b/src/js/src/shared/rest-records.js
@@ -107,9 +107,17 @@ export const useRecordsByIds = ( {
 		[ normalizedIds, chunkSize ]
 	);
 	const queryKey = JSON.stringify( query );
+	const requestKey = JSON.stringify( {
+		enabled: Boolean( enabled && path && normalizedIds.length > 0 ),
+		path: path || '',
+		ids: normalizedIds,
+		query: queryKey,
+	} );
 	const [ records, setRecords ] = useState( [] );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ error, setError ] = useState( null );
+	const [ resolvedRequestKey, setResolvedRequestKey ] = useState( null );
+	const hasResolved = resolvedRequestKey === requestKey;
 
 	useEffect( () => {
 		let isCancelled = false;
@@ -118,6 +126,7 @@ export const useRecordsByIds = ( {
 			setRecords( [] );
 			setIsLoading( false );
 			setError( null );
+			setResolvedRequestKey( requestKey );
 			return undefined;
 		}
 
@@ -144,11 +153,13 @@ export const useRecordsByIds = ( {
 				setRecords(
 					mergeRecordsByIdOrder( normalizedIds, chunkedRecords.flat() )
 				);
+				setResolvedRequestKey( requestKey );
 			} )
 			.catch( ( nextError ) => {
 				if ( ! isCancelled ) {
 					setError( nextError );
 					setRecords( [] );
+					setResolvedRequestKey( requestKey );
 				}
 			} )
 			.finally( () => {
@@ -160,9 +171,9 @@ export const useRecordsByIds = ( {
 		return () => {
 			isCancelled = true;
 		};
-	}, [ enabled, idChunks, normalizedIds, path, queryKey ] );
+	}, [ enabled, idChunks, normalizedIds, path, queryKey, requestKey ] );
 
-	return { records, isLoading, error };
+	return { records, isLoading, error, hasResolved };
 };
 
 export const usePaginatedRecords = ( {


### PR DESCRIPTION
## Summary

This PR fixes a storymap editor regression where previously configured per-slide layer selections disappeared after upgrading to the current 3.0.0 release candidate.

Existing storymaps saved with JEO 2.14.1 still contained their `selectedLayers` data, and the selections would reappear after switching the plugin back to 2.14.1. The data was not actually gone initially; the 3.0.0 editor was failing to hydrate it safely and could then persist the empty selection state on save.

## Root cause

The storymap editor now hydrates map layers through the paginated `/jeo/v1/map-layer` REST helper instead of relying on an unbounded `getEntityRecords` request. That optimization made the editor initialize `loadedLayers` as an empty array while the layer request was still pending.

The existing reconciliation effect interpreted that initial empty array as a complete response, then filtered every slide's `selectedLayers` against it. Since no layer records were present yet, each slide was rewritten with `selectedLayers: []`.

There was a second compatibility risk: some older saved storymap payloads can carry layer IDs as strings while the newer map/layer records expose numeric IDs. Strict ID comparisons made those otherwise valid saved selections easier to drop during reconciliation and rendering.

## What changed

- Added a `hasResolved` signal to `useRecordsByIds()` so consumers can distinguish "request has not completed yet" from "request completed with no records".
- Updated the storymap editor to wait until the map-layer hydration request resolves before reconciling slide layer selections.
- Added a guard so a map that has configured layer IDs does not clear all slide selections merely because the layer hydration result is unexpectedly empty.
- Centralized storymap layer ID handling in tested helpers:
  - normalize layer IDs to positive integers
  - compare saved layer references across string/number ID formats
  - reconcile selected layers against both the parent map layers and hydrated map-layer records
- Updated the storymap editor's preview and layer toggle checks to use normalized ID matching.
- Updated the PHP storymap render callback to tolerate string IDs in saved storymap JSON while preserving the existing behavior of removing deleted, private, trashed, or detached layers.

## Decisions

- I kept reconciliation in place because it still protects users from stale references to deleted or removed layers. The fix is to run it only after layer data is actually available, not to remove the cleanup behavior.
- I normalized IDs at the helper/render boundary instead of changing the persisted storymap schema. This keeps backward compatibility for existing storymaps and avoids forcing a migration before users can safely reopen and save them.
- I did not include generated `src/js/build` assets in the commit because that directory is ignored in this repository. I did run the build locally to verify the editor bundle still compiles.
- I intentionally left the unrelated local `src/includes/storymap/class-storymap.php` change out of this PR so this branch only covers the storymap layer-selection regression.

## Validation

Automated checks run on the isolated PR worktree:

- `npm run test:unit` — passed, 14 suites / 46 tests
- `npm run build:assets` — passed, webpack compiled successfully and the compliance patch script completed
- `php -l src/includes/class-jeo.php` — passed
- `git diff --check` — passed

Focused regression coverage added:

- saved layer IDs represented as strings are normalized and matched against numeric map-layer IDs
- selected layers are sorted in parent map order without dropping valid legacy IDs
- reconciliation removes only layers that are absent from the parent map or the hydrated layer records

Local manual-test preparation:

- Applied the same fix directly to the JEO plugin installed at `infoamazonia.local`
- Copied the compiled `js/build` output into that local plugin installation
- Flushed the local WordPress cache with WP-CLI using a higher memory limit

Expected behavior after this fix: opening an existing storymap in the 3.0.0 editor should preserve the layers configured inside each slide instead of showing every slide as if no layers were selected.
