### PR TITLE
Simplify JeoLayerTypes change event emission

### DIFF
--- a/src/includes/layer-types/JeoLayerTypes.js
+++ b/src/includes/layer-types/JeoLayerTypes.js
@@ -4,14 +4,6 @@ class JeoLayerTypes {
 	}
 
 	emitChange() {
-		if (
-			typeof window === 'undefined' ||
-			typeof window.dispatchEvent !== 'function' ||
-			typeof CustomEvent !== 'function'
-		) {
-			return;
-		}
-
 		window.dispatchEvent(
 			new CustomEvent( 'jeo-layer-types-changed', {
 				detail: {

--- a/src/includes/layer-types/JeoLayerTypes.test.js
+++ b/src/includes/layer-types/JeoLayerTypes.test.js
@@ -1,0 +1,25 @@
+describe( 'JeoLayerTypes', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		delete window.JeoLayerTypes;
+	} );
+
+	it( 'dispatches a change event when a layer type is registered', () => {
+		const handleChange = jest.fn();
+		window.addEventListener( 'jeo-layer-types-changed', handleChange );
+
+		const layerTypes = require( './JeoLayerTypes' ).default;
+		const layerType = { label: 'Custom layer' };
+
+		layerTypes.registerLayerType( 'custom-layer', layerType );
+
+		expect( window.JeoLayerTypes ).toBe( layerTypes );
+		expect( layerTypes.getLayerType( 'custom-layer' ) ).toBe( layerType );
+		expect( handleChange ).toHaveBeenCalledTimes( 1 );
+		expect( handleChange.mock.calls[0][0].detail ).toEqual( {
+			layerTypes: [ 'custom-layer' ],
+		} );
+
+		window.removeEventListener( 'jeo-layer-types-changed', handleChange );
+	} );
+} );


### PR DESCRIPTION
## Summary

This PR fixes #523 by simplifying the `JeoLayerTypes` change event path and adding focused unit coverage for it.

## What changed

- Removed the defensive browser capability guard from `JeoLayerTypes.emitChange()`.
- Kept the method focused on dispatching the `jeo-layer-types-changed` `CustomEvent` with the registered layer type list in `detail.layerTypes`.
- Added a Jest test that verifies registering a layer type exposes it through `window.JeoLayerTypes`, stores it in the registry, and dispatches exactly one change event with the expected payload.

## Why

The removed guard checked for `window`, `window.dispatchEvent`, and `CustomEvent`, but the surrounding module already assumes a browser runtime by assigning `window.JeoLayerTypes = instance`. Current consumers also subscribe with `window.addEventListener( 'jeo-layer-types-changed', ... )` directly.

Because of that, the guard did not provide a complete non-browser fallback. It only made `emitChange()` look more defensive than the rest of the file, which made the runtime expectations harder to read. If this module ever needs true non-browser support, that should happen as a broader module boundary change rather than a local early return in the event emitter.

## Validation

- `npm run test:unit -- --runInBand`
