### PR TITLE
Optimize storymap admin listing memory usage

### DIFF
--- a/src/includes/storymap/class-storymap.php
+++ b/src/includes/storymap/class-storymap.php
@@ -27,6 +27,13 @@ class Storymap {
 	public $post_type = 'storymap';
 
 	/**
+	 * Post IDs cached with lightweight admin-list objects during this request.
+	 *
+	 * @var int[]
+	 */
+	private $lightweight_admin_list_cache_ids = array();
+
+	/**
 	 * Register storymap hooks.
 	 *
 	 * @return void
@@ -37,6 +44,13 @@ class Storymap {
 		add_action( 'admin_init', array( $this, 'add_capabilities' ) );
 
 		add_action( 'pre_get_posts', array( $this, 'show_on_archives' ) );
+		add_action( 'pre_get_posts', array( $this, 'prepare_admin_list_query' ) );
+		add_filter( 'request', array( $this, 'paginate_admin_list_request' ) );
+		add_filter( 'posts_fields', array( $this, 'lightweight_admin_list_fields' ), 10, 2 );
+		add_filter( 'the_posts', array( $this, 'prime_lightweight_admin_list_cache' ), 10, 2 );
+		add_filter( 'manage_' . $this->post_type . '_posts_columns', array( $this, 'remove_expensive_admin_list_columns' ), 20 );
+		add_filter( 'quick_edit_dropdown_pages_args', array( $this, 'disable_admin_parent_dropdown' ) );
+		add_action( 'shutdown', array( $this, 'clear_lightweight_admin_list_cache' ) );
 
 		add_filter( 'rest_prepare_storymap', array( $this, 'prepare_rest_response' ), 10, 2 );
 
@@ -169,6 +183,214 @@ class Storymap {
 				$types[] = $this->post_type;
 				$query->set( 'post_types', $types );
 		}
+	}
+
+	/**
+	 * Keep the storymap admin list paginated.
+	 *
+	 * WordPress treats hierarchical post types like pages and loads every item
+	 * to build the tree. Storymaps can contain large serialized block payloads,
+	 * so the default list table query can exhaust memory on content-heavy sites.
+	 *
+	 * @param array $query_vars Request query vars.
+	 * @return array
+	 */
+	public function paginate_admin_list_request( $query_vars ) {
+		if ( ! is_admin() ) {
+			return $query_vars;
+		}
+		if ( 'edit.php' !== ( $GLOBALS['pagenow'] ?? '' ) ) {
+			return $query_vars;
+		}
+		if ( ( $query_vars['post_type'] ?? '' ) !== $this->post_type ) {
+			return $query_vars;
+		}
+		if ( 'menu_order title' !== ( $query_vars['orderby'] ?? '' ) ) {
+			return $query_vars;
+		}
+		if ( -1 !== (int) ( $query_vars['posts_per_page'] ?? 0 ) ) {
+			return $query_vars;
+		}
+		if ( 'id=>parent' !== ( $query_vars['fields'] ?? '' ) ) {
+			return $query_vars;
+		}
+
+		$posts_per_page = (int) get_user_option( 'edit_' . $this->post_type . '_per_page' );
+		if ( $posts_per_page < 1 ) {
+			$posts_per_page = 20;
+		}
+
+		/** This filter is documented in wp-admin/includes/post.php */
+		$posts_per_page = (int) apply_filters( "edit_{$this->post_type}_per_page", $posts_per_page );
+
+		/** This filter is documented in wp-admin/includes/post.php */
+		$posts_per_page = (int) apply_filters( 'edit_posts_per_page', $posts_per_page, $this->post_type );
+		$posts_per_page = max( 1, $posts_per_page );
+
+		$query_vars['orderby']                = 'date';
+		$query_vars['order']                  = 'DESC';
+		$query_vars['posts_per_page']         = $posts_per_page;
+		$query_vars['posts_per_archive_page'] = $posts_per_page;
+		unset( $query_vars['fields'] );
+
+		return $query_vars;
+	}
+
+	/**
+	 * Mark storymap admin list queries to avoid loading full post content.
+	 *
+	 * @param \WP_Query $query Query instance.
+	 * @return void
+	 */
+	public function prepare_admin_list_query( $query ) {
+		if ( ! $this->is_admin_list_query( $query ) ) {
+			return;
+		}
+
+		$query->set( 'cache_results', false );
+		$query->set( 'update_post_meta_cache', false );
+		$query->set( 'jeo_lightweight_storymap_admin_list', true );
+	}
+
+	/**
+	 * Select only lightweight post fields for the storymap admin list.
+	 *
+	 * @param string    $fields Current SELECT fields.
+	 * @param \WP_Query $query Query instance.
+	 * @return string
+	 */
+	public function lightweight_admin_list_fields( $fields, $query ) {
+		if ( ! $query->get( 'jeo_lightweight_storymap_admin_list' ) ) {
+			return $fields;
+		}
+
+		global $wpdb;
+
+		return "{$wpdb->posts}.ID,
+			{$wpdb->posts}.post_author,
+			{$wpdb->posts}.post_date,
+			{$wpdb->posts}.post_date_gmt,
+			'' AS post_content,
+			{$wpdb->posts}.post_title,
+			{$wpdb->posts}.post_excerpt,
+			{$wpdb->posts}.post_status,
+			{$wpdb->posts}.comment_status,
+			{$wpdb->posts}.ping_status,
+			{$wpdb->posts}.post_password,
+			{$wpdb->posts}.post_name,
+			{$wpdb->posts}.to_ping,
+			{$wpdb->posts}.pinged,
+			{$wpdb->posts}.post_modified,
+			{$wpdb->posts}.post_modified_gmt,
+			'' AS post_content_filtered,
+			{$wpdb->posts}.post_parent,
+			{$wpdb->posts}.guid,
+			{$wpdb->posts}.menu_order,
+			{$wpdb->posts}.post_type,
+			{$wpdb->posts}.post_mime_type,
+			{$wpdb->posts}.comment_count";
+	}
+
+	/**
+	 * Cache lightweight row objects so admin-list callbacks do not fetch content.
+	 *
+	 * Core and plugin columns can call get_post( $id ) while rendering each row.
+	 * Without a cache entry, WordPress reloads the full storymap row, including
+	 * the heavy post_content this screen deliberately avoids.
+	 *
+	 * @param \WP_Post[] $posts List query results.
+	 * @param \WP_Query  $query Query instance.
+	 * @return \WP_Post[]
+	 */
+	public function prime_lightweight_admin_list_cache( $posts, $query ) {
+		if ( ! $query->get( 'jeo_lightweight_storymap_admin_list' ) ) {
+			return $posts;
+		}
+
+		foreach ( $posts as $post ) {
+			if ( ! $post instanceof \WP_Post || $this->post_type !== $post->post_type ) {
+				continue;
+			}
+			if ( wp_cache_add( $post->ID, $post, 'posts' ) ) {
+				$this->lightweight_admin_list_cache_ids[] = (int) $post->ID;
+			}
+		}
+
+		return $posts;
+	}
+
+	/**
+	 * Clear request-local lightweight post cache entries.
+	 *
+	 * @return void
+	 */
+	public function clear_lightweight_admin_list_cache() {
+		foreach ( array_unique( $this->lightweight_admin_list_cache_ids ) as $post_id ) {
+			wp_cache_delete( $post_id, 'posts' );
+		}
+
+		$this->lightweight_admin_list_cache_ids = array();
+	}
+
+	/**
+	 * Determine whether the query belongs to the storymap admin list screen.
+	 *
+	 * @param \WP_Query $query Query instance.
+	 * @return bool
+	 */
+	private function is_admin_list_query( $query ) {
+		if ( ! is_admin() ) {
+			return false;
+		}
+		if ( 'edit.php' !== ( $GLOBALS['pagenow'] ?? '' ) ) {
+			return false;
+		}
+		if ( ! $query->is_main_query() ) {
+			return false;
+		}
+
+		return $this->post_type === $query->get( 'post_type' );
+	}
+
+	/**
+	 * Remove columns that force full storymap content parsing in the admin list.
+	 *
+	 * Yoast SEO columns recalculate meta context in the posts table and parse
+	 * full block content, which defeats the lightweight list query.
+	 *
+	 * @param array $columns Admin list columns.
+	 * @return array
+	 */
+	public function remove_expensive_admin_list_columns( $columns ) {
+		foreach ( array_keys( $columns ) as $column_name ) {
+			if ( strpos( $column_name, 'wpseo-' ) === 0 ) {
+				unset( $columns[ $column_name ] );
+			}
+		}
+
+		return $columns;
+	}
+
+	/**
+	 * Avoid loading every storymap into the Quick Edit parent dropdown.
+	 *
+	 * Storymaps do not use parent/child relationships in JEO, and loading all
+	 * storymap content for this hidden dropdown can exhaust memory.
+	 *
+	 * @param array $dropdown_args Arguments passed to wp_dropdown_pages().
+	 * @return array
+	 */
+	public function disable_admin_parent_dropdown( $dropdown_args ) {
+		if ( ! is_admin() ) {
+			return $dropdown_args;
+		}
+		if ( ( $dropdown_args['post_type'] ?? '' ) !== $this->post_type ) {
+			return $dropdown_args;
+		}
+
+		$dropdown_args['post_type'] = '__jeo_no_storymap_parent_options';
+
+		return $dropdown_args;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR optimizes the Story Map admin listing so large production datasets can open `/wp-admin/edit.php?post_type=storymap` without exhausting PHP memory.

The fix keeps the WordPress Screen Options value for items per page working normally, while preventing the list table from loading and parsing full Story Map block payloads for every row.

## Why this is needed

On the local InfoAmazonia copy, Story Maps are the real memory pressure point:

- the Portuguese Story Map listing has 91 visible items;
- Story Map `post_content` can be several MB per post;
- loading 50 full Story Maps at once can require well over 100 MB just for raw `post_content`, before WordPress, WPML, Yoast, Co-Authors Plus, and other admin integrations add overhead.

The visible fatal error was:

```text
Allowed memory size of 268435456 bytes exhausted ... wp-includes/class-wpdb.php
```

That `wpdb` failure was a symptom: WordPress was materializing very large post rows into memory for an admin screen that only needs lightweight listing data.

## Root cause

There were several overlapping contributors:

1. Story Maps are registered as hierarchical posts, so the admin list can trigger page-like behavior that requests all IDs/parents and bypasses normal pagination.
2. The main admin list query selected complete post rows, including huge `post_content` values.
3. Core list-table code such as `wp_check_post_lock()` can call `get_post( $id )` while rendering each row. If the lightweight row is not cached, WordPress reloads the full post row by ID.
4. Yoast SEO list columns recalculate meta context and parse block content from each Story Map row, which defeats any lightweight query and can trigger `parse_blocks()` on multi-MB payloads.
5. The hidden Quick Edit parent dropdown is unnecessary for JEO Story Maps and can also force expensive hierarchical post behavior.

## What changed

- Keeps the Story Map admin list paginated using the user's configured Screen Options value instead of capping it artificially.
- Marks only the Story Map admin list main query for lightweight handling.
- Replaces the main list query fields with an explicit lightweight column list and returns empty placeholders for `post_content` and `post_content_filtered`.
- Disables post meta cache priming for this listing query.
- Temporarily primes the object cache with lightweight `WP_Post` objects during the request so row-level admin callbacks do not refetch full Story Map rows.
- Clears those request-local lightweight cache entries on `shutdown` to avoid leaving partial post objects around.
- Removes `wpseo-*` columns from the Story Map list table because they force full block-content parsing in the listing.
- Disables the hidden Quick Edit parent dropdown for Story Maps, since JEO does not use parent/child Story Map relationships in the evaluated InfoAmazonia data.

## Impact

The Story Map listing should now behave like a normal paginated admin list even when users choose higher Screen Options values such as 50 or 100 items per page.

The main visible tradeoff is that Yoast SEO columns no longer appear on the Story Map list table. The Yoast metabox and SEO data on individual Story Map edit screens are not changed.

Maps and Layers are intentionally not changed here. In the evaluated InfoAmazonia copy, their `post_content` payloads were tiny compared with Story Maps, so applying the same content-light query to those post types would add unnecessary behavioral risk.

## Validation

Validated against the local InfoAmazonia copy at `infoamazonia.local`.

Story Map admin listing:

| Screen Options value | Result |
| --- | --- |
| 20 items per page | `HTTP 200`, 20 rows, 91 items, 5 pages, no fatal error |
| 50 items per page | `HTTP 200`, 50 rows, 91 items, 2 pages, no fatal error |
| 100 items per page | `HTTP 200`, 91 rows, 91 items, 1 page, no fatal error |

Additional HTTP checks:

- Story Map search returned `HTTP 200` with no memory fatal.
- Draft status filter returned `HTTP 200` with no memory fatal.
- WPML language filter for `lang=en` returned `HTTP 200` with no memory fatal.
- Editing an individual Story Map returned `HTTP 200` and still loaded the full edit screen.
- A published Story Map frontend URL returned `HTTP 200`.
- Quick Edit buttons still render.
- The parent dropdown is absent from the Story Map Quick Edit markup.
- Yoast table columns are absent from the Story Map list table.

Local code checks:

```text
php -l src/includes/storymap/class-storymap.php
vendor/bin/phpcs --standard=phpcs.xml.dist src/includes/storymap/class-storymap.php
php scripts/check-php-compat.php
git diff --check -- src/includes/storymap/class-storymap.php
```
