### PR TITLE
Fix circle legend editor controls

### DIFF
--- a/src/js/src/posts-sidebar/legends-editor/editors/circle.js
+++ b/src/js/src/posts-sidebar/legends-editor/editors/circle.js
@@ -1,6 +1,7 @@
 import { Component, Fragment } from '@wordpress/element';
 import { Button, Dropdown, ColorPicker } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { RangeControl, TextControl } from '../../../shared/wp-form-controls';
 import '../editors/circle.css';
 import JeoLegend from '../../../../../includes/legend-types/JeoLegend';
 


### PR DESCRIPTION
## Summary

- Import the shared `TextControl` and `RangeControl` wrappers in the circle legend editor.
- Keep the circle legend editor behavior otherwise unchanged.
- Limit this PR to the circle-size legend crash fix; the separate legend crypto compatibility follow-up remains in PR #563.

## Root Cause

Selecting the circle-size legend type mounts `CircleEditor` and its `CircleItem` rows. Those rows render `TextControl` and `RangeControl`, but `circle.js` did not import either component. Once React tried to render the selected legend editor, the missing bindings caused a runtime error, which WordPress surfaced as the generic "The editor has encountered an unexpected error" message.

## User Impact

With the controls imported from the same shared WordPress form-control wrappers used by the other legend editors, circle-size legends can be selected and edited without crashing the post editor. This restores the expected flow for choosing a circle legend from the layer editor sidebar.

## Validation

- `npm run build:assets`
