### PR TITLE
Fix storymap display state in post contexts

### DIFF
--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -718,13 +718,49 @@ class Jeo {
 	 */
 	public function embedded_story_map_dynamic_render_callback( $block_attributes, $content ) {
 		$content = json_decode( $this->extract_json_from_block_content( $content ) );
+		if ( ! is_object( $content ) || empty( $content->attributes->storyID ) ) {
+			return '';
+		}
 
-		$story_id                       = $content->attributes->storyID;
-		$story                          = get_post( $story_id );
-		$story_block                    = parse_blocks( $story->post_content )[0];
+		$story_id = absint( $content->attributes->storyID );
+		$story    = get_post( $story_id );
+		if ( ! $story instanceof WP_Post ) {
+			return '';
+		}
+
+		$story_blocks = parse_blocks( $story->post_content );
+		$story_block  = $story_blocks[0] ?? null;
+		if ( ! is_array( $story_block ) || empty( $story_block['attrs'] ) ) {
+			return '';
+		}
+
 		$story_block['attrs']['postID'] = $story_id;
 
 		return $this->story_map_dynamic_render_callback( $block_attributes, wp_json_encode( $story_block['attrs'] ) );
+	}
+
+	/**
+	 * Add REST endpoint information for the post shown in the story map header.
+	 *
+	 * @param object $saved_data Story map saved data.
+	 * @param int    $post_id    Post ID to expose.
+	 * @return void
+	 */
+	private function set_story_map_post_rest_data( $saved_data, int $post_id ) {
+		if ( ! $post_id ) {
+			return;
+		}
+
+		$post_type = get_post_type( $post_id );
+		if ( ! $post_type ) {
+			return;
+		}
+
+		$post_type_object = get_post_type_object( $post_type );
+		$rest_base        = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type;
+
+		$saved_data->postID       = $post_id;
+		$saved_data->postRestBase = $rest_base;
 	}
 
 	/**
@@ -752,15 +788,30 @@ class Jeo {
 	 * @return bool
 	 */
 	private function layer_still_exists( array $map_layers, $selected_layer ) {
-		$layer_status = get_post_status( $selected_layer->id );
+		if ( ! is_object( $selected_layer ) || ! isset( $selected_layer->id ) ) {
+			return false;
+		}
+
+		$selected_layer_id = absint( $selected_layer->id );
+		if ( ! $selected_layer_id ) {
+			return false;
+		}
+
+		$layer_status = get_post_status( $selected_layer_id );
 		if ( 'trash' === $layer_status || false === $layer_status || 'private' === $layer_status ) {
 			return false;
 		}
 
 		foreach ( $map_layers as $layer ) {
-			if ( $layer['id'] === $selected_layer->id ) {
-				$selected_layer->meta->type               = get_post_meta( $layer['id'], 'type', true );
-				$selected_layer->meta->layer_type_options = (object) get_post_meta( $layer['id'], 'layer_type_options', true );
+			$map_layer_id = absint( $layer['id'] ?? 0 );
+			if ( $map_layer_id === $selected_layer_id ) {
+				if ( ! isset( $selected_layer->meta ) || ! is_object( $selected_layer->meta ) ) {
+					$selected_layer->meta = new \stdClass();
+				}
+
+				$selected_layer->id                       = $selected_layer_id;
+				$selected_layer->meta->type               = get_post_meta( $selected_layer_id, 'type', true );
+				$selected_layer->meta->layer_type_options = (object) get_post_meta( $selected_layer_id, 'layer_type_options', true );
 				return true;
 			}
 		}
@@ -799,11 +850,16 @@ class Jeo {
 	 * @param string $content Saved block content.
 	 * @return string
 	 */
-	public function story_map_dynamic_render_callback( $block_attributes, $content ) {
+	public function story_map_dynamic_render_callback( $block_attributes, $content, $block = null ) {
+		unset( $block );
+
 		$saved_data = json_decode( $this->extract_json_from_block_content( $content ) );
 		if ( ! is_object( $saved_data ) ) {
 			return '';
 		}
+
+		$post_id = absint( $saved_data->postID ?? get_the_ID() );
+		$this->set_story_map_post_rest_data( $saved_data, $post_id );
 
 		$map_id     = isset( $saved_data->map_id ) ? (int) $saved_data->map_id : 0;
 		$map_layers = get_post_meta( $map_id, 'layers', true );
@@ -830,7 +886,7 @@ class Jeo {
 
 			foreach ( $map_layers as $layer ) {
 				foreach ( $selected_layers as $selected_layer ) {
-					if ( $selected_layer->id === $layer['id'] ) {
+					if ( absint( $selected_layer->id ?? 0 ) === absint( $layer['id'] ?? 0 ) ) {
 						$selected_layers_order[] = $selected_layer;
 					}
 				}
@@ -846,7 +902,7 @@ class Jeo {
 
 		foreach ( $map_layers as $layer ) {
 			foreach ( $navigate_map_layers as $index => $navigate_layer ) {
-				if ( $navigate_layer->id === $layer['id'] ) {
+				if ( absint( $navigate_layer->id ?? 0 ) === absint( $layer['id'] ?? 0 ) ) {
 					// Update the saved metadata and layer types.
 					if ( ! $this->layer_still_exists( $map_layers, $navigate_layer ) ) {
 						array_splice( $navigate_map_layers, $index, 1 );

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -759,8 +759,8 @@ class Jeo {
 		$post_type_object = get_post_type_object( $post_type );
 		$rest_base        = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type;
 
-		$saved_data->postID       = $post_id;
-		$saved_data->postRestBase = $rest_base;
+		$saved_data->{'postID'}       = $post_id;
+		$saved_data->{'postRestBase'} = $rest_base;
 	}
 
 	/**
@@ -848,6 +848,7 @@ class Jeo {
 	 *
 	 * @param array  $block_attributes Block attributes.
 	 * @param string $content Saved block content.
+	 * @param object $block Block instance.
 	 * @return string
 	 */
 	public function story_map_dynamic_render_callback( $block_attributes, $content, $block = null ) {
@@ -858,7 +859,7 @@ class Jeo {
 			return '';
 		}
 
-		$post_id = absint( $saved_data->postID ?? get_the_ID() );
+		$post_id = absint( $saved_data->{'postID'} ?? get_the_ID() );
 		$this->set_story_map_post_rest_data( $saved_data, $post_id );
 
 		$map_id     = isset( $saved_data->map_id ) ? (int) $saved_data->map_id : 0;

--- a/src/js/src/jeo-storymap/storymap-display.js
+++ b/src/js/src/jeo-storymap/storymap-display.js
@@ -66,7 +66,7 @@ class StoryMapDisplay extends Component {
 				returnToSlidesContainer.style.display = document.fullscreenElement ? 'none' : 'block';
 			}
 
-			window.scrollTo ( 0, document.body.scrollHeight );
+			window.scrollTo( 0, document.body.scrollHeight );
 		};
 
 		const slides = [];
@@ -174,8 +174,12 @@ class StoryMapDisplay extends Component {
 
 	syncIntroductionScrollLock() {
 		this.setIntroductionScrollLocked(
-			Boolean( isSingle && this.props.hasIntroduction && ! this.state.hasStartedStorymap && ! this.state.isNavigating )
+			Boolean( isSingle && this.isIntroductionActive() && ! this.state.isNavigating )
 		);
+	}
+
+	isIntroductionActive() {
+		return Boolean( this.props.hasIntroduction && this.state.hasStartedStorymap === false );
 	}
 
 	startStorymapDisplay() {
@@ -247,7 +251,7 @@ class StoryMapDisplay extends Component {
 				progress: true,
 			})
 			.onStepEnter(response => {
-				if ( this.props.hasIntroduction && ! this.state.hasStartedStorymap ) {
+				if ( this.isIntroductionActive() ) {
 					return;
 				}
 
@@ -290,7 +294,7 @@ class StoryMapDisplay extends Component {
 				})
 		})
 		.onStepExit(response => {
-			if ( this.props.hasIntroduction && ! this.state.hasStartedStorymap ) {
+			if ( this.isIntroductionActive() ) {
 				return;
 			}
 
@@ -331,48 +335,49 @@ class StoryMapDisplay extends Component {
 			const navigateMapContainer = this.el?.querySelector( '.navigate-map' );
 
 			if ( navigateMapContainer ) {
+				// Mapbox owns the map element after initialization, so storymap controls stay outside it.
 				navigateMapContainer.append( navigateMapDiv );
 			}
 		}
 
-			const postRestBase = this.props.postRestBase || 'storymap';
-			const url = `${ window.jeoMapVars.jsonUrl }${ postRestBase }/${ this.props.postID }`;
-			window.fetch( url )
-				.then( ( response ) => {
-					if ( ! response.ok ) {
-						return null;
-					}
-					return response.json();
-				} )
-				.then( ( json ) => {
-					if ( json ) {
-						this.setState( { ...this.state, postData: json } );
-					}
-				} );
+		const postRestBase = this.props.postRestBase || 'storymap';
+		const url = `${ window.jeoMapVars.jsonUrl }${ postRestBase }/${ this.props.postID }`;
+		window.fetch( url )
+			.then( ( response ) => {
+				if ( ! response.ok ) {
+					return null;
+				}
+				return response.json();
+			} )
+			.then( ( json ) => {
+				if ( json ) {
+					this.setState( { ...this.state, postData: json } );
+				}
+			} );
 
 		document.addEventListener( 'fullscreenchange', this.handleFullscreenChange );
 	}
 
-		enterNavigationMode() {
-			this.setState( { isNavigating: true, mapBrightness: 1 }, () => {
-				this.el?.scrollIntoView( { block: 'start' } );
-				window.requestAnimationFrame( () => {
-					this.navigateMap?.forceUpdate?.();
-					window.requestAnimationFrame( () => this.navigateMap?.forceUpdate?.() );
-				} );
+	enterNavigationMode() {
+		this.setState( { isNavigating: true, mapBrightness: 1 }, () => {
+			this.el?.scrollIntoView( { block: 'start' } );
+			window.requestAnimationFrame( () => {
+				this.navigateMap?.forceUpdate?.();
+				window.requestAnimationFrame( () => this.navigateMap?.forceUpdate?.() );
 			} );
-		}
+		} );
+	}
 
 	exitNavigationMode() {
 		if ( document.fullscreenElement ) {
 			document.exitFullscreen();
 		}
 
-			this.setState( { isNavigating: false, mapBrightness: 1, inSlides: true, hasStartedStorymap: true }, () => {
-				this.map?.resize();
-				this.el?.scrollIntoView( { block: 'start' } );
-			} );
-		}
+		this.setState( { isNavigating: false, mapBrightness: 1, inSlides: true, hasStartedStorymap: true }, () => {
+			this.map?.resize();
+			this.el?.scrollIntoView( { block: 'start' } );
+		} );
+	}
 
 	lazyInitStorymap() {
 		if ( this.initialized ) {
@@ -419,7 +424,7 @@ class StoryMapDisplay extends Component {
 	componentDidUpdate() {
 		this.syncIntroductionScrollLock();
 
-		const mapEl = this.el.querySelector(`.${MAP_RUNTIME}-map`);
+		const mapEl = this.el?.querySelector(`.${MAP_RUNTIME}-map`);
 		if (mapEl) {
 			mapEl.style.filter = `brightness(${ this.state.mapBrightness })`;
 		}
@@ -456,24 +461,24 @@ class StoryMapDisplay extends Component {
 		}
 	}
 
-	    render() {
-	        const theme = this.config.theme;
-			const currentChapterID = this.state.currentChapter.id;
-			const postTitle = this.state.postData?.title?.rendered;
-			const storyDate = this.state.postData?.date ? new Date( this.state.postData.date ) : null;
-			const Heading = isSingle ? 'h1' : 'h2';
-			const isNavigating = this.state.isNavigating;
-			const isIntroductionActive = this.props.hasIntroduction && ! this.state.hasStartedStorymap;
+    render() {
+        const theme = this.config.theme;
+		const currentChapterID = this.state.currentChapter.id;
+		const postTitle = this.state.postData?.title?.rendered;
+		const storyDate = this.state.postData?.date ? new Date( this.state.postData.date ) : null;
+		const Heading = isSingle ? 'h1' : 'h2';
+		const isNavigating = this.state.isNavigating;
+		const isIntroductionActive = this.isIntroductionActive();
 
-	        return(
-				<section
-					id={ `story-map-${this.cid}` }
-					className={ classNames( 'story-map', {
-						'story-map--navigating': isNavigating,
-						'story-map--intro-active': isIntroductionActive,
-					} ) }
-					ref={ ( el ) => ( this.el = el ) }
-				>
+        return(
+			<section
+				id={ `story-map-${this.cid}` }
+				className={ classNames( 'story-map', {
+					'story-map--navigating': isNavigating,
+					'story-map--intro-active': isIntroductionActive,
+				} ) }
+				ref={ ( el ) => ( this.el = el ) }
+			>
 				<div
 					className="not-navigating-map"
 					style={ { display: isNavigating ? 'none' : 'block' } }
@@ -486,18 +491,18 @@ class StoryMapDisplay extends Component {
 
 					<div className="the-story">
 						{ isIntroductionActive &&
-								<div className={ classNames( [ 'storymap-header', theme ] ) } style={ { marginBottom: window.innerHeight / 3 } }>
-									{ postTitle && (
-										<>
-											<Heading className="storymap-page-title" dangerouslySetInnerHTML={ { __html: postTitle } } />
-											<div className="post-info">
-												<p className="author" dangerouslySetInnerHTML={ { __html: getAuthorsLinks( this.state.postData ) } } />
-												{ storyDate && (
-													<p className="date">{ `${formatDate(storyDate)} ${ __('at', 'jeo') } ${formatHour(storyDate)}` }</p>
-												) }
-											</div>
-										</>
-									) }
+							<div className={ classNames( [ 'storymap-header', theme ] ) } style={ { marginBottom: window.innerHeight / 3 } }>
+								{ postTitle && (
+									<>
+										<Heading className="storymap-page-title" dangerouslySetInnerHTML={ { __html: postTitle } } />
+										<div className="post-info">
+											<p className="author" dangerouslySetInnerHTML={ { __html: getAuthorsLinks( this.state.postData ) } } />
+											{ storyDate && (
+												<p className="date">{ `${formatDate(storyDate)} ${ __('at', 'jeo') } ${formatHour(storyDate)}` }</p>
+											) }
+										</div>
+									</>
+								) }
 								{ this.config.subtitle &&
 									<h3 className="storymap-description" dangerouslySetInnerHTML={ { __html: decodeHtmlEntity( this.config.subtitle ) } } />
 								}
@@ -516,7 +521,7 @@ class StoryMapDisplay extends Component {
 											onClick={ async () => {
 												this.el?.querySelector( '.storymap-start-button' )?.click();
 												await sleep(1);
-												window.scrollTo( 0, this.el.scrollHeight );
+												window.scrollTo( 0, this.el?.scrollHeight || document.body.scrollHeight );
 												this.el?.querySelector( '.navigate-button-display' )?.click();
 											} }
 										>
@@ -605,18 +610,13 @@ class StoryMapDisplay extends Component {
 						<p className="icon-return">
 							<div
 								className="icon"
-								onClick={ () => {
-									sleep(1000)
-									this.exitNavigationMode();
-								} }
+								onClick={ () => this.exitNavigationMode() }
 							>
 								<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="angle-double-up" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="white" d="M177 255.7l136 136c9.4 9.4 9.4 24.6 0 33.9l-22.6 22.6c-9.4 9.4-24.6 9.4-33.9 0L160 351.9l-96.4 96.4c-9.4 9.4-24.6 9.4-33.9 0L7 425.7c-9.4-9.4-9.4-24.6 0-33.9l136-136c9.4-9.5 24.6-9.5 34-.1zm-34-192L7 199.7c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l96.4-96.4 96.4 96.4c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9l-136-136c-9.2-9.4-24.4-9.4-33.8 0z"></path></svg>
 							</div>
 						</p>
 						<p
-							onClick={ async () => {
-								this.exitNavigationMode();
-							} }
+							onClick={ () => this.exitNavigationMode() }
 						>
 							{ __('Back to top', 'jeo') }
 						</p>

--- a/src/js/src/jeo-storymap/storymap-display.js
+++ b/src/js/src/jeo-storymap/storymap-display.js
@@ -59,6 +59,15 @@ class StoryMapDisplay extends Component {
 		this.isIntroductionScrollLocked = false;
 		this.previousBodyOverflow = null;
 		this.previousDocumentOverflow = null;
+		this.handleFullscreenChange = () => {
+			const returnToSlidesContainer = this.el?.querySelector( '.return-to-slides-container' );
+
+			if ( returnToSlidesContainer ) {
+				returnToSlidesContainer.style.display = document.fullscreenElement ? 'none' : 'block';
+			}
+
+			window.scrollTo ( 0, document.body.scrollHeight );
+		};
 
 		const slides = [];
 		props.slides.map( ( slide, index ) => {
@@ -124,6 +133,7 @@ class StoryMapDisplay extends Component {
 			postData: null,
 			hiddenLayersIds: [],
 			inSlides,
+			hasStartedStorymap: ! props.hasIntroduction,
         };
     }
 
@@ -137,6 +147,7 @@ class StoryMapDisplay extends Component {
 	componentWillUnmount() {
 		this.setIntroductionScrollLocked( false );
 		window.removeEventListener( 'resize', this.scroller.resize );
+		document.removeEventListener( 'fullscreenchange', this.handleFullscreenChange );
 	}
 
 	setIntroductionScrollLocked( locked ) {
@@ -163,8 +174,18 @@ class StoryMapDisplay extends Component {
 
 	syncIntroductionScrollLock() {
 		this.setIntroductionScrollLocked(
-			Boolean( this.props.hasIntroduction && ! this.state.inSlides && ! this.state.isNavigating )
+			Boolean( isSingle && this.props.hasIntroduction && ! this.state.hasStartedStorymap && ! this.state.isNavigating )
 		);
+	}
+
+	startStorymapDisplay() {
+		this.setIntroductionScrollLocked( false );
+		this.setState( { ...this.state, mapBrightness: 1, inSlides: true, hasStartedStorymap: true }, () => {
+			window.requestAnimationFrame( () => {
+				this.scroller.resize();
+				this.el?.querySelector( '.storymap-features' )?.scrollIntoView();
+			} );
+		} );
 	}
 
 	scheduleInitialMapLibreAttributionSync() {
@@ -226,6 +247,10 @@ class StoryMapDisplay extends Component {
 				progress: true,
 			})
 			.onStepEnter(response => {
+				if ( this.props.hasIntroduction && ! this.state.hasStartedStorymap ) {
+					return;
+				}
+
 				if ( response.index === config.chapters.length - 1 ) {
 					this.setState({ ...this.state, mapBrightness: MAP_DIM, inSlides: false })
 					this.map?.flyTo({
@@ -265,7 +290,15 @@ class StoryMapDisplay extends Component {
 				})
 		})
 		.onStepExit(response => {
+			if ( this.props.hasIntroduction && ! this.state.hasStartedStorymap ) {
+				return;
+			}
+
 			if ( response.index === 0 && response.direction === 'up' ) {
+				if ( ! this.props.hasIntroduction || this.state.hasStartedStorymap ) {
+					return;
+				}
+
 				this.setState( { ...this.state, inSlides: false, mapBrightness: MAP_DIM } );
 
 				// show the ones we need and just after hide the ones we dont need (this forces the map to always have at least one layer)
@@ -295,27 +328,51 @@ class StoryMapDisplay extends Component {
 			navigateMapDiv.dataset.map_id = this.props.map_id;
 
 			this.navigateMap = new JeoMap( navigateMapDiv );
-			this.el.querySelector('.navigate-map').append( navigateMapDiv );
-			this.el.querySelector('.navigate-map .jeomap').appendChild(this.el.querySelector('.return-to-slides-container'))
+			const navigateMapContainer = this.el?.querySelector( '.navigate-map' );
+
+			if ( navigateMapContainer ) {
+				navigateMapContainer.append( navigateMapDiv );
+			}
 		}
 
-		const url = `${ window.jeoMapVars.jsonUrl }storymap/${ this.props.postID }`;
-		window.fetch( url )
-			.then( ( response ) => {
-				return response.json();
-			} )
-			.then( ( json ) => this.setState( { ...this.state, postData: json } ) );
+			const postRestBase = this.props.postRestBase || 'storymap';
+			const url = `${ window.jeoMapVars.jsonUrl }${ postRestBase }/${ this.props.postID }`;
+			window.fetch( url )
+				.then( ( response ) => {
+					if ( ! response.ok ) {
+						return null;
+					}
+					return response.json();
+				} )
+				.then( ( json ) => {
+					if ( json ) {
+						this.setState( { ...this.state, postData: json } );
+					}
+				} );
 
-		document.addEventListener('fullscreenchange', function() {
-			if ( document.fullscreenElement ) {
-				this.el.querySelector( '.return-to-slides-container' ).style.display = 'none';
-			} else {
-				this.el.querySelector( '.return-to-slides-container' ).style.display = 'block';
-			}
-
-			window.scrollTo ( 0, document.body.scrollHeight );
-		});
+		document.addEventListener( 'fullscreenchange', this.handleFullscreenChange );
 	}
+
+		enterNavigationMode() {
+			this.setState( { isNavigating: true, mapBrightness: 1 }, () => {
+				this.el?.scrollIntoView( { block: 'start' } );
+				window.requestAnimationFrame( () => {
+					this.navigateMap?.forceUpdate?.();
+					window.requestAnimationFrame( () => this.navigateMap?.forceUpdate?.() );
+				} );
+			} );
+		}
+
+	exitNavigationMode() {
+		if ( document.fullscreenElement ) {
+			document.exitFullscreen();
+		}
+
+			this.setState( { isNavigating: false, mapBrightness: 1, inSlides: true, hasStartedStorymap: true }, () => {
+				this.map?.resize();
+				this.el?.scrollIntoView( { block: 'start' } );
+			} );
+		}
 
 	lazyInitStorymap() {
 		if ( this.initialized ) {
@@ -351,8 +408,11 @@ class StoryMapDisplay extends Component {
 				jeoLayer.addLayer(map);
 			});
 
-			this.el.querySelector(`.${MAP_RUNTIME}-map`).style.filter = `brightness(${ this.state.mapBrightness })`;
-			this.el.querySelector('.the-story').classList.add('loaded');
+			const mapEl = this.el?.querySelector( `.${MAP_RUNTIME}-map` );
+			if ( mapEl ) {
+				mapEl.style.filter = `brightness(${ this.state.mapBrightness })`;
+			}
+			this.el?.querySelector( '.the-story' )?.classList.add( 'loaded' );
 		});
 	}
 
@@ -396,15 +456,28 @@ class StoryMapDisplay extends Component {
 		}
 	}
 
-    render() {
-        const theme = this.config.theme;
-		const currentChapterID = this.state.currentChapter.id;
-		const storyDate = this.state.postData ? new Date( this.state.postData.date ) : null;
-		const Heading = isSingle ? 'h1' : 'h2';
+	    render() {
+	        const theme = this.config.theme;
+			const currentChapterID = this.state.currentChapter.id;
+			const postTitle = this.state.postData?.title?.rendered;
+			const storyDate = this.state.postData?.date ? new Date( this.state.postData.date ) : null;
+			const Heading = isSingle ? 'h1' : 'h2';
+			const isNavigating = this.state.isNavigating;
+			const isIntroductionActive = this.props.hasIntroduction && ! this.state.hasStartedStorymap;
 
-        return(
-			<section id={ `story-map-${this.cid}` } className="story-map" ref={ ( el ) => ( this.el = el ) }>
-				<div className="not-navigating-map">
+	        return(
+				<section
+					id={ `story-map-${this.cid}` }
+					className={ classNames( 'story-map', {
+						'story-map--navigating': isNavigating,
+						'story-map--intro-active': isIntroductionActive,
+					} ) }
+					ref={ ( el ) => ( this.el = el ) }
+				>
+				<div
+					className="not-navigating-map"
+					style={ { display: isNavigating ? 'none' : 'block' } }
+				>
 					<div
 						ref={ ( el ) => ( this.mapContainer = el ) }
 						className="story-map-element"
@@ -412,29 +485,26 @@ class StoryMapDisplay extends Component {
 					</div>
 
 					<div className="the-story">
-						{ this.props.hasIntroduction &&
-							<div className={ classNames( [ 'storymap-header', theme ] ) } style={ { marginBottom: window.innerHeight / 3 } }>
-								{ this.state.postData && (
-									<>
-										<Heading className="storymap-page-title" dangerouslySetInnerHTML={ { __html: this.state.postData.title.rendered } } />
-										<div className="post-info">
-											<p className="author" dangerouslySetInnerHTML={ { __html: getAuthorsLinks( this.state.postData ) } } />
-											<p className="date">{ `${formatDate(storyDate)} ${ __('at', 'jeo') } ${formatHour(storyDate)}` }</p>
-										</div>
-									</>
-								) }
+						{ isIntroductionActive &&
+								<div className={ classNames( [ 'storymap-header', theme ] ) } style={ { marginBottom: window.innerHeight / 3 } }>
+									{ postTitle && (
+										<>
+											<Heading className="storymap-page-title" dangerouslySetInnerHTML={ { __html: postTitle } } />
+											<div className="post-info">
+												<p className="author" dangerouslySetInnerHTML={ { __html: getAuthorsLinks( this.state.postData ) } } />
+												{ storyDate && (
+													<p className="date">{ `${formatDate(storyDate)} ${ __('at', 'jeo') } ${formatHour(storyDate)}` }</p>
+												) }
+											</div>
+										</>
+									) }
 								{ this.config.subtitle &&
 									<h3 className="storymap-description" dangerouslySetInnerHTML={ { __html: decodeHtmlEntity( this.config.subtitle ) } } />
 								}
 
 								<button
 									className="storymap-start-button"
-									onClick={ () => {
-										this.setIntroductionScrollLocked( false );
-										this.setState( { ...this.state, mapBrightness: 1, inSlides: true } );
-
-										this.el.querySelector( '.storymap-features' ).scrollIntoView();
-									} }
+									onClick={ () => this.startStorymapDisplay() }
 								>
 									{ __('START', 'jeo') }
 								</button>
@@ -444,22 +514,17 @@ class StoryMapDisplay extends Component {
 										<p
 											className="skip-intro-link"
 											onClick={ async () => {
-												this.el.querySelector('.storymap-start-button').click();
+												this.el?.querySelector( '.storymap-start-button' )?.click();
 												await sleep(1);
 												window.scrollTo( 0, this.el.scrollHeight );
-												this.el.querySelector('.navigate-button-display').click();
+												this.el?.querySelector( '.navigate-button-display' )?.click();
 											} }
 										>
 											{ __('skip intro', 'jeo') }
 										</p>
 										<div
 											className="skip-intro-icon"
-											onClick={ async () => {
-												this.setIntroductionScrollLocked( false );
-												this.setState( { ...this.state, mapBrightness: 1, inSlides: true } );
-
-												this.el.querySelector( '.storymap-features' ).scrollIntoView();
-											} }
+											onClick={ () => this.startStorymapDisplay() }
 										>
 											<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="angle-double-down" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" ><path fill="currentColor" d="M143 256.3L7 120.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0L313 86.3c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.4 9.5-24.6 9.5-34 .1zm34 192l136-136c9.4-9.4 9.4-24.6 0-33.9l-22.6-22.6c-9.4-9.4-24.6-9.4-33.9 0L160 352.1l-96.4-96.4c-9.4-9.4-24.6-9.4-33.9 0L7 278.3c-9.4 9.4-9.4 24.6 0 33.9l136 136c9.4 9.5 24.6 9.5 34 .1z"></path></svg>
 										</div>
@@ -477,7 +542,14 @@ class StoryMapDisplay extends Component {
 											'storymap-features--with-navigation-step': this.props.navigateButton,
 										},
 									] ) }
-									style={ { display: 'block' } }
+									style={ isIntroductionActive ? {
+										height: 0,
+										overflow: 'hidden',
+										paddingBottom: 0,
+										paddingTop: 0,
+										pointerEvents: 'none',
+										visibility: 'hidden',
+									} : { display: 'block' } }
 								>
 									{
 										this.config.chapters.map( ( chapter, index ) => {
@@ -496,14 +568,7 @@ class StoryMapDisplay extends Component {
 													<Chapter
 														index={ this.config.chapters.length }
 														props={ this.props }
-														onClickFunction={ () => {
-															this.el.querySelector( '.navigate-map' ).style.display = 'block';
-															this.setState( { ...this.state, isNavigating: true, mapBrightness: 1 } );
-															this.navigateMap?.forceUpdate();
-															this.el.querySelector( '.not-navigating-map' ).style.display = ' none ';
-
-															window.scrollTo( 0,this.el.scrollHeight );
-														} }
+														onClickFunction={ () => this.enterNavigationMode() }
 														isLastChapter={ true }
 														{ ...this.lastChapter }
 														theme={ theme }
@@ -532,32 +597,17 @@ class StoryMapDisplay extends Component {
 						) }
 					</div>
 				</div>
-				<div style={ { display: 'none' } } className="navigate-map">
+				<div
+					className="navigate-map"
+					style={ { display: isNavigating ? 'block' : 'none' } }
+				>
 					<div className="return-to-slides-container">
 						<p className="icon-return">
 							<div
 								className="icon"
 								onClick={ () => {
-									if ( document.fullscreenElement ) {
-										document.exitFullscreen();
-									}
-
 									sleep(1000)
-
-									let mapBrightness;
-
-									if ( this.props.hasIntroduction ) {
-										mapBrightness = MAP_DIM;
-									} else {
-										mapBrightness = 1;
-									}
-
-									this.setState( { ...this.state, isNavigating: false, mapBrightness } )
-									window.scrollTo(0, 0);
-									this.el.querySelector('.navigate-map').style.display = 'none';
-									this.el.querySelector('.not-navigating-map').style.display = 'block';
-
-									this.map?.resize();
+									this.exitNavigationMode();
 								} }
 							>
 								<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="angle-double-up" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="white" d="M177 255.7l136 136c9.4 9.4 9.4 24.6 0 33.9l-22.6 22.6c-9.4 9.4-24.6 9.4-33.9 0L160 351.9l-96.4 96.4c-9.4 9.4-24.6 9.4-33.9 0L7 425.7c-9.4-9.4-9.4-24.6 0-33.9l136-136c9.4-9.5 24.6-9.5 34-.1zm-34-192L7 199.7c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l96.4-96.4 96.4 96.4c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9l-136-136c-9.2-9.4-24.4-9.4-33.8 0z"></path></svg>
@@ -565,26 +615,7 @@ class StoryMapDisplay extends Component {
 						</p>
 						<p
 							onClick={ async () => {
-								if ( document.fullscreenElement ) {
-									document.exitFullscreen();
-								}
-
-								let mapBrightness;
-
-								if ( this.props.hasIntroduction ) {
-									mapBrightness = MAP_DIM;
-								} else {
-									mapBrightness = 1;
-								}
-
-								this.setState( { ...this.state, isNavigating: false, mapBrightness } )
-
-								this.el.querySelector('.navigate-map').style.display = 'none';
-								this.el.querySelector('.not-navigating-map').style.display = 'block';
-
-								this.map?.resize();
-
-								window.scrollTo(0, 0);
+								this.exitNavigationMode();
 							} }
 						>
 							{ __('Back to top', 'jeo') }

--- a/src/js/src/jeo-storymap/storymap-display.scss
+++ b/src/js/src/jeo-storymap/storymap-display.scss
@@ -40,45 +40,14 @@ $font-stories: var( --jeo-font-stories );
 	}
 }
 
-	.story-map {
-		margin: 0;
-		min-height: 100vh;
-		padding: 0;
-		position: relative;
+.story-map {
+	margin: 0;
+	padding: 0;
+	position: relative;
 
-		&.story-map--navigating {
-			min-height: 100vh;
-
-			.navigate-map {
-				background: #ffffff;
-				height: 100vh;
-				inset-inline: 50%;
-				margin-inline: -50vw;
-				overflow: hidden;
-				position: relative;
-				width: 100vw;
-
-				.jeomap {
-					height: 100%;
-					inset: 0;
-					max-width: none;
-					position: absolute;
-					width: 100%;
-				}
-			}
-		}
-
-		&.story-map--intro-active {
-			min-height: 100vh;
-
-			.not-navigating-map {
-				min-height: 100vh;
-			}
-		}
-
-		@media (max-width: 829px) {
-			.storymap-page-title {
-				margin-top: 70px;
+	@media (max-width: 829px) {
+		.storymap-page-title {
+			margin-top: 70px;
 		}
 
 		:is(.mapboxgl-ctrl-top-left .mapboxgl-ctrl:first-of-type, .maplibregl-ctrl-top-left .maplibregl-ctrl:first-of-type) {
@@ -371,16 +340,16 @@ $font-stories: var( --jeo-font-stories );
 		}
 	}
 
-		.step.active {
-			opacity: 0.99;
-		}
+	.step.active {
+		opacity: 0.99;
+	}
 
-		.step.storymap-navigation-step {
-			opacity: 0.99;
-		}
+	.step.storymap-navigation-step {
+		opacity: 0.99;
+	}
 
-		.navigate-button-display {
-			background-color: var( --jeo-primary-color );
+	.navigate-button-display {
+		background-color: var( --jeo-primary-color );
 		color: white;
 		border-radius: 10px;
 		width: 237px;
@@ -461,13 +430,13 @@ $font-stories: var( --jeo-font-stories );
 		}
 	}
 
-		.return-to-slides-container {
-			filter: drop-shadow( 0px 0px 4px black );
-			position: absolute;
-			inset-inline-start: 50%;
-			transform: translateX( -50% );
-			bottom: 28px;
-			z-index: 5;
+	.return-to-slides-container {
+		filter: drop-shadow( 0px 0px 4px black );
+		position: fixed;
+		inset-inline-start: 50%;
+		transform: translate( -50%, -50% );
+		bottom: 0;
+		z-index: 1;
 
 		p {
 			text-decoration: underline;
@@ -551,25 +520,25 @@ $font-stories: var( --jeo-font-stories );
 		inset-inline-end: 20px;
 	}
 
-		.navigate-map {
-			:is(.mapboxgl-map, .maplibregl-map) {
-				transition: filter 0.7s ease;
-				width: 100% !important;
-				height: 100% !important;
-				max-width: none;
+	.navigate-map {
+		:is(.mapboxgl-map, .maplibregl-map) {
+			transition: filter 0.7s ease;
+			width: 100vw !important;
+			height: 96vh !important;
+			max-width: 100%;
 
-				:is(.mapboxgl-canvas-container, .maplibregl-canvas-container) {
-					canvas {
-						width: 100% !important;
-						height: 100% !important;
-					}
-				}
-
-				@media ( max-width: 800px ) {
-					height: 100% !important;
+			:is(.mapboxgl-canvas-container, .maplibregl-canvas-container) {
+				canvas {
+					width: 100vw !important;
+					height: 95vh !important;
 				}
 			}
+
+			@media ( max-width: 800px ) {
+				height: 94vh !important;
+			}
 		}
+	}
 
 	@media ( max-width: 650px ) {
 		.storymap-header {

--- a/src/js/src/jeo-storymap/storymap-display.scss
+++ b/src/js/src/jeo-storymap/storymap-display.scss
@@ -40,14 +40,45 @@ $font-stories: var( --jeo-font-stories );
 	}
 }
 
-.story-map {
-	margin: 0;
-	padding: 0;
-	position: relative;
+	.story-map {
+		margin: 0;
+		min-height: 100vh;
+		padding: 0;
+		position: relative;
 
-	@media (max-width: 829px) {
-		.storymap-page-title {
-			margin-top: 70px;
+		&.story-map--navigating {
+			min-height: 100vh;
+
+			.navigate-map {
+				background: #ffffff;
+				height: 100vh;
+				inset-inline: 50%;
+				margin-inline: -50vw;
+				overflow: hidden;
+				position: relative;
+				width: 100vw;
+
+				.jeomap {
+					height: 100%;
+					inset: 0;
+					max-width: none;
+					position: absolute;
+					width: 100%;
+				}
+			}
+		}
+
+		&.story-map--intro-active {
+			min-height: 100vh;
+
+			.not-navigating-map {
+				min-height: 100vh;
+			}
+		}
+
+		@media (max-width: 829px) {
+			.storymap-page-title {
+				margin-top: 70px;
 		}
 
 		:is(.mapboxgl-ctrl-top-left .mapboxgl-ctrl:first-of-type, .maplibregl-ctrl-top-left .maplibregl-ctrl:first-of-type) {
@@ -340,12 +371,16 @@ $font-stories: var( --jeo-font-stories );
 		}
 	}
 
-	.step.active {
-		opacity: 0.99;
-	}
+		.step.active {
+			opacity: 0.99;
+		}
 
-	.navigate-button-display {
-		background-color: var( --jeo-primary-color );
+		.step.storymap-navigation-step {
+			opacity: 0.99;
+		}
+
+		.navigate-button-display {
+			background-color: var( --jeo-primary-color );
 		color: white;
 		border-radius: 10px;
 		width: 237px;
@@ -426,13 +461,13 @@ $font-stories: var( --jeo-font-stories );
 		}
 	}
 
-	.return-to-slides-container {
-		filter: drop-shadow( 0px 0px 4px black );
-		position: fixed;
-		inset-inline-start: 50%;
-		transform: translate( -50%, -50% );
-		bottom: 0;
-		z-index: 1;
+		.return-to-slides-container {
+			filter: drop-shadow( 0px 0px 4px black );
+			position: absolute;
+			inset-inline-start: 50%;
+			transform: translateX( -50% );
+			bottom: 28px;
+			z-index: 5;
 
 		p {
 			text-decoration: underline;
@@ -516,25 +551,25 @@ $font-stories: var( --jeo-font-stories );
 		inset-inline-end: 20px;
 	}
 
-	.navigate-map {
-		:is(.mapboxgl-map, .maplibregl-map) {
-			transition: filter 0.7s ease;
-			width: 100vw !important;
-			height: 96vh !important;
-			max-width: 100%;
+		.navigate-map {
+			:is(.mapboxgl-map, .maplibregl-map) {
+				transition: filter 0.7s ease;
+				width: 100% !important;
+				height: 100% !important;
+				max-width: none;
 
-			:is(.mapboxgl-canvas-container, .maplibregl-canvas-container) {
-				canvas {
-					width: 100vw !important;
-					height: 95vh !important;
+				:is(.mapboxgl-canvas-container, .maplibregl-canvas-container) {
+					canvas {
+						width: 100% !important;
+						height: 100% !important;
+					}
+				}
+
+				@media ( max-width: 800px ) {
+					height: 100% !important;
 				}
 			}
-
-			@media ( max-width: 800px ) {
-				height: 94vh !important;
-			}
 		}
-	}
 
 	@media ( max-width: 650px ) {
 		.storymap-header {


### PR DESCRIPTION
## Summary

This PR fixes several related storymap rendering/state issues that appear when storymaps are used inside regular posts, especially when a post contains an existing embedded storymap or multiple storymaps created directly in the post editor.

The root issue was that the storymap display component reused page-level assumptions from standalone storymap pages in embedded/post contexts. That caused global scroll locking, introduction state, navigation mode, and map brightness to leak outside the intended storymap instance.

## What changed

- Embedded storymaps now preserve the referenced storymap post ID and REST base when rendering their saved block data.
- Storymap header data is fetched from the correct REST endpoint for both `storymap` posts and regular `posts`.
- Missing or invalid embedded storymap payloads are handled defensively instead of rendering broken state.
- Introduction scroll locking is now limited to dedicated `single-storymap` pages. Embedded storymaps inside posts no longer lock the whole page.
- The introduction is now an explicit one-way state: before `START`, slides are kept collapsed and hidden; after `START`, the intro/header/button do not render again when scrolling back up.
- Scrollama handlers ignore slide transitions while the introduction is still closed, avoiding accidental map/layer changes while the reader is simply scrolling past an embedded storymap.
- Normal storymaps without introduction no longer dim the map when the reader scrolls to the page bottom and returns to the top.
- Navigation mode is scoped to the storymap area instead of behaving like a full-page overlay in posts.
- The "Back to top" control now belongs to the storymap navigation context and exits navigation with full map brightness and slide state restored.
- Storymap containers now reserve at least `100vh`, preventing following post blocks from overlapping short storymaps whose sticky map is taller than their slide content.
- Layer matching in rendered storymap data now normalizes IDs and avoids accessing missing selected-layer data.

## Design decisions

- The intro remains blocking only on standalone storymap pages, where the full-page storymap experience is expected.
- In regular posts, the post remains scrollable. If a storymap has an intro, readers can pass the intro without seeing all slides unless they click `START`.
- After `START`, the intro is considered consumed for that component instance. Scrolling back to the top should not resurrect the intro or reapply the dimmed map mask.
- The navigation map is rendered in-flow with the storymap instead of `fixed`, so it cannot cover the whole post or unrelated content.
- The `100vh` minimum is applied to the storymap shell, not to individual slides, so longer storymaps still size naturally while short storymaps reserve enough room for the sticky map.

## Local verification

Manual browser checks were run against `infoamazonia.local` before porting the fix:

- `http://infoamazonia.local/?p=229218`
  - Reproduced the intro-enabled storymap inside a post.
  - Verified the page remains scrollable before clicking `START`.
  - Verified slides are hidden/collapsed until `START`.
  - Verified `START` removes the intro permanently for that instance.
  - Verified scrolling down and back up does not bring the intro/button back and leaves the map at `brightness(1)`.

- `http://infoamazonia.local/?p=229212`
  - Reproduced the `Navigate the map` flow inside a post.
  - Verified navigation mode stays within the storymap area rather than covering the full post.
  - Verified `Back to top` exits navigation without restoring the dimmed intro mask.

- `http://infoamazonia.local/?p=229231`
  - Reproduced two storymaps created directly inside the post.
  - Verified following blocks no longer overlap short storymaps.
  - Verified scrolling to the bottom and back up leaves both maps at `brightness(1)`.

- `http://infoamazonia.local/storymap/ate-a-ultima-gota-colombia/`
  - Verified standalone storymaps still lock page scroll on the initial introduction.
  - Verified clicking `START` restores normal slide display and prevents the intro from returning.

## Automated checks

- `php -l src/includes/class-jeo.php`
- `npm run test:unit -- --runInBand`
- `npm run build`
- `npm run check:wporg-compliance`
- `git diff --check`

`npm run build` completed successfully. WP-CLI emitted existing PHP deprecation warnings while generating i18n JSON files, but the build finished successfully.
