### PR TITLE
Fix Discovery cluster hover outside stories tab

### DIFF
--- a/src/js/src/discovery/blocks/stories.js
+++ b/src/js/src/discovery/blocks/stories.js
@@ -359,9 +359,8 @@ class Stories extends Component {
 			} );
 		}
 
-
 		map.on('mousemove', 'unclustered-points', (e) => {
-			if (e.features.length > 0 && map.selectedTab.name === "stories") {
+			if ( e.features.length > 0 && this.isStoriesTabActive() ) {
 				const hoveredFeature = e.features[0];
 				this.replaceHoveredFeatureState( getHoveredFeatureIds( hoveredFeature ) );
 				this.setState( {
@@ -371,7 +370,7 @@ class Stories extends Component {
 		});
 
 		map.on('mouseleave', 'unclustered-points', () => {
-			if(map.selectedTab.name === "stories"){
+			if ( this.isStoriesTabActive() ) {
 				this.clearHoveredFeatureState();
 				this.setState( {
 					hoveredPostId: null,
@@ -380,7 +379,15 @@ class Stories extends Component {
 		});
 
 		const handleClusterMouseMove = ( event ) => {
+			if ( ! this.isStoriesTabActive() ) {
+				return;
+			}
+
 			getClusterHoverData( map, event ).then( ( { clusterId, postsIds } ) => {
+				if ( ! this.isStoriesTabActive() ) {
+					return;
+				}
+
 				this.replaceHoveredClusterState( clusterId );
 				this.setState( {
 					hoveredClusterPostsId: postsIds,
@@ -406,7 +413,15 @@ class Stories extends Component {
 		this.clearHoveredClusterState();
 	}
 
+	isStoriesTabActive() {
+		return this.props.map?.selectedTab?.name === 'stories';
+	}
+
 	componentDidUpdate( prevProps, prevState ) {
+		if ( ! this.isStoriesTabActive() ) {
+			return;
+		}
+
 		if ( prevState.hoveredPostId !== this.state.hoveredPostId ) {
 			this.scrollStoryIntoView( this.state.hoveredPostId );
 			return;
@@ -602,7 +617,7 @@ class Stories extends Component {
 	}
 
 	scrollStoryIntoView( storyId ) {
-		if ( ! storyId ) {
+		if ( ! storyId || ! this.isStoriesTabActive() ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

This PR fixes a Discovery sidebar jump that happens when hovering story clusters while the left sidebar is on the "Map layers" tab.

The bug only affected clustered story markers. Single story pins already checked that the active Discovery tab was `stories` before updating hover state, so hovering a single pin from the "Map layers" tab did not move the sidebar. Cluster hover did not have the same tab guard.

## Root Cause

Discovery keeps both tab panels mounted and toggles visibility between the "Stories" and "Map layers" views. The `Stories` component still owns the story marker hover handlers even when its cards are hidden behind the "Map layers" tab.

For unclustered points, the hover path already required `map.selectedTab.name === "stories"` before setting `hoveredPostId`.

For clusters, `handleClusterMouseMove` always called `getClusterHoverData()` and then updated `hoveredClusterPostsId`. That state change triggered `componentDidUpdate()`, which called `scrollStoryIntoView()` for the first story represented by the cluster. Because the scroll container is the shared `.togable-panel`, the visible "Map layers" list scrolled even though there were no visible story cards in that tab.

## What Changed

- Added `isStoriesTabActive()` as the single tab-state helper for story hover behavior.
- Reused that helper for the existing unclustered point hover checks, keeping the previous behavior but avoiding direct `map.selectedTab.name` reads.
- Added a cluster hover guard before `getClusterHoverData()` so cluster hover does not update story state while the "Map layers" tab is active.
- Added a second guard inside the async cluster hover callback so a tab switch while cluster leaves are being resolved cannot apply stale story hover state.
- Added defensive guards in `componentDidUpdate()` and `scrollStoryIntoView()` so hidden story-list state changes cannot scroll the shared tab panel outside the "Stories" tab.
- Kept cluster mouseleave clearing hover state, which lets stale cluster highlight state be cleaned up without allowing sidebar scrolling outside the Stories tab.

## Manual Validation

Validated first on `infoamazonia.local` by temporarily patching the served Discovery build before moving the fix into the repository.

Test setup:

- Opened `http://infoamazonia.local/discovery/`.
- Searched for `Brasília` to load visible geolocated stories and a cluster containing 4 story pins.
- Used the same cluster in both tabs for comparison.

Before the fix:

- On "Stories", hovering the cluster highlighted the matching story cards and scrolled the story list as expected.
- On "Map layers", hovering the same cluster still marked hidden story cards active and changed the shared `.togable-panel` scroll position. In the reproduced case, the panel jumped from `193.5` to `0`, which made the map-layer list move even though no story card was visible.
- Hovering a single unclustered pin from "Map layers" did not cause the jump, confirming the issue was specific to the cluster hover path.

After the temporary local patch:

- On "Map layers", hovering the same 4-pin cluster left the sidebar stable. The panel stayed at `scrollTop: 520` and no hidden `.stories .card.active` entries were created.
- On "Stories", hovering the cluster still highlighted the related cards. The intended cluster hover behavior was preserved for the tab where stories are visible.

## Automated Checks

- `npm run build:assets`
- `npm run test:unit -- --runTestsByPath src/js/src/discovery/blocks/stories.test.js`
