### PR TITLE
Restore layer description editing

### DIFF
--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -1239,7 +1239,7 @@ class Jeo {
 		if ( 'edit' === $request->get_param( 'context' ) ) {
 			$raw = $response->data['content']['raw'] ?? '';
 			if ( false === strpos( $raw, 'jeo/layer-editor' ) ) {
-				$response->data['content']['raw'] = '<!-- wp:jeo/layer-editor {"align":"full"} /-->';
+				$response->data['content']['raw'] = '<!-- wp:jeo/layer-editor {"align":"full"} /-->' . $raw;
 			}
 		}
 		return $response;
@@ -1297,10 +1297,18 @@ class Jeo {
 			}
 
 			if ( isset( $wp_post_types['map-layer'] ) ) {
-				$wp_post_types['map-layer']->template      = array(
-					array( 'jeo/layer-editor', array( 'align' => 'full' ) ),
+				$wp_post_types['map-layer']->template = array(
+					array(
+						'jeo/layer-editor',
+						array(
+							'align' => 'full',
+							'lock'  => array(
+								'move'   => true,
+								'remove' => true,
+							),
+						),
+					),
 				);
-				$wp_post_types['map-layer']->template_lock = 'all';
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Restores the editable description area for map layer posts by keeping the layer post content available below the editor preview block.

## Root Cause

Layer editor REST responses injected the `jeo/layer-editor` preview block by replacing the raw post content entirely. The layer post type template was also locked at the document level, so editors could not add or edit content underneath the preview. Maps already preserved their existing content when injecting the preview block, which is why the map editor did not have the same problem.

## Changes

- Preserve existing layer `post_content` when injecting the `jeo/layer-editor` preview block in edit-context REST responses.
- Keep the layer preview block locked against move/removal while removing the document-level `template_lock` for map layers.
- Leave the public description pipeline unchanged, so layer descriptions continue to come from `post_content`.

## Validation

- Ran `php -l src/includes/class-jeo.php`.
- Mirrored the change into the local InfoAmazonia test site and confirmed the layer REST edit payload includes the preview block followed by the existing paragraph content.
- Temporarily edited layer `90005`, opened `http://infoamazonia.local/maps/oilgas/`, clicked `INFORMAÇÕES`, and confirmed the updated layer description appeared in the published map.
- Restored layer `90005` to its original content and confirmed the test text was gone while the original description remained visible.
