### PR TITLE
Stabilize storymap rich text editing panels

### DIFF
--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -593,7 +593,7 @@ class Jeo {
 			'jeo-map-blocks',
 			JEO_BASEURL . '/js/build/mapBlocks.css',
 			array( 'mapgl', 'mapgl-react-style' ),
-			JEO_VERSION,
+			$map_blocks_assets['version'] ?? JEO_VERSION,
 		);
 		wp_register_script(
 			'jeo-map-blocks',

--- a/src/js/src/map-blocks/storymap-editor.js
+++ b/src/js/src/map-blocks/storymap-editor.js
@@ -1121,7 +1121,10 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 																	editor={ ClassicEditor }
 																	data={ slide.title }
 																	config={ titleEditorConfig }
-																	onReady={ ( editor ) => setupEditor( editor, { singleLine: true } ) }
+																	onReady={ ( editor ) => setupEditor( editor, {
+																		singleLine: true,
+																		stabilizeOuterScroll: true,
+																	} ) }
 																	onChange={ ( event, editor ) => {
 																		setCurrentSlideIndex( slideIndex );
 

--- a/src/js/src/map-blocks/storymap-editor.js
+++ b/src/js/src/map-blocks/storymap-editor.js
@@ -392,6 +392,82 @@ function configureSingleLineEditor( editor ) {
 	}, true );
 }
 
+function stabilizeStorymapEditorScroll( editor ) {
+	const editableElement = editor.ui.getEditableElement();
+
+	if ( ! editableElement || editableElement.dataset.jeoStableOuterScroll === 'true' ) {
+		return;
+	}
+
+	editableElement.dataset.jeoStableOuterScroll = 'true';
+
+	const getScrollContainer = () => (
+		editableElement.closest( '.interface-interface-skeleton__content' ) ||
+		document.querySelector( '.interface-interface-skeleton__content' )
+	);
+
+	let anchoredScrollTop = null;
+	let lastCaptureTime = 0;
+
+	const captureScroll = () => {
+		const scrollContainer = getScrollContainer();
+
+		if ( ! scrollContainer ) {
+			return;
+		}
+
+		anchoredScrollTop = scrollContainer.scrollTop;
+		lastCaptureTime = Date.now();
+	};
+
+	const restoreScroll = () => {
+		const scrollContainer = getScrollContainer();
+
+		if (
+			! scrollContainer ||
+			anchoredScrollTop === null ||
+			Date.now() - lastCaptureTime > 1000
+		) {
+			return;
+		}
+
+		const restoreIfStillEditing = () => {
+			if (
+				document.activeElement !== editableElement &&
+				! editableElement.contains( document.activeElement )
+			) {
+				return;
+			}
+
+			if ( Math.abs( scrollContainer.scrollTop - anchoredScrollTop ) > 1 ) {
+				scrollContainer.scrollTop = anchoredScrollTop;
+			}
+		};
+
+		window.requestAnimationFrame( restoreIfStillEditing );
+		window.setTimeout( restoreIfStillEditing, 0 );
+		window.setTimeout( restoreIfStillEditing, 80 );
+	};
+
+	const shouldStabilizeKey = ( event ) => (
+		! event.metaKey &&
+		! event.ctrlKey &&
+		! event.altKey &&
+		( event.key.length === 1 || [ 'Enter', 'Backspace', 'Delete' ].includes( event.key ) )
+	);
+
+	editableElement.addEventListener( 'beforeinput', captureScroll, true );
+	editableElement.addEventListener( 'keydown', ( event ) => {
+		if ( shouldStabilizeKey( event ) ) {
+			captureScroll();
+		}
+	}, true );
+	editableElement.addEventListener( 'input', restoreScroll, true );
+	editableElement.addEventListener( 'keyup', restoreScroll, true );
+
+	editor.model.document.on( 'change:data', restoreScroll );
+}
+
 export default function StoryMapEditor ( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps( { className: 'jeo-mapblock storymap' } );
 	const instanceId = useId();
@@ -644,6 +720,10 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 		if ( options.singleLine ) {
 			configureSingleLineEditor( editor );
 		}
+
+		if ( options.stabilizeOuterScroll ) {
+			stabilizeStorymapEditorScroll( editor );
+		}
 	};
 
 	const moveSlide = ( fromIndex, toIndex ) => {
@@ -763,18 +843,22 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 									</Button>
 								</div>
 								<label className="input-label">{ __('Brief description', 'jeo' ) }</label>
-								<CKEditor
-									editor={ ClassicEditor }
-									data={ attributes.description }
-									config={ editorConfig }
-									onReady={ setupEditor }
-									onChange={ ( event, editor ) =>  {
-										setAttributes( {
-											...attributes,
-											description: editor.getData(),
-										} );
-									} }
-								/>
+								<div className="storymap-description-editor">
+									<CKEditor
+										editor={ ClassicEditor }
+										data={ attributes.description }
+										config={ editorConfig }
+										onReady={ ( editor ) => setupEditor( editor, {
+											stabilizeOuterScroll: true,
+										} ) }
+										onChange={ ( event, editor ) =>  {
+											setAttributes( {
+												...attributes,
+												description: editor.getData(),
+											} );
+										} }
+									/>
+								</div>
 								<CheckboxControl
 									className="introduction-button"
 									label={ __( 'Show story map introduction', 'jeo'  ) }
@@ -1056,6 +1140,7 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 														) }</span>
 														{ /* Same isolation for the content editor. */ }
 														<div
+															className="storymap-content-editor"
 															onMouseDown={ ( e ) => e.stopPropagation() }
 															onKeyDown={ ( e ) => e.stopPropagation() }
 														>
@@ -1063,7 +1148,9 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 																editor={ ClassicEditor }
 																data={ slide.content }
 																config={ editorConfig }
-																onReady={ setupEditor }
+																onReady={ ( editor ) => setupEditor( editor, {
+																	stabilizeOuterScroll: true,
+																} ) }
 																onChange={ ( event, editor ) => {
 																	setCurrentSlideIndex( slideIndex );
 

--- a/src/js/src/map-blocks/storymap-editor.scss
+++ b/src/js/src/map-blocks/storymap-editor.scss
@@ -97,12 +97,25 @@
 	overscroll-behavior: contain;
 }
 
+.slides-settings .storymap-content-editor {
+	.ck.ck-content.ck-editor__editable.ck-blurred,
+	.ck.ck-content.ck-editor__editable.ck-focused {
+		height: 300px !important;
+		min-height: 300px;
+		max-height: 300px;
+		overflow-y: auto !important;
+		overflow-anchor: none;
+		overscroll-behavior: contain;
+		scrollbar-gutter: stable;
+	}
+}
+
 .storymap-title-editor {
 	.ck.ck-content.ck-editor__editable.ck-blurred,
 	.ck.ck-content.ck-editor__editable.ck-focused {
-		height: 44px !important;
-		min-height: 44px;
-		max-height: 44px;
+		height: 72px !important;
+		min-height: 72px;
+		max-height: none;
 		overflow-y: hidden;
 	}
 }
@@ -132,6 +145,18 @@
 		}
 		textarea {
 			height: 150px;
+		}
+	}
+	.storymap-description-editor {
+		.ck.ck-content.ck-editor__editable.ck-blurred,
+		.ck.ck-content.ck-editor__editable.ck-focused {
+			height: 300px !important;
+			min-height: 300px;
+			max-height: 300px;
+			overflow-y: auto !important;
+			overflow-anchor: none;
+			overscroll-behavior: contain;
+			scrollbar-gutter: stable;
 		}
 	}
 	.input-label {
@@ -356,7 +381,8 @@
 		}
 	}
 	.slides-container {
-		height: 330px;
+		height: min( 650px, calc( 85vh - 120px ) );
+		max-height: calc( 100vh - 160px );
 		overflow-y: scroll;
 		overflow-x: hidden;
 		padding-inline-end: 16px;

--- a/src/js/src/map-blocks/storymap-editor.scss
+++ b/src/js/src/map-blocks/storymap-editor.scss
@@ -113,10 +113,13 @@
 .storymap-title-editor {
 	.ck.ck-content.ck-editor__editable.ck-blurred,
 	.ck.ck-content.ck-editor__editable.ck-focused {
-		height: 72px !important;
+		height: auto !important;
 		min-height: 72px;
-		max-height: none;
-		overflow-y: hidden;
+		max-height: 144px;
+		overflow-y: auto !important;
+		overflow-anchor: none;
+		overscroll-behavior: contain;
+		scrollbar-gutter: stable;
 	}
 }
 


### PR DESCRIPTION
## Summary

- Keep the story settings description editor and slide content editor at stable heights, with long text scrolling inside each CKEditor instead of growing the surrounding panel.
- Increase the slide title editor height so longer titles are not cramped or internally clipped.
- Preserve the Gutenberg editor scroll position while typing, pressing Enter, or deleting inside storymap CKEditor instances so the map canvas and panels do not jump while editing.
- Version the storymap editor stylesheet from the generated `mapBlocks.asset.php` metadata so local/editor CSS updates are cache-busted together with the block script.

## Why

Editing multi-line storymap text was uncomfortable because CKEditor content changes could cause the Gutenberg editor scroller to re-anchor around the active caret. In practice, pressing Enter in slide content or story settings moved the storymap canvas and controls instead of keeping the panel stationary while the text changed.

The title field also used a very small fixed height, which made the first storymap slide title field feel undersized. The CSS-only local test confirmed that fixed-height CKEditor areas with internal scrolling remove the growth/shrink behavior, and the remaining movement came from Gutenberg scroll adjustments. This patch contains both parts of the fix.

## What changed

- Added a shared `stabilizeStorymapEditorScroll()` setup for CKEditor instances that captures the Gutenberg content scroller before text input and restores it immediately after CKEditor updates while focus remains in the same editor.
- Applied that scroll stabilization to the story settings description editor and the slide content editor.
- Added wrapper classes for the story description and slide content editors so their layout rules are explicit.
- Set the story description and slide content editors to fixed 300px editing areas with internal scrollbars.
- Raised the slide title editor to 72px and removed its previous 44px max-height limit.
- Made the slides settings container taller and viewport-aware so the expanded editing controls have enough room.
- Registered the map blocks editor stylesheet with the generated asset version, matching the script cache-busting behavior.

## Validation

- Tested manually in the local `infoamazonia.local` storymap editor, including multi-line typing and deletion in slide content and story settings fields.
- Verified the Gutenberg editor scroll position stayed stable while CKEditor internal scroll handled long content.
- Ran `npm run build` successfully. The command emits existing WP-CLI PHP deprecation warnings in the local environment, but webpack and i18n generation completed successfully.
- Ran `npm run test:unit -- --runInBand` successfully: 14 suites and 43 tests passed.
