### PR TITLE
Fix aligned map sizing and compact controls

### DIFF
--- a/src/css/jeo-map.scss
+++ b/src/css/jeo-map.scss
@@ -249,6 +249,17 @@
 			margin-inline-end: 12px;
 			filter: brightness(0) invert(1);
 		}
+
+		.info-icon {
+			width: 16px;
+			height: 16px;
+			background-size: cover;
+			background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23333' d='M11 10h2v7h-2zm0-3h2v2h-2z'/%3E%3Cpath fill='%23333' d='M12 2a10 10 0 100 20 10 10 0 000-20zm0 18a8 8 0 110-16 8 8 0 010 16z'/%3E%3C/svg%3E");
+			background-position: center;
+			cursor: pointer;
+			margin-inline-end: 12px;
+			filter: brightness(0) invert(1);
+		}
 	}
 
 	div.more-info-overlayer {
@@ -355,6 +366,11 @@
 			justify-content: space-between;
 			align-items: center;
 			font-family: var(--jeo-font);
+		}
+
+		.more-info-title {
+			cursor: pointer;
+			display: none;
 		}
 
 		i.arrow-icon {
@@ -537,6 +553,24 @@
 			color: rgba(0, 0, 0, .78);
 			text-underline-offset: 2px;
 		}
+	}
+
+	:is(.mapboxgl-ctrl-attrib, .maplibregl-ctrl-attrib) {
+		box-sizing: border-box;
+	}
+
+	.maplibregl-ctrl-attrib-button {
+		list-style: none;
+
+		&::-webkit-details-marker {
+			display: none;
+		}
+	}
+
+	.mapboxgl-ctrl-attrib.mapboxgl-compact-show .mapboxgl-ctrl-attrib-inner,
+	.maplibregl-ctrl-attrib.maplibregl-compact-show .maplibregl-ctrl-attrib-inner {
+		box-sizing: border-box;
+		padding-inline-end: 32px;
 	}
 
 	.mapboxgl-ctrl-attrib.mapboxgl-compact-show {
@@ -1137,12 +1171,15 @@
 
 .jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignleft,
 .jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignright {
-	--jeo-aligned-map-base-width: var( --wp--style--global--content-size, 645px );
-	--jeo-aligned-map-expanded-width: calc( var( --jeo-aligned-map-base-width ) * 1.6 );
-	display: table;
-	max-width: none;
-	min-width: min( var( --jeo-aligned-map-base-width ), calc( 100vw - 2rem ) );
-	width: min( var( --jeo-aligned-map-expanded-width ), calc( 100vw - 2rem ) );
+	--jeo-aligned-map-width: 420px;
+	--jeo-aligned-map-aspect-ratio: 8 / 9;
+	aspect-ratio: var( --jeo-aligned-map-aspect-ratio );
+	box-sizing: border-box;
+	display: block;
+	height: auto;
+	max-width: min( 50%, calc( 100vw - 2rem ) );
+	min-width: 0;
+	width: min( var( --jeo-aligned-map-width ), 50%, calc( 100vw - 2rem ) );
 }
 
 .jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignleft {
@@ -1161,13 +1198,38 @@
 	margin-bottom: 0.5em;
 }
 
+.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignleft:fullscreen,
+.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignright:fullscreen,
+.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignleft:-webkit-full-screen,
+.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignright:-webkit-full-screen,
+.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignleft.mapboxgl-pseudo-fullscreen,
+.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignright.mapboxgl-pseudo-fullscreen,
+.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignleft.maplibregl-pseudo-fullscreen,
+.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignright.maplibregl-pseudo-fullscreen {
+	aspect-ratio: auto;
+	display: block;
+	float: none;
+	height: 100%;
+	margin: 0;
+	max-width: none;
+	width: 100%;
+}
+
+.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignleft div.more-info-overlayer,
+.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignright div.more-info-overlayer {
+	inset-inline-end: 10px;
+	max-width: none;
+	width: auto;
+}
+
 @media (max-width: 782px) {
-	.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignleft,
-	.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignright {
+	.jeomap.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignleft,
+	.jeomap.jeomap:is(.wp-block-jeo-map, .wp-block-jeo-onetime-map).alignright {
 		display: block;
 		float: none;
 		margin-left: 0;
 		margin-right: 0;
+		max-width: 100%;
 		min-width: 0;
 		width: 100%;
 	}
@@ -1181,7 +1243,34 @@ p.jeomap-no-layers__text {
 
 .mapboxgl-ctrl-attrib.mapboxgl-compact {
 	.mapboxgl-ctrl-attrib-button {
+		appearance: none;
+		background-color: #ffffff80;
+		background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E");
+		background-position: center;
+		background-repeat: no-repeat;
+		background-size: 20px 20px;
+		border: 0;
+		border-radius: 50%;
+		box-sizing: border-box;
+		color: transparent;
+		cursor: pointer;
+		display: block;
+		font-size: 0;
+		height: 24px;
+		line-height: 0;
+		margin: 0;
+		min-height: 0;
+		min-width: 0;
+		padding: 0;
+		vertical-align: initial;
 		visibility: visible;
+		width: 24px;
+	}
+
+	&.mapboxgl-compact-show {
+		.mapboxgl-ctrl-attrib-button {
+			background-color: #0000000d;
+		}
 	}
 }
 
@@ -1193,6 +1282,62 @@ p.jeomap-no-layers__text {
 
 div.jeomap.alignwide {
 	width: auto;
+}
+
+.jeomap.jeo-small-controls {
+	nav.layers-selection.hidden {
+		max-width: 40px;
+		min-width: 40px;
+		transition: all .2s ease-in-out;
+
+		.layer-selection-title {
+			.legends-title {
+				padding: 12px 10px;
+				justify-content: center;
+
+				.text {
+					display: none;
+				}
+			}
+
+			.arrow-icon {
+				display: none;
+			}
+		}
+
+		.text-icon {
+			.layer-icon {
+				margin-inline-end: 0;
+			}
+		}
+	}
+
+	.legend-container .more-info-title {
+		display: flex;
+	}
+
+	.legend-container.hidden {
+		min-width: 40px;
+		max-width: 40px;
+		transition: all .2s ease-in-out;
+
+		.legends-title {
+			padding: 12px 10px;
+
+			.text {
+				display: none;
+			}
+
+			.arrow-icon {
+				display: none;
+			}
+
+			.legend-icon,
+			.info-icon {
+				margin-inline-end: 0;
+			}
+		}
+	}
 }
 
 @media (max-width: 800px) {
@@ -1230,6 +1375,10 @@ div.jeomap.alignwide {
 			max-height: 230px;
 			transition: all .2s ease-in-out;
 
+			.more-info-title {
+				display: flex;
+			}
+
 			&.hidden {
 				min-width: 40px;
 				max-width: 40px;
@@ -1242,10 +1391,15 @@ div.jeomap.alignwide {
 						.text {
 							display: none;
 						}
+					}
 
-						.arrow-icon {
-							display: none;
-						}
+					.arrow-icon {
+						display: none;
+					}
+
+					.legend-icon,
+					.info-icon {
+						margin-inline-end: 0;
 					}
 				}
 			}

--- a/src/js/src/jeo-map/class-jeo-map.js
+++ b/src/js/src/jeo-map/class-jeo-map.js
@@ -32,6 +32,7 @@ const chevronRightSmallIcon = `
 `;
 
 const RELATED_POSTS_CLUSTER_BADGE_PREFIX = 'jeo-related-posts-cluster-badge-';
+const SMALL_MAP_CONTROL_MAX_WIDTH = 420;
 
 function mergeUniqueStoriesById( currentStories = [], nextStories = [] ) {
 	const storiesById = new Map();
@@ -152,6 +153,7 @@ export default class JeoMap {
 
 					if ( this.getArg( 'enable_fullscreen' ) ) {
 						map.addControl( new mapgl.FullscreenControl(), `top-${inlineStart}` );
+						this.bindAlignedFullscreenReset();
 					}
 
 					if (
@@ -280,45 +282,41 @@ export default class JeoMap {
 								}
 							} );
 
-									const isMobileViewport = window.matchMedia
-										? window.matchMedia( '(max-width: 599px)' ).matches
-										: window.innerWidth < 600;
-									const controlPostion = MAP_RUNTIME === 'mapboxgl'
-										? 'bottom-right'
-										: `bottom-${inlineEnd}`;
+							const isMobileViewport = window.matchMedia
+								? window.matchMedia( '(max-width: 599px)' ).matches
+								: window.innerWidth < 600;
+							const shouldCompactAttribution =
+								isMobileViewport || this.shouldStartControlsCollapsed();
+							const controlPostion = MAP_RUNTIME === 'mapboxgl'
+								? 'bottom-right'
+								: `bottom-${inlineEnd}`;
+							const attributionOptions = {
+								customAttribution,
+							};
 
-									let attributionControl = MAP_RUNTIME === 'mapboxgl'
-										? new mapgl.AttributionControl( {
-											compact: false,
-											customAttribution,
-										} )
-										: new mapgl.AttributionControl( {
-											customAttribution,
-										} );
+							if ( MAP_RUNTIME === 'mapboxgl' || shouldCompactAttribution ) {
+								attributionOptions.compact = shouldCompactAttribution;
+							}
 
-									if ( isMobileViewport && MAP_RUNTIME === 'mapboxgl' ) {
-										attributionControl = new mapgl.AttributionControl( {
-											compact: true,
-											customAttribution,
-										} );
-									}
+							const attributionControl = new mapgl.AttributionControl(
+								attributionOptions
+							);
 
-								map.addControl(
-									attributionControl,
-									controlPostion
-								);
-								this.syncAttributionSpacing();
+							map.addControl(
+								attributionControl,
+								controlPostion
+							);
+							this.syncAttributionSpacing();
+							this.queueCompactAttributionCollapse();
+							map.once?.( 'idle', () => this.queueCompactAttributionCollapse() );
+							map.on( 'resize', () => this.queueCompactAttributionCollapse() );
 
-								if ( MAP_RUNTIME === 'maplibregl' ) {
-									this.collapseCompactMapLibreAttribution();
-									map.on( 'resize', () => this.collapseCompactMapLibreAttribution() );
-								}
-
-								this.getRelatedPosts();
+							this.getRelatedPosts();
 						});
 
 						this.addLayersControl( amountLayers );
 						this.addMoreButtonAndLegends();
+						this.syncSmallMapControlState();
 					}
 
 					// Show a message when a map doesn't have layers
@@ -381,15 +379,70 @@ export default class JeoMap {
 		jQuery( this.element ).find( '.mapboxgl-canvas-container, .maplibregl-canvas-container' ).remove();
 	}
 
-	collapseCompactMapLibreAttribution() {
+	shouldStartControlsCollapsed() {
+		const width =
+			this.element.getBoundingClientRect().width ||
+			this.element.clientWidth ||
+			0;
+		const shouldCollapse = width > 0 && width <= SMALL_MAP_CONTROL_MAX_WIDTH;
+
+		this.element.classList.toggle( 'jeo-small-controls', shouldCollapse );
+		return shouldCollapse;
+	}
+
+	queueCompactAttributionCollapse() {
+		this.collapseCompactAttribution();
+		window.requestAnimationFrame( () => this.collapseCompactAttribution() );
+		[ 100, 500, 1000 ].forEach( ( delay ) => {
+			window.setTimeout(
+				() => this.collapseCompactAttribution(),
+				delay
+			);
+		} );
+	}
+
+	collapseCompactAttribution() {
 		const attributionControl = this.element.querySelector(
-			'details.maplibregl-ctrl-attrib.maplibregl-compact'
+			'.mapboxgl-ctrl-attrib.mapboxgl-compact, .maplibregl-ctrl-attrib.maplibregl-compact'
 		);
 
 		if ( attributionControl ) {
-			attributionControl.classList.remove( 'maplibregl-compact-show' );
+			attributionControl.classList.remove(
+				'mapboxgl-compact-show',
+				'maplibregl-compact-show'
+			);
 			attributionControl.removeAttribute( 'open' );
 		}
+	}
+
+	syncSmallMapControlState() {
+		if ( ! this.shouldStartControlsCollapsed() ) {
+			return;
+		}
+
+		const layersControl = this.element.querySelector( 'nav.layers-selection' );
+		const layersTitle = layersControl?.querySelector( '.layer-selection-title' );
+		const layersWrapper = layersControl?.querySelector( '.layers-wrapper' );
+		const layersArrow = layersTitle?.querySelector( '.arrow-icon' );
+
+		if ( layersTitle && layersWrapper ) {
+			layersControl.classList.add( 'hidden' );
+			layersWrapper.style.display = 'none';
+			layersArrow?.classList.remove( 'active' );
+		}
+
+		const legendControl = this.element.querySelector( '.legend-container' );
+		const legendTitle = legendControl?.querySelector( '.legends-title' );
+		const legendContent = legendControl?.querySelector( '.hideable-content' );
+		const legendArrow = legendTitle?.querySelector( '.arrow-icon' );
+
+		if ( legendTitle && legendContent ) {
+			legendControl.classList.add( 'hidden' );
+			legendContent.style.display = 'none';
+			legendArrow?.classList.remove( 'active' );
+		}
+
+		this.queueCompactAttributionCollapse();
 	}
 
 	syncAttributionSpacing() {
@@ -428,6 +481,130 @@ export default class JeoMap {
 		window.requestAnimationFrame( updateSpacing );
 	}
 
+	bindAlignedFullscreenReset() {
+		if ( ! this.element.matches( '.alignleft, .alignright' ) ) {
+			return;
+		}
+
+		const ownerDoc = this.element.ownerDocument || document;
+		const pseudoFullscreenClasses = [
+			'mapboxgl-pseudo-fullscreen',
+			'maplibregl-pseudo-fullscreen',
+		];
+		const fullscreenControlSelector = [
+			'.mapboxgl-ctrl-fullscreen',
+			'.mapboxgl-ctrl-shrink',
+			'.maplibregl-ctrl-fullscreen',
+			'.maplibregl-ctrl-shrink',
+		].join( ',' );
+		const shrinkControlSelector = [
+			'.mapboxgl-ctrl-shrink',
+			'.maplibregl-ctrl-shrink',
+		].join( ',' );
+
+		let previousStyle = null;
+		let previousSize = null;
+		let trackedFullscreen = false;
+
+		const isNativeFullscreen = () =>
+			ownerDoc.fullscreenElement === this.element ||
+			ownerDoc.webkitFullscreenElement === this.element;
+
+		const hasPseudoFullscreenClass = () =>
+			pseudoFullscreenClasses.some( ( className ) =>
+				this.element.classList.contains( className )
+			);
+
+		const isFullscreenActive = () =>
+			isNativeFullscreen() ||
+			( hasPseudoFullscreenClass() &&
+				this.element.querySelector( shrinkControlSelector ) );
+
+		const resizeMap = () => {
+			if ( typeof this.map?.resize !== 'function' ) {
+				return;
+			}
+			window.requestAnimationFrame( () => this.map.resize() );
+			window.setTimeout( () => this.map.resize(), 50 );
+			window.setTimeout( () => this.map.resize(), 250 );
+		};
+
+		const restorePreviousStyle = () => {
+			if ( previousStyle === null ) {
+				this.element.removeAttribute( 'style' );
+			} else {
+				this.element.setAttribute( 'style', previousStyle );
+			}
+		};
+
+		const applyPreviousSize = () => {
+			if ( ! previousSize?.width || ! previousSize?.height ) {
+				return false;
+			}
+
+			this.element.style.width = `${ previousSize.width }px`;
+			this.element.style.height = `${ previousSize.height }px`;
+			return true;
+		};
+
+		const releasePreviousSize = () => {
+			restorePreviousStyle();
+			previousStyle = null;
+			previousSize = null;
+			resizeMap();
+		};
+
+		const restoreAfterExit = () => {
+			window.setTimeout( () => {
+				if ( ! trackedFullscreen || isFullscreenActive() ) {
+					return;
+				}
+
+				trackedFullscreen = false;
+				pseudoFullscreenClasses.forEach( ( className ) => {
+					this.element.classList.remove( className );
+				} );
+
+				restorePreviousStyle();
+				const constrained = applyPreviousSize();
+				resizeMap();
+
+				if ( constrained ) {
+					window.requestAnimationFrame( () => {
+						window.requestAnimationFrame( releasePreviousSize );
+					} );
+					window.setTimeout( releasePreviousSize, 300 );
+				} else {
+					previousStyle = null;
+					previousSize = null;
+				}
+			}, 0 );
+		};
+
+		this.element.addEventListener(
+			'click',
+			( event ) => {
+				if ( ! event.target.closest( fullscreenControlSelector ) ) {
+					return;
+				}
+
+				if ( ! isFullscreenActive() ) {
+					previousStyle = this.element.getAttribute( 'style' );
+					previousSize = this.element.getBoundingClientRect();
+					trackedFullscreen = true;
+				}
+
+				restoreAfterExit();
+				window.setTimeout( restoreAfterExit, 100 );
+				window.setTimeout( restoreAfterExit, 300 );
+			},
+			true
+		);
+
+		ownerDoc.addEventListener( 'fullscreenchange', restoreAfterExit );
+		ownerDoc.addEventListener( 'webkitfullscreenchange', restoreAfterExit );
+	}
+
 	/**
 	 * Adds the "More" button that will open the Content of the Map post in an overlayer
 	 *
@@ -436,6 +613,7 @@ export default class JeoMap {
 	addMoreButtonAndLegends() {
 		const container = document.createElement( 'div' );
 		container.classList.add( 'legend-container' );
+		const startCollapsed = this.shouldStartControlsCollapsed();
 
 		const hideableContent = document.createElement( 'div' );
 		hideableContent.classList.add( 'hideable-content' );
@@ -449,7 +627,15 @@ export default class JeoMap {
 			appearingLegends++;
 		} );
 
-		if ( this.legends.length > 0 && appearingLegends > 0 ) {
+		const hasAppearingLegends =
+			this.legends.length > 0 && appearingLegends > 0;
+
+		if ( hasAppearingLegends ) {
+			if ( startCollapsed ) {
+				container.classList.add( 'hidden' );
+				hideableContent.style.display = 'none';
+			}
+
 			/*const legendsTitle = document.createElement( 'div' );
 			legendsTitle.classList.add( 'legends-title' );
 			legendsTitle.innerHTML = '<span class="text"> Legend </span>';*/
@@ -471,7 +657,10 @@ export default class JeoMap {
 			legendsTitle.appendChild( legendTextIcon );
 
 			const legendsHideIcon = document.createElement( 'i' );
-			legendsHideIcon.classList.add( 'arrow-icon', 'active' );
+			legendsHideIcon.classList.add( 'arrow-icon' );
+			if ( ! startCollapsed ) {
+				legendsHideIcon.classList.add( 'active' );
+			}
 
 			legendsTitle.appendChild( legendsHideIcon );
 			container.appendChild( legendsTitle );
@@ -513,6 +702,46 @@ export default class JeoMap {
 
 				legendContainer.appendChild( legend.render() );
 				legendsWrapper.appendChild( legendContainer );
+			} );
+		}
+
+		if ( ! hasAppearingLegends ) {
+			if ( startCollapsed ) {
+				container.classList.add( 'hidden' );
+				hideableContent.style.display = 'none';
+			}
+
+			const moreInfoTitle = document.createElement( 'div' );
+			moreInfoTitle.classList.add( 'legends-title', 'more-info-title' );
+			moreInfoTitle.setAttribute( 'role', 'button' );
+			moreInfoTitle.tabIndex = 0;
+
+			const moreInfoTextIcon = document.createElement( 'div' );
+			moreInfoTextIcon.classList.add( 'text-icon' );
+
+			const moreInfoIcon = document.createElement( 'i' );
+			moreInfoIcon.classList.add( 'info-icon' );
+
+			const moreInfoText = document.createElement( 'span' );
+			moreInfoText.classList.add( 'text' );
+			moreInfoText.innerText = ` ${ __( 'Info', 'jeo' ) } `;
+
+			moreInfoTextIcon.appendChild( moreInfoIcon );
+			moreInfoTextIcon.appendChild( moreInfoText );
+			moreInfoTitle.appendChild( moreInfoTextIcon );
+			container.appendChild( moreInfoTitle );
+
+			const openMoreInfoModal = ( e ) => {
+				e.preventDefault();
+				e.stopPropagation();
+				jQuery( container ).siblings( '.more-info-overlayer' ).show();
+			};
+
+			moreInfoTitle.addEventListener( 'click', openMoreInfoModal );
+			moreInfoTitle.addEventListener( 'keydown', ( e ) => {
+				if ( e.key === 'Enter' || e.key === ' ' ) {
+					openMoreInfoModal( e );
+				}
 			} );
 		}
 

--- a/src/js/src/map-blocks/map-editor.css
+++ b/src/js/src/map-blocks/map-editor.css
@@ -153,19 +153,37 @@
 	width: 100%;
 }
 
-/* Content editor map blocks need an explicit width when floated left/right.
-   Otherwise the wrapper can shrink to 0 because the interactive map internals
-   are absolutely positioned. */
-.wp-block-jeo-map.alignleft,
-.wp-block-jeo-map.alignright {
-	--jeo-aligned-map-base-width: var( --wp--style--global--content-size, 645px );
-	--jeo-aligned-map-expanded-width: calc( var( --jeo-aligned-map-base-width ) * 1.6 );
-	box-sizing: border-box;
-	display: table;
-	max-width: none;
-	width: auto;
+/* The map component is absolutely positioned internally, so the editor preview
+   needs a real container size before the map runtime can measure it. */
+.wp-block-jeo-map .jeo-preview-area {
+	height: 50vh;
+	max-height: 500px;
+	min-height: 320px;
+	width: 100%;
 }
 
+.wp-block-jeo-map .mapboxgl-map,
+.wp-block-jeo-map .maplibregl-map {
+	height: 100%;
+	width: 100%;
+}
+
+/* In the block editor, alignment may live on Gutenberg's wrapper as
+   data-align rather than on the JEO block element itself. */
+.wp-block[data-align="left"] > .wp-block-jeo-map,
+.wp-block[data-align="right"] > .wp-block-jeo-map,
+.wp-block-jeo-map.alignleft,
+.wp-block-jeo-map.alignright {
+	--jeo-aligned-map-width: 420px;
+	--jeo-aligned-map-aspect-ratio: 8 / 9;
+	box-sizing: border-box;
+	display: table;
+	max-width: min( 50%, calc( 100vw - 2rem ) );
+	min-width: 0;
+	width: min( var( --jeo-aligned-map-width ), 50%, calc( 100vw - 2rem ) );
+}
+
+.wp-block[data-align="left"] > .wp-block-jeo-map,
 .wp-block-jeo-map.alignleft {
 	margin-right: 1em;
 	margin-left: 0;
@@ -173,6 +191,7 @@
 	margin-bottom: 0.5em;
 }
 
+.wp-block[data-align="right"] > .wp-block-jeo-map,
 .wp-block-jeo-map.alignright {
 	margin-left: 1em;
 	margin-right: 0;
@@ -180,38 +199,61 @@
 	margin-bottom: 0.5em;
 }
 
+.wp-block[data-align="left"] > .wp-block-jeo-map .jeo-preview-area,
+.wp-block[data-align="right"] > .wp-block-jeo-map .jeo-preview-area,
 .wp-block-jeo-map.alignleft .jeo-preview-area,
 .wp-block-jeo-map.alignright .jeo-preview-area,
+.wp-block[data-align="left"] > .wp-block-jeo-map .mapboxgl-map,
+.wp-block[data-align="right"] > .wp-block-jeo-map .mapboxgl-map,
 .wp-block-jeo-map.alignleft .mapboxgl-map,
 .wp-block-jeo-map.alignright .mapboxgl-map,
+.wp-block[data-align="left"] > .wp-block-jeo-map .maplibregl-map,
+.wp-block[data-align="right"] > .wp-block-jeo-map .maplibregl-map,
 .wp-block-jeo-map.alignleft .maplibregl-map,
 .wp-block-jeo-map.alignright .maplibregl-map {
 	max-width: none;
 	width: 100%;
 }
 
+.wp-block[data-align="left"] > .wp-block-jeo-map .jeo-preview-area,
+.wp-block[data-align="right"] > .wp-block-jeo-map .jeo-preview-area,
 .wp-block-jeo-map.alignleft .jeo-preview-area,
 .wp-block-jeo-map.alignright .jeo-preview-area {
-	min-width: min( var( --jeo-aligned-map-base-width ), calc( 100vw - 2rem ) );
-	width: min( var( --jeo-aligned-map-expanded-width ), calc( 100vw - 2rem ) );
+	aspect-ratio: var( --jeo-aligned-map-aspect-ratio );
+	height: auto;
+	max-height: none;
+	min-height: 0;
 }
 
 @media (max-width: 782px) {
+	.wp-block[data-align="left"] > .wp-block-jeo-map,
+	.wp-block[data-align="right"] > .wp-block-jeo-map,
 	.wp-block-jeo-map.alignleft,
 	.wp-block-jeo-map.alignright {
 		display: block;
 		float: none;
+		max-width: none;
 		margin-left: 0;
 		margin-right: 0;
 		width: 100%;
 	}
 
+	.wp-block[data-align="left"] > .wp-block-jeo-map .jeo-preview-area,
+	.wp-block[data-align="right"] > .wp-block-jeo-map .jeo-preview-area,
 	.wp-block-jeo-map.alignleft .jeo-preview-area,
 	.wp-block-jeo-map.alignright .jeo-preview-area,
+	.wp-block[data-align="left"] > .wp-block-jeo-map .mapboxgl-map,
+	.wp-block[data-align="right"] > .wp-block-jeo-map .mapboxgl-map,
 	.wp-block-jeo-map.alignleft .mapboxgl-map,
 	.wp-block-jeo-map.alignright .mapboxgl-map,
+	.wp-block[data-align="left"] > .wp-block-jeo-map .maplibregl-map,
+	.wp-block[data-align="right"] > .wp-block-jeo-map .maplibregl-map,
 	.wp-block-jeo-map.alignleft .maplibregl-map,
 	.wp-block-jeo-map.alignright .maplibregl-map {
+		aspect-ratio: auto;
+		height: 50vh;
+		max-height: 500px;
+		min-height: 320px;
 		min-width: 0;
 		width: 100%;
 	}

--- a/src/js/src/map-blocks/map-editor.js
+++ b/src/js/src/map-blocks/map-editor.js
@@ -76,7 +76,7 @@ export default function MapEditor ( {attributes, setAttributes } ) {
 									}
 								}
 							} }
-							style={ { height: '50vh' } }
+							style={ { height: '100%', width: '100%' } }
 							latitude={ loadedMap.meta.center_lat || mapDefaults.lat }
 							longitude={ loadedMap.meta.center_lon || mapDefaults.lng }
 							zoom={ loadedMap.meta.initial_zoom || mapDefaults.zoom }

--- a/src/js/src/map-blocks/onetime-map-editor.css
+++ b/src/js/src/map-blocks/onetime-map-editor.css
@@ -243,18 +243,37 @@ ul.jeo-layers-list .components-card {
 	margin-inline-end: 1em;
 }
 
-/* One-time map blocks need the same explicit floated width in the editor as
-   regular maps, otherwise the wrapper can collapse to zero width. */
-.wp-block-jeo-onetime-map.alignleft,
-.wp-block-jeo-onetime-map.alignright {
-	--jeo-aligned-map-base-width: var( --wp--style--global--content-size, 645px );
-	--jeo-aligned-map-expanded-width: calc( var( --jeo-aligned-map-base-width ) * 1.6 );
-	box-sizing: border-box;
-	display: table;
-	max-width: none;
-	width: auto;
+/* The map component is absolutely positioned internally, so the editor preview
+   needs a real container size before the map runtime can measure it. */
+.wp-block-jeo-onetime-map .jeo-preview-area {
+	height: 50vh;
+	max-height: 500px;
+	min-height: 320px;
+	width: 100%;
 }
 
+.wp-block-jeo-onetime-map .mapboxgl-map,
+.wp-block-jeo-onetime-map .maplibregl-map {
+	height: 100%;
+	width: 100%;
+}
+
+/* In the block editor, alignment may live on Gutenberg's wrapper as
+   data-align rather than on the JEO block element itself. */
+.wp-block[data-align="left"] > .wp-block-jeo-onetime-map,
+.wp-block[data-align="right"] > .wp-block-jeo-onetime-map,
+.wp-block-jeo-onetime-map.alignleft,
+.wp-block-jeo-onetime-map.alignright {
+	--jeo-aligned-map-width: 420px;
+	--jeo-aligned-map-aspect-ratio: 8 / 9;
+	box-sizing: border-box;
+	display: table;
+	max-width: min( 50%, calc( 100vw - 2rem ) );
+	min-width: 0;
+	width: min( var( --jeo-aligned-map-width ), 50%, calc( 100vw - 2rem ) );
+}
+
+.wp-block[data-align="left"] > .wp-block-jeo-onetime-map,
 .wp-block-jeo-onetime-map.alignleft {
 	margin-right: 1em;
 	margin-left: 0;
@@ -262,6 +281,7 @@ ul.jeo-layers-list .components-card {
 	margin-bottom: 0.5em;
 }
 
+.wp-block[data-align="right"] > .wp-block-jeo-onetime-map,
 .wp-block-jeo-onetime-map.alignright {
 	margin-left: 1em;
 	margin-right: 0;
@@ -269,38 +289,61 @@ ul.jeo-layers-list .components-card {
 	margin-bottom: 0.5em;
 }
 
+.wp-block[data-align="left"] > .wp-block-jeo-onetime-map .jeo-preview-area,
+.wp-block[data-align="right"] > .wp-block-jeo-onetime-map .jeo-preview-area,
 .wp-block-jeo-onetime-map.alignleft .jeo-preview-area,
 .wp-block-jeo-onetime-map.alignright .jeo-preview-area,
+.wp-block[data-align="left"] > .wp-block-jeo-onetime-map .mapboxgl-map,
+.wp-block[data-align="right"] > .wp-block-jeo-onetime-map .mapboxgl-map,
 .wp-block-jeo-onetime-map.alignleft .mapboxgl-map,
 .wp-block-jeo-onetime-map.alignright .mapboxgl-map,
+.wp-block[data-align="left"] > .wp-block-jeo-onetime-map .maplibregl-map,
+.wp-block[data-align="right"] > .wp-block-jeo-onetime-map .maplibregl-map,
 .wp-block-jeo-onetime-map.alignleft .maplibregl-map,
 .wp-block-jeo-onetime-map.alignright .maplibregl-map {
 	max-width: none;
 	width: 100%;
 }
 
+.wp-block[data-align="left"] > .wp-block-jeo-onetime-map .jeo-preview-area,
+.wp-block[data-align="right"] > .wp-block-jeo-onetime-map .jeo-preview-area,
 .wp-block-jeo-onetime-map.alignleft .jeo-preview-area,
 .wp-block-jeo-onetime-map.alignright .jeo-preview-area {
-	min-width: min( var( --jeo-aligned-map-base-width ), calc( 100vw - 2rem ) );
-	width: min( var( --jeo-aligned-map-expanded-width ), calc( 100vw - 2rem ) );
+	aspect-ratio: var( --jeo-aligned-map-aspect-ratio );
+	height: auto;
+	max-height: none;
+	min-height: 0;
 }
 
 @media (max-width: 782px) {
+	.wp-block[data-align="left"] > .wp-block-jeo-onetime-map,
+	.wp-block[data-align="right"] > .wp-block-jeo-onetime-map,
 	.wp-block-jeo-onetime-map.alignleft,
 	.wp-block-jeo-onetime-map.alignright {
 		display: block;
 		float: none;
+		max-width: none;
 		margin-left: 0;
 		margin-right: 0;
 		width: 100%;
 	}
 
+	.wp-block[data-align="left"] > .wp-block-jeo-onetime-map .jeo-preview-area,
+	.wp-block[data-align="right"] > .wp-block-jeo-onetime-map .jeo-preview-area,
 	.wp-block-jeo-onetime-map.alignleft .jeo-preview-area,
 	.wp-block-jeo-onetime-map.alignright .jeo-preview-area,
+	.wp-block[data-align="left"] > .wp-block-jeo-onetime-map .mapboxgl-map,
+	.wp-block[data-align="right"] > .wp-block-jeo-onetime-map .mapboxgl-map,
 	.wp-block-jeo-onetime-map.alignleft .mapboxgl-map,
 	.wp-block-jeo-onetime-map.alignright .mapboxgl-map,
+	.wp-block[data-align="left"] > .wp-block-jeo-onetime-map .maplibregl-map,
+	.wp-block[data-align="right"] > .wp-block-jeo-onetime-map .maplibregl-map,
 	.wp-block-jeo-onetime-map.alignleft .maplibregl-map,
 	.wp-block-jeo-onetime-map.alignright .maplibregl-map {
+		aspect-ratio: auto;
+		height: 50vh;
+		max-height: 500px;
+		min-height: 320px;
 		min-width: 0;
 		width: 100%;
 	}

--- a/src/js/src/map-blocks/onetime-map-editor.js
+++ b/src/js/src/map-blocks/onetime-map-editor.js
@@ -119,7 +119,7 @@ export default function OnetimeMapEditor ( { attributes, setAttributes } ) {
 				<Map
 					key={ `${ key }:${ currentZoom }:${ layerSettingsKey }` }
 					ref={ mapRef }
-					style={ { height: '50vh' } }
+					style={ { height: '100%', width: '100%' } }
 					latitude={ normalizedAttributes.center_lat }
 					longitude={ normalizedAttributes.center_lon }
 					zoom={ currentZoom || mapDefaults.zoom }


### PR DESCRIPTION
## Summary

- Give left/right aligned map blocks a stable width and aspect ratio so surrounding content can flow beside them without the map stretching across the article.
- Make aligned maps become full-width on small screens, matching the expected mobile reading flow.
- Improve editor previews for regular and one-time map blocks so the map runtime has a real, proportionate container to measure.
- Collapse layers, legends, compact attributions, and info-only controls on small maps; info-only compact controls now open the information overlay directly.
- Reset compact Mapbox attribution button styles so theme-level button rules do not distort the control, while keeping required attribution/logo behavior intact.
- Restore aligned map sizing after exiting fullscreen so pseudo-fullscreen does not leave the block expanded.

## Root Cause

Aligned maps were relying on wide/table sizing while the map canvas is positioned and measured by the map runtime. In narrow aligned contexts that left the plugin vulnerable to theme layout rules, collapsed editor preview dimensions, global button styling, and Mapbox/MapLibre fullscreen or attribution state that did not always return to the block's original size.

## Validation

- `node --check src/js/src/jeo-map/class-jeo-map.js`
- `node --check src/js/src/map-blocks/map-editor.js`
- `node --check src/js/src/map-blocks/onetime-map-editor.js`
- `npx sass src/css/jeo-map.scss /tmp/jeo-map-check.css --style=compressed --no-source-map`
- `npm run build` completed successfully. The build emitted local WP-CLI PHP deprecation warnings while generating i18n JSON, but exited successfully.
- Manually validated on `infoamazonia.local` before porting: aligned map flow, fullscreen exit, compact info-only controls, compact attribution behavior, and small-screen full-width behavior.