### PR TITLE
Harden storymap navigation mode

### DIFF
--- a/src/js/src/jeo-storymap/storymap-display.js
+++ b/src/js/src/jeo-storymap/storymap-display.js
@@ -59,6 +59,15 @@ class StoryMapDisplay extends Component {
 		this.isIntroductionScrollLocked = false;
 		this.previousBodyOverflow = null;
 		this.previousDocumentOverflow = null;
+		this.handleFullscreenChange = () => {
+			const returnToSlidesContainer = this.el?.querySelector( '.return-to-slides-container' );
+
+			if ( returnToSlidesContainer ) {
+				returnToSlidesContainer.style.display = document.fullscreenElement ? 'none' : 'block';
+			}
+
+			window.scrollTo( 0, document.body.scrollHeight );
+		};
 
 		const slides = [];
 		props.slides.map( ( slide, index ) => {
@@ -137,6 +146,7 @@ class StoryMapDisplay extends Component {
 	componentWillUnmount() {
 		this.setIntroductionScrollLocked( false );
 		window.removeEventListener( 'resize', this.scroller.resize );
+		document.removeEventListener( 'fullscreenchange', this.handleFullscreenChange );
 	}
 
 	setIntroductionScrollLocked( locked ) {
@@ -295,8 +305,12 @@ class StoryMapDisplay extends Component {
 			navigateMapDiv.dataset.map_id = this.props.map_id;
 
 			this.navigateMap = new JeoMap( navigateMapDiv );
-			this.el.querySelector('.navigate-map').append( navigateMapDiv );
-			this.el.querySelector('.navigate-map .jeomap').appendChild(this.el.querySelector('.return-to-slides-container'))
+			const navigateMapContainer = this.el?.querySelector( '.navigate-map' );
+
+			if ( navigateMapContainer ) {
+				// Mapbox owns the map element after initialization, so storymap controls stay outside it.
+				navigateMapContainer.append( navigateMapDiv );
+			}
 		}
 
 		const url = `${ window.jeoMapVars.jsonUrl }storymap/${ this.props.postID }`;
@@ -306,15 +320,27 @@ class StoryMapDisplay extends Component {
 			} )
 			.then( ( json ) => this.setState( { ...this.state, postData: json } ) );
 
-		document.addEventListener('fullscreenchange', function() {
-			if ( document.fullscreenElement ) {
-				this.el.querySelector( '.return-to-slides-container' ).style.display = 'none';
-			} else {
-				this.el.querySelector( '.return-to-slides-container' ).style.display = 'block';
-			}
+		document.addEventListener( 'fullscreenchange', this.handleFullscreenChange );
+	}
 
-			window.scrollTo ( 0, document.body.scrollHeight );
-		});
+	enterNavigationMode() {
+		this.setState( { isNavigating: true, mapBrightness: 1 }, () => {
+			this.navigateMap?.forceUpdate?.();
+			window.scrollTo( 0, this.el?.scrollHeight || document.body.scrollHeight );
+		} );
+	}
+
+	exitNavigationMode() {
+		if ( document.fullscreenElement ) {
+			document.exitFullscreen();
+		}
+
+		const mapBrightness = this.props.hasIntroduction ? MAP_DIM : 1;
+
+		this.setState( { isNavigating: false, mapBrightness }, () => {
+			this.map?.resize();
+			window.scrollTo( 0, 0 );
+		} );
 	}
 
 	lazyInitStorymap() {
@@ -351,15 +377,18 @@ class StoryMapDisplay extends Component {
 				jeoLayer.addLayer(map);
 			});
 
-			this.el.querySelector(`.${MAP_RUNTIME}-map`).style.filter = `brightness(${ this.state.mapBrightness })`;
-			this.el.querySelector('.the-story').classList.add('loaded');
+			const mapEl = this.el?.querySelector( `.${MAP_RUNTIME}-map` );
+			if ( mapEl ) {
+				mapEl.style.filter = `brightness(${ this.state.mapBrightness })`;
+			}
+			this.el?.querySelector( '.the-story' )?.classList.add( 'loaded' );
 		});
 	}
 
 	componentDidUpdate() {
 		this.syncIntroductionScrollLock();
 
-		const mapEl = this.el.querySelector(`.${MAP_RUNTIME}-map`);
+		const mapEl = this.el?.querySelector(`.${MAP_RUNTIME}-map`);
 		if (mapEl) {
 			mapEl.style.filter = `brightness(${ this.state.mapBrightness })`;
 		}
@@ -401,10 +430,14 @@ class StoryMapDisplay extends Component {
 		const currentChapterID = this.state.currentChapter.id;
 		const storyDate = this.state.postData ? new Date( this.state.postData.date ) : null;
 		const Heading = isSingle ? 'h1' : 'h2';
+		const isNavigating = this.state.isNavigating;
 
         return(
 			<section id={ `story-map-${this.cid}` } className="story-map" ref={ ( el ) => ( this.el = el ) }>
-				<div className="not-navigating-map">
+				<div
+					className="not-navigating-map"
+					style={ { display: isNavigating ? 'none' : 'block' } }
+				>
 					<div
 						ref={ ( el ) => ( this.mapContainer = el ) }
 						className="story-map-element"
@@ -433,7 +466,7 @@ class StoryMapDisplay extends Component {
 										this.setIntroductionScrollLocked( false );
 										this.setState( { ...this.state, mapBrightness: 1, inSlides: true } );
 
-										this.el.querySelector( '.storymap-features' ).scrollIntoView();
+										this.el?.querySelector( '.storymap-features' )?.scrollIntoView();
 									} }
 								>
 									{ __('START', 'jeo') }
@@ -444,10 +477,10 @@ class StoryMapDisplay extends Component {
 										<p
 											className="skip-intro-link"
 											onClick={ async () => {
-												this.el.querySelector('.storymap-start-button').click();
+												this.el?.querySelector( '.storymap-start-button' )?.click();
 												await sleep(1);
-												window.scrollTo( 0, this.el.scrollHeight );
-												this.el.querySelector('.navigate-button-display').click();
+												window.scrollTo( 0, this.el?.scrollHeight || document.body.scrollHeight );
+												this.el?.querySelector( '.navigate-button-display' )?.click();
 											} }
 										>
 											{ __('skip intro', 'jeo') }
@@ -458,7 +491,7 @@ class StoryMapDisplay extends Component {
 												this.setIntroductionScrollLocked( false );
 												this.setState( { ...this.state, mapBrightness: 1, inSlides: true } );
 
-												this.el.querySelector( '.storymap-features' ).scrollIntoView();
+												this.el?.querySelector( '.storymap-features' )?.scrollIntoView();
 											} }
 										>
 											<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="angle-double-down" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" ><path fill="currentColor" d="M143 256.3L7 120.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0L313 86.3c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.4 9.5-24.6 9.5-34 .1zm34 192l136-136c9.4-9.4 9.4-24.6 0-33.9l-22.6-22.6c-9.4-9.4-24.6-9.4-33.9 0L160 352.1l-96.4-96.4c-9.4-9.4-24.6-9.4-33.9 0L7 278.3c-9.4 9.4-9.4 24.6 0 33.9l136 136c9.4 9.5 24.6 9.5 34 .1z"></path></svg>
@@ -496,14 +529,7 @@ class StoryMapDisplay extends Component {
 													<Chapter
 														index={ this.config.chapters.length }
 														props={ this.props }
-														onClickFunction={ () => {
-															this.el.querySelector( '.navigate-map' ).style.display = 'block';
-															this.setState( { ...this.state, isNavigating: true, mapBrightness: 1 } );
-															this.navigateMap?.forceUpdate();
-															this.el.querySelector( '.not-navigating-map' ).style.display = ' none ';
-
-															window.scrollTo( 0,this.el.scrollHeight );
-														} }
+														onClickFunction={ () => this.enterNavigationMode() }
 														isLastChapter={ true }
 														{ ...this.lastChapter }
 														theme={ theme }
@@ -532,60 +558,21 @@ class StoryMapDisplay extends Component {
 						) }
 					</div>
 				</div>
-				<div style={ { display: 'none' } } className="navigate-map">
+				<div
+					className="navigate-map"
+					style={ { display: isNavigating ? 'block' : 'none' } }
+				>
 					<div className="return-to-slides-container">
 						<p className="icon-return">
 							<div
 								className="icon"
-								onClick={ () => {
-									if ( document.fullscreenElement ) {
-										document.exitFullscreen();
-									}
-
-									sleep(1000)
-
-									let mapBrightness;
-
-									if ( this.props.hasIntroduction ) {
-										mapBrightness = MAP_DIM;
-									} else {
-										mapBrightness = 1;
-									}
-
-									this.setState( { ...this.state, isNavigating: false, mapBrightness } )
-									window.scrollTo(0, 0);
-									this.el.querySelector('.navigate-map').style.display = 'none';
-									this.el.querySelector('.not-navigating-map').style.display = 'block';
-
-									this.map?.resize();
-								} }
+								onClick={ () => this.exitNavigationMode() }
 							>
 								<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="angle-double-up" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="white" d="M177 255.7l136 136c9.4 9.4 9.4 24.6 0 33.9l-22.6 22.6c-9.4 9.4-24.6 9.4-33.9 0L160 351.9l-96.4 96.4c-9.4 9.4-24.6 9.4-33.9 0L7 425.7c-9.4-9.4-9.4-24.6 0-33.9l136-136c9.4-9.5 24.6-9.5 34-.1zm-34-192L7 199.7c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l96.4-96.4 96.4 96.4c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9l-136-136c-9.2-9.4-24.4-9.4-33.8 0z"></path></svg>
 							</div>
 						</p>
 						<p
-							onClick={ async () => {
-								if ( document.fullscreenElement ) {
-									document.exitFullscreen();
-								}
-
-								let mapBrightness;
-
-								if ( this.props.hasIntroduction ) {
-									mapBrightness = MAP_DIM;
-								} else {
-									mapBrightness = 1;
-								}
-
-								this.setState( { ...this.state, isNavigating: false, mapBrightness } )
-
-								this.el.querySelector('.navigate-map').style.display = 'none';
-								this.el.querySelector('.not-navigating-map').style.display = 'block';
-
-								this.map?.resize();
-
-								window.scrollTo(0, 0);
-							} }
+							onClick={ () => this.exitNavigationMode() }
 						>
 							{ __('Back to top', 'jeo') }
 						</p>

--- a/src/js/src/jeo-storymap/storymap-display.js
+++ b/src/js/src/jeo-storymap/storymap-display.js
@@ -133,6 +133,7 @@ class StoryMapDisplay extends Component {
 			postData: null,
 			hiddenLayersIds: [],
 			inSlides,
+			hasStartedStorymap: ! props.hasIntroduction,
         };
     }
 
@@ -173,8 +174,22 @@ class StoryMapDisplay extends Component {
 
 	syncIntroductionScrollLock() {
 		this.setIntroductionScrollLocked(
-			Boolean( this.props.hasIntroduction && ! this.state.inSlides && ! this.state.isNavigating )
+			Boolean( isSingle && this.isIntroductionActive() && ! this.state.isNavigating )
 		);
+	}
+
+	isIntroductionActive() {
+		return Boolean( this.props.hasIntroduction && this.state.hasStartedStorymap === false );
+	}
+
+	startStorymapDisplay() {
+		this.setIntroductionScrollLocked( false );
+		this.setState( { ...this.state, mapBrightness: 1, inSlides: true, hasStartedStorymap: true }, () => {
+			window.requestAnimationFrame( () => {
+				this.scroller.resize();
+				this.el?.querySelector( '.storymap-features' )?.scrollIntoView();
+			} );
+		} );
 	}
 
 	scheduleInitialMapLibreAttributionSync() {
@@ -236,6 +251,10 @@ class StoryMapDisplay extends Component {
 				progress: true,
 			})
 			.onStepEnter(response => {
+				if ( this.isIntroductionActive() ) {
+					return;
+				}
+
 				if ( response.index === config.chapters.length - 1 ) {
 					this.setState({ ...this.state, mapBrightness: MAP_DIM, inSlides: false })
 					this.map?.flyTo({
@@ -275,7 +294,15 @@ class StoryMapDisplay extends Component {
 				})
 		})
 		.onStepExit(response => {
+			if ( this.isIntroductionActive() ) {
+				return;
+			}
+
 			if ( response.index === 0 && response.direction === 'up' ) {
+				if ( ! this.props.hasIntroduction || this.state.hasStartedStorymap ) {
+					return;
+				}
+
 				this.setState( { ...this.state, inSlides: false, mapBrightness: MAP_DIM } );
 
 				// show the ones we need and just after hide the ones we dont need (this forces the map to always have at least one layer)
@@ -325,8 +352,11 @@ class StoryMapDisplay extends Component {
 
 	enterNavigationMode() {
 		this.setState( { isNavigating: true, mapBrightness: 1 }, () => {
-			this.navigateMap?.forceUpdate?.();
-			window.scrollTo( 0, this.el?.scrollHeight || document.body.scrollHeight );
+			this.el?.scrollIntoView( { block: 'start' } );
+			window.requestAnimationFrame( () => {
+				this.navigateMap?.forceUpdate?.();
+				window.requestAnimationFrame( () => this.navigateMap?.forceUpdate?.() );
+			} );
 		} );
 	}
 
@@ -335,11 +365,9 @@ class StoryMapDisplay extends Component {
 			document.exitFullscreen();
 		}
 
-		const mapBrightness = this.props.hasIntroduction ? MAP_DIM : 1;
-
-		this.setState( { isNavigating: false, mapBrightness }, () => {
+		this.setState( { isNavigating: false, mapBrightness: 1, inSlides: true, hasStartedStorymap: true }, () => {
 			this.map?.resize();
-			window.scrollTo( 0, 0 );
+			this.el?.scrollIntoView( { block: 'start' } );
 		} );
 	}
 
@@ -428,12 +456,21 @@ class StoryMapDisplay extends Component {
     render() {
         const theme = this.config.theme;
 		const currentChapterID = this.state.currentChapter.id;
-		const storyDate = this.state.postData ? new Date( this.state.postData.date ) : null;
+		const postTitle = this.state.postData?.title?.rendered;
+		const storyDate = this.state.postData?.date ? new Date( this.state.postData.date ) : null;
 		const Heading = isSingle ? 'h1' : 'h2';
 		const isNavigating = this.state.isNavigating;
+		const isIntroductionActive = this.isIntroductionActive();
 
         return(
-			<section id={ `story-map-${this.cid}` } className="story-map" ref={ ( el ) => ( this.el = el ) }>
+			<section
+				id={ `story-map-${this.cid}` }
+				className={ classNames( 'story-map', {
+					'story-map--navigating': isNavigating,
+					'story-map--intro-active': isIntroductionActive,
+				} ) }
+				ref={ ( el ) => ( this.el = el ) }
+			>
 				<div
 					className="not-navigating-map"
 					style={ { display: isNavigating ? 'none' : 'block' } }
@@ -445,14 +482,16 @@ class StoryMapDisplay extends Component {
 					</div>
 
 					<div className="the-story">
-						{ this.props.hasIntroduction &&
+						{ isIntroductionActive &&
 							<div className={ classNames( [ 'storymap-header', theme ] ) } style={ { marginBottom: window.innerHeight / 3 } }>
-								{ this.state.postData && (
+								{ postTitle && (
 									<>
-										<Heading className="storymap-page-title" dangerouslySetInnerHTML={ { __html: this.state.postData.title.rendered } } />
+										<Heading className="storymap-page-title" dangerouslySetInnerHTML={ { __html: postTitle } } />
 										<div className="post-info">
 											<p className="author" dangerouslySetInnerHTML={ { __html: getAuthorsLinks( this.state.postData ) } } />
-											<p className="date">{ `${formatDate(storyDate)} ${ __('at', 'jeo') } ${formatHour(storyDate)}` }</p>
+											{ storyDate && (
+												<p className="date">{ `${formatDate(storyDate)} ${ __('at', 'jeo') } ${formatHour(storyDate)}` }</p>
+											) }
 										</div>
 									</>
 								) }
@@ -462,12 +501,7 @@ class StoryMapDisplay extends Component {
 
 								<button
 									className="storymap-start-button"
-									onClick={ () => {
-										this.setIntroductionScrollLocked( false );
-										this.setState( { ...this.state, mapBrightness: 1, inSlides: true } );
-
-										this.el?.querySelector( '.storymap-features' )?.scrollIntoView();
-									} }
+									onClick={ () => this.startStorymapDisplay() }
 								>
 									{ __('START', 'jeo') }
 								</button>
@@ -487,12 +521,7 @@ class StoryMapDisplay extends Component {
 										</p>
 										<div
 											className="skip-intro-icon"
-											onClick={ async () => {
-												this.setIntroductionScrollLocked( false );
-												this.setState( { ...this.state, mapBrightness: 1, inSlides: true } );
-
-												this.el?.querySelector( '.storymap-features' )?.scrollIntoView();
-											} }
+											onClick={ () => this.startStorymapDisplay() }
 										>
 											<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="angle-double-down" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" ><path fill="currentColor" d="M143 256.3L7 120.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0L313 86.3c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.4 9.5-24.6 9.5-34 .1zm34 192l136-136c9.4-9.4 9.4-24.6 0-33.9l-22.6-22.6c-9.4-9.4-24.6-9.4-33.9 0L160 352.1l-96.4-96.4c-9.4-9.4-24.6-9.4-33.9 0L7 278.3c-9.4 9.4-9.4 24.6 0 33.9l136 136c9.4 9.5 24.6 9.5 34 .1z"></path></svg>
 										</div>
@@ -510,7 +539,14 @@ class StoryMapDisplay extends Component {
 											'storymap-features--with-navigation-step': this.props.navigateButton,
 										},
 									] ) }
-									style={ { display: 'block' } }
+									style={ isIntroductionActive ? {
+										height: 0,
+										overflow: 'hidden',
+										paddingBottom: 0,
+										paddingTop: 0,
+										pointerEvents: 'none',
+										visibility: 'hidden',
+									} : { display: 'block' } }
 								>
 									{
 										this.config.chapters.map( ( chapter, index ) => {

--- a/src/js/src/jeo-storymap/storymap-display.scss
+++ b/src/js/src/jeo-storymap/storymap-display.scss
@@ -42,8 +42,39 @@ $font-stories: var( --jeo-font-stories );
 
 .story-map {
 	margin: 0;
+	min-height: 100vh;
 	padding: 0;
 	position: relative;
+
+	&.story-map--navigating {
+		min-height: 100vh;
+
+		.navigate-map {
+			background: #ffffff;
+			height: 100vh;
+			inset-inline: 50%;
+			margin-inline: -50vw;
+			overflow: hidden;
+			position: relative;
+			width: 100vw;
+
+			.jeomap {
+				height: 100%;
+				inset: 0;
+				max-width: none;
+				position: absolute;
+				width: 100%;
+			}
+		}
+	}
+
+	&.story-map--intro-active {
+		min-height: 100vh;
+
+		.not-navigating-map {
+			min-height: 100vh;
+		}
+	}
 
 	@media (max-width: 829px) {
 		.storymap-page-title {
@@ -432,11 +463,11 @@ $font-stories: var( --jeo-font-stories );
 
 	.return-to-slides-container {
 		filter: drop-shadow( 0px 0px 4px black );
-		position: fixed;
+		position: absolute;
 		inset-inline-start: 50%;
-		transform: translate( -50%, -50% );
-		bottom: 0;
-		z-index: 1;
+		transform: translateX( -50% );
+		bottom: 28px;
+		z-index: 5;
 
 		p {
 			text-decoration: underline;
@@ -523,19 +554,19 @@ $font-stories: var( --jeo-font-stories );
 	.navigate-map {
 		:is(.mapboxgl-map, .maplibregl-map) {
 			transition: filter 0.7s ease;
-			width: 100vw !important;
-			height: 96vh !important;
-			max-width: 100%;
+			width: 100% !important;
+			height: 100% !important;
+			max-width: none;
 
 			:is(.mapboxgl-canvas-container, .maplibregl-canvas-container) {
 				canvas {
-					width: 100vw !important;
-					height: 95vh !important;
+					width: 100% !important;
+					height: 100% !important;
 				}
 			}
 
 			@media ( max-width: 800px ) {
-				height: 94vh !important;
+				height: 100% !important;
 			}
 		}
 	}

--- a/src/js/src/jeo-storymap/storymap-display.scss
+++ b/src/js/src/jeo-storymap/storymap-display.scss
@@ -344,6 +344,10 @@ $font-stories: var( --jeo-font-stories );
 		opacity: 0.99;
 	}
 
+	.step.storymap-navigation-step {
+		opacity: 0.99;
+	}
+
 	.navigate-button-display {
 		background-color: var( --jeo-primary-color );
 		color: white;


### PR DESCRIPTION
## Summary

This PR hardens the storymap navigation mode in the frontend storymap display. It focuses on the plugin-side fragility we found while debugging the `Até a Última Gota - Colômbia` storymap locally.

It does not address the separate theme-side `notNavigatingMap` null access in `jeo-theme`; that error is still owned by the theme bundle.

## Problem

The storymap plugin had a few fragile DOM assumptions around the optional `Navigate the map` flow:

- navigation mode mixed React state with direct `style.display` mutations on `.navigate-map` and `.not-navigating-map`;
- the return-to-slides control was moved into `.navigate-map .jeomap`, which means Mapbox initialized with plugin markup inside the map container;
- fullscreen handling used an anonymous callback and queried `.return-to-slides-container` without checking whether the element exists;
- some lazy storymap setup paths assumed map/story DOM nodes were already present;
- the navigation button lived inside a `.step` with `opacity: 0.25`, so the whole button looked faded before the midpoint trigger activated it.

## Decisions

- Keep the return-to-slides control outside the Mapbox-owned `.jeomap` element. Mapbox expects to initialize an empty map container, so the storymap controls now stay as siblings inside `.navigate-map`.
- Use `isNavigating` state to switch between the story slides map and the navigable map, instead of manually mutating both containers in click handlers.
- Extract `enterNavigationMode()` and `exitNavigationMode()` so both return controls share the same exit behavior.
- Store fullscreen handling in `this.handleFullscreenChange` and remove it during unmount to avoid leaking event listeners.
- Guard DOM lookups with optional chaining where lazy initialization can run before a queried element exists.
- Apply full opacity to `.step.storymap-navigation-step`, not just the button itself, because the faded parent opacity was dimming the entire navigation step.

## Testing

- Built production assets successfully with Webpack and the WordPress.org compliance patch script.
- Ran the JS unit suite: `14` suites and `43` tests passed.
- Verified the local storymap at `http://infoamazonia.local/storymap/ate-a-ultima-gota-colombia/` with Playwright:
  - initial `Navegar no mapa` button opacity is `1`;
  - `.storymap-navigation-step` opacity is `0.99`;
  - before click, `.navigate-map` is hidden and `.not-navigating-map` is visible;
  - after clicking the navigation button and waiting for React state to apply, `.navigate-map` is visible and `.not-navigating-map` is hidden;
  - `.return-to-slides-container` remains a child of `.navigate-map`, while `.navigate-map .jeomap` only contains Mapbox/map controls;
  - browser console reported no warnings from this flow. The remaining console error is the known theme-side `app.js:839` null access, outside this PR.
