### PR TITLE
Persist map and layer editor settings

### DIFF
--- a/src/includes/layers/class-layers.php
+++ b/src/includes/layers/class-layers.php
@@ -34,6 +34,7 @@ class Layers {
 	protected function init() {
 		add_action( 'init', array( $this, 'register_post_type' ) );
 		add_action( 'admin_init', array( $this, 'add_capabilities' ) );
+		add_action( 'add_meta_boxes', array( $this, 'remove_custom_fields_meta_box' ), 99 );
 		add_filter( "rest_{$this->post_type}_collection_params", array( $this, 'rest_collection_params' ) );
 		$this->register_rest_meta_validation();
 	}
@@ -214,6 +215,19 @@ class Layers {
 				'description'   => __( 'Legend title', 'jeo' ),
 			)
 		);
+	}
+
+	/**
+	 * Keep REST metadata support enabled while hiding the legacy custom fields UI.
+	 *
+	 * JEO layer metadata is edited through dedicated editor sidebars. Leaving the
+	 * core custom fields metabox visible can resubmit stale values after a REST
+	 * editor save and overwrite the sidebar state.
+	 *
+	 * @return void
+	 */
+	public function remove_custom_fields_meta_box() {
+		remove_meta_box( 'postcustom', $this->post_type, 'normal' );
 	}
 
 	/**

--- a/src/includes/maps/class-maps.php
+++ b/src/includes/maps/class-maps.php
@@ -39,6 +39,7 @@ class Maps {
 		add_filter( 'single_template', array( $this, 'override_template' ) );
 		add_filter( 'the_content', array( $this, 'the_content_filter' ) );
 		add_action( 'admin_init', array( $this, 'add_capabilities' ) );
+		add_action( 'add_meta_boxes', array( $this, 'remove_custom_fields_meta_box' ), 99 );
 		$this->register_rest_meta_validation();
 	}
 
@@ -408,6 +409,19 @@ class Maps {
 				'description'       => __( 'Disable embed', 'jeo' ),
 			)
 		);
+	}
+
+	/**
+	 * Keep REST metadata support enabled while hiding the legacy custom fields UI.
+	 *
+	 * JEO map metadata is edited through dedicated editor sidebars. Leaving the
+	 * core custom fields metabox visible can resubmit stale values after a REST
+	 * editor save and overwrite the sidebar state.
+	 *
+	 * @return void
+	 */
+	public function remove_custom_fields_meta_box() {
+		remove_meta_box( 'postcustom', $this->post_type, 'normal' );
 	}
 
 	/**

--- a/src/js/src/layers-sidebar/attribution-settings.js
+++ b/src/js/src/layers-sidebar/attribution-settings.js
@@ -1,4 +1,4 @@
-import { withDispatch, withSelect } from '@wordpress/data';
+import { select, withDispatch, withSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -37,10 +37,15 @@ const AttributionSettings = ( { postMeta, setPostMeta } ) => {
 
 export default withDispatch( ( dispatch ) => ( {
 	setPostMeta: ( meta ) => {
-		dispatch( 'core/editor' ).editPost( { meta } );
+		const currentMeta =
+			select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {};
+
+		dispatch( 'core/editor' ).editPost( {
+			meta: { ...currentMeta, ...meta },
+		} );
 	},
 } ) )(
 	withSelect( ( select ) => ( {
-		postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+		postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {},
 	} ) )( AttributionSettings )
 );

--- a/src/js/src/layers-sidebar/layer-settings.js
+++ b/src/js/src/layers-sidebar/layer-settings.js
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { withDispatch, withSelect } from '@wordpress/data';
+import { select, withDispatch, withSelect } from '@wordpress/data';
 import {
 	Fragment,
 	useCallback,
@@ -249,10 +249,15 @@ const LayerSettings = ( { postMeta, setPostMeta } ) => {
 
 export default withDispatch( ( dispatch ) => ( {
 	setPostMeta: ( meta ) => {
-		dispatch( 'core/editor' ).editPost( { meta } );
+		const currentMeta =
+			select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {};
+
+		dispatch( 'core/editor' ).editPost( {
+			meta: { ...currentMeta, ...meta },
+		} );
 	},
 } ) )(
 	withSelect( ( select ) => ( {
-		postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+		postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {},
 	} ) )( LayerSettings )
 );

--- a/src/js/src/layers-sidebar/layers-sidebar.js
+++ b/src/js/src/layers-sidebar/layers-sidebar.js
@@ -1,22 +1,23 @@
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import AttributionSettings from './attribution-settings';
 import LegendsEditor from '../posts-sidebar/legends-editor/legend-editor';
-import { withDispatch, withSelect } from '@wordpress/data';
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { select, withDispatch, withSelect } from '@wordpress/data';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { isEmpty, isEqual } from 'lodash-es';
+import { isEmpty } from 'lodash-es';
 import { useDebounce } from 'use-debounce';
 import LayerSettings from './layer-settings';
 import { getEditorLayerTypeSchema } from './layer-type-definitions';
 import './layers-sidebar.scss';
 
 const LayersSidebar = ( {
-	postMeta,
+	postMeta = {},
 	setPostMeta,
 	sendNotice,
 	removeNotice,
 	lockPostAutoSaving,
 	lockPostSaving,
+	unlockPostAutoSaving,
 	unlockPostSaving,
 } ) => {
 	const [ layerTypeSchema, setLayerTypeSchema ] = useState( {} );
@@ -26,7 +27,6 @@ const LayersSidebar = ( {
 		status: 'incomplete_form',
 	} );
 	const [ debouncedPostMeta ] = useDebounce( postMeta, 1500 );
-	const prevPostMeta = useRef( {} );
 
 	const createNotice = useCallback( ( type, message, options = {} ) => {
 		sendNotice( type, message, { id: 'layer_notices', isDismissible: false, ...options } );
@@ -96,40 +96,39 @@ const LayersSidebar = ( {
 			case 'ready':
 				removeNotice( 'layer_notices' );
 				unlockPostSaving( 'layer_lock_key' );
+				unlockPostAutoSaving( 'layer_lock_key' );
 				break;
 		}
 	}, [ renderControl.status ] );
 
 	useEffect( () => {
 		const debouncedLayerTypeOptions = debouncedPostMeta.layer_type_options || {};
-		const prevLayerTypeOptions = prevPostMeta.current.layer_type_options || {};
-		if ( Object.keys( debouncedLayerTypeOptions ).length && Object.keys( layerTypeSchema ).length ) {
-			const optionsKeys = Object.keys( layerTypeSchema.properties );
-			let anyEmpty = false;
-			optionsKeys.some( ( k ) => {
-				if (
-					isEmpty( debouncedLayerTypeOptions[ k ] ) &&
-					layerTypeSchema.required.includes( k )
-				) {
-					anyEmpty = true;
-					setRenderControl( {
-						status: 'incomplete_form',
-					} );
-					return anyEmpty;
-				}
-				return false;
+		const requiredOptions = Array.isArray( layerTypeSchema.required )
+			? layerTypeSchema.required
+			: [];
+		const hasSchema = Object.keys( layerTypeSchema ).length > 0;
+
+		if ( ! debouncedPostMeta.type || ! hasSchema ) {
+			setRenderControl( {
+				status: 'incomplete_form',
 			} );
-			if (
-				! anyEmpty &&
-				renderControl != 'ready' &&
-				! isEqual( debouncedLayerTypeOptions, prevLayerTypeOptions )
-			) {
-				setRenderControl( {
-					status: 'ready',
-				} );
-			}
-			prevPostMeta.current = debouncedPostMeta;
+			return;
 		}
+
+		const hasEmptyRequiredOption = requiredOptions.some( ( key ) =>
+			isEmpty( debouncedLayerTypeOptions[ key ] )
+		);
+
+		if ( hasEmptyRequiredOption ) {
+			setRenderControl( {
+				status: 'incomplete_form',
+			} );
+			return;
+		}
+
+		setRenderControl( {
+			status: 'ready',
+		} );
 	}, [ debouncedPostMeta.layer_type_options, layerTypeSchema ] );
 
 	return (
@@ -159,7 +158,12 @@ const LayersSidebar = ( {
 };
 export default withDispatch( ( dispatch ) => ( {
 	setPostMeta: ( meta ) => {
-		dispatch( 'core/editor' ).editPost( { meta } );
+		const currentMeta =
+			select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {};
+
+		dispatch( 'core/editor' ).editPost( {
+			meta: { ...currentMeta, ...meta },
+		} );
 	},
 	sendNotice: ( type, message, options ) => {
 		dispatch( 'core/notices' ).createNotice( type, message, options );
@@ -173,11 +177,14 @@ export default withDispatch( ( dispatch ) => ( {
 	lockPostAutoSaving: ( key ) => {
 		dispatch( 'core/editor' ).lockPostAutosaving( key );
 	},
+	unlockPostAutoSaving: ( key ) => {
+		dispatch( 'core/editor' ).unlockPostAutosaving( key );
+	},
 	unlockPostSaving: ( key ) => {
 		dispatch( 'core/editor' ).unlockPostSaving( key );
 	},
 } ) )(
 	withSelect( ( select ) => ( {
-		postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+		postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {},
 	} ) )( LayersSidebar )
 );

--- a/src/js/src/map-blocks/layers-settings.js
+++ b/src/js/src/map-blocks/layers-settings.js
@@ -18,7 +18,7 @@ const anySwapDefault = ( settings ) =>
 	settings.some( ( s ) => s.use === 'swappable' && s.default );
 
 export default function LayersSettings ( { attributes, setAttributes, loadedLayers, loadingLayers, closeModal } ) {
-	const setLayers = ( layers ) => setAttributes( { ...attributes, layers } );
+	const setLayers = ( layers ) => setAttributes( { layers } );
 	let widths = [];
 
 	const [ layerTypeFilter, setLayerTypeFilter ] = useState( '' );
@@ -196,7 +196,6 @@ export default function LayersSettings ( { attributes, setAttributes, loadedLaye
 													<p
 														onClick={ () => {
 															setAttributes( {
-																...attributes,
 																layers: [ ...attributes.layers, setLayer( layer.id ) ],
 															} );
 														} }

--- a/src/js/src/map-blocks/map-editor-preview.js
+++ b/src/js/src/map-blocks/map-editor-preview.js
@@ -1,6 +1,6 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { select, useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -20,9 +20,16 @@ export default function MapEditorPreview() {
 	const blockProps = useBlockProps();
 
 	const postMeta = useSelect( ( select ) =>
-		select( 'core/editor' ).getEditedPostAttribute( 'meta' ), [] );
+		select( 'core/editor' ).getEditedPostAttribute( 'meta' ), [] ) || {};
 	const { editPost } = useDispatch( 'core/editor' );
-	const setPostMeta = useCallback( ( meta ) => editPost( { meta } ), [ editPost ] );
+	const setPostMeta = useCallback(
+		( meta ) => {
+			const currentMeta =
+				select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {};
+			editPost( { meta: { ...currentMeta, ...meta } } );
+		},
+		[ editPost ]
+	);
 
 	const [ zoomState, setZoomState ] = useState( 'initial_zoom' );
 	const [ key, setKey ] = useState( 0 );

--- a/src/js/src/map-blocks/map-settings.js
+++ b/src/js/src/map-blocks/map-settings.js
@@ -40,7 +40,7 @@ export default ( { attributes, setAttributes, setPanLimitsFromMap } ) => {
 	} = { ...mapDefaults, ...attributes };
 
 	const attributeUpdater = ( attribute ) => ( value ) => {
-		setAttributes( { ...attributes, [ attribute ]: value } );
+		setAttributes( { [ attribute ]: value } );
 	};
 
 	const editingMap = useRef( false );
@@ -176,7 +176,12 @@ export default ( { attributes, setAttributes, setPanLimitsFromMap } ) => {
 							label={ __( 'North', 'jeo' ) }
 							value={ attributes.pan_limits?.north || "__"}
 							onChange={ ( value ) => {
-								return setAttributes({ ...attributes, 'pan_limits': { ...attributes.pan_limits, north: parseNumber(value) }});
+								return setAttributes({
+									pan_limits: {
+										...attributes.pan_limits,
+										north: parseNumber(value),
+									},
+								});
 							} }
 						/>
 
@@ -185,7 +190,12 @@ export default ( { attributes, setAttributes, setPanLimitsFromMap } ) => {
 							label={ __( 'East', 'jeo' ) }
 							value={ attributes.pan_limits?.east || "__" }
 							onChange={ ( value ) => {
-								return setAttributes({ ...attributes, 'pan_limits': { ...attributes.pan_limits, east: parseNumber(value) }});
+								return setAttributes({
+									pan_limits: {
+										...attributes.pan_limits,
+										east: parseNumber(value),
+									},
+								});
 							} }
 						/>
 
@@ -195,7 +205,12 @@ export default ( { attributes, setAttributes, setPanLimitsFromMap } ) => {
 							label={ __( 'South', 'jeo' ) }
 							value={ attributes.pan_limits?.south || "__"}
 							onChange={ ( value ) => {
-								return setAttributes({ ...attributes, 'pan_limits': { ...attributes.pan_limits, south: parseNumber(value) }});
+								return setAttributes({
+									pan_limits: {
+										...attributes.pan_limits,
+										south: parseNumber(value),
+									},
+								});
 							} }
 						/>
 
@@ -204,7 +219,12 @@ export default ( { attributes, setAttributes, setPanLimitsFromMap } ) => {
 							label={ __( 'West', 'jeo' ) }
 							value={ attributes.pan_limits?.west || "__"}
 							onChange={ ( value ) => {
-								return setAttributes({ ...attributes, 'pan_limits': { ...attributes.pan_limits, west: parseNumber(value) }});
+								return setAttributes({
+									pan_limits: {
+										...attributes.pan_limits,
+										west: parseNumber(value),
+									},
+								});
 							} }
 						/>
 					</div>

--- a/src/js/src/maps-sidebar/maps-sidebar.js
+++ b/src/js/src/maps-sidebar/maps-sidebar.js
@@ -1,4 +1,4 @@
-import { withDispatch, withSelect } from '@wordpress/data';
+import { select, withDispatch, withSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -15,15 +15,14 @@ import './maps-sidebar.scss';
 
 function MapsSidebar( {
 	postId,
-	postMeta,
+	postMeta = {},
 	relatedPosts,
 	setPostMeta,
-	setRelatedPosts,
 } ) {
 	const [ modal, setModal ] = useState( false );
 
 	const layerIds = useMemo( () => {
-		return postMeta.layers.map( ( layer ) => layer.id );
+		return ( postMeta.layers || [] ).map( ( layer ) => layer.id );
 	}, [ postMeta.layers ] );
 
 	const { records: loadedLayers = [], isLoading: loadingLayers } = useRecordsByIds( {
@@ -35,6 +34,14 @@ function MapsSidebar( {
 
 	const closeModal = useCallback( () => setModal( false ), [ setModal ] );
 	const openModal = useCallback( () => setModal( true ), [ setModal ] );
+	const setRelatedPosts = useCallback(
+		( value ) => {
+			setPostMeta( {
+				related_posts: normalizeRelatedPosts( value ),
+			} );
+		},
+		[ setPostMeta ]
+	);
 
 	const embedUrl =
 		postId && `${ jeo_settings.site_url }/embed/?map_id=${ postId }`;
@@ -79,20 +86,21 @@ function MapsSidebar( {
 
 export default withDispatch( ( dispatch ) => ( {
 	setPostMeta: ( meta ) => {
-		dispatch( 'core/editor' ).editPost( { meta } );
-	},
-	setRelatedPosts: ( value ) => {
+		const currentMeta =
+			select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {};
 		dispatch( 'core/editor' ).editPost( {
-			meta: { related_posts: normalizeRelatedPosts( value ) },
+			meta: { ...currentMeta, ...meta },
 		} );
 	},
 } ) )(
-	withSelect( ( select ) => ( {
-		postId: select( 'core/editor' ).getCurrentPostId(),
-		postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
-		relatedPosts: normalizeRelatedPosts(
-			select( 'core/editor' ).getEditedPostAttribute( 'meta' )
-				.related_posts
-		),
-	} ) )( MapsSidebar )
+	withSelect( ( select ) => {
+		const postMeta =
+			select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {};
+
+		return {
+			postId: select( 'core/editor' ).getCurrentPostId(),
+			postMeta,
+			relatedPosts: normalizeRelatedPosts( postMeta.related_posts ),
+		};
+	} )( MapsSidebar )
 );

--- a/src/js/src/posts-selector/index.js
+++ b/src/js/src/posts-selector/index.js
@@ -1,4 +1,4 @@
-import { useDispatch, useSelect } from '@wordpress/data';
+import { select, useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '../shared/wp-form-controls';
 
@@ -16,12 +16,23 @@ const PostsSelector = ( {
 	renderPanel: Panel,
 } ) => {
 	const postMeta = useSelect(
-		( select ) => select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+		( select ) =>
+			select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {},
 		[]
 	);
 	const normalizedRelatedPosts = normalizeRelatedPosts( relatedPosts );
 	const { editPost } = useDispatch( 'core/editor' );
-	const setPostMeta = ( meta ) => editPost( { meta } );
+	const setPostMeta = ( meta ) => {
+		const currentMeta =
+			select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {};
+
+		editPost( {
+			meta: {
+				...currentMeta,
+				...meta,
+			},
+		} );
+	};
 
 	return (
 		<Panel name="related-posts" title={ __( 'Related posts', 'jeo' ) }>
@@ -31,7 +42,6 @@ const PostsSelector = ( {
 				checked={ postMeta.relate_posts }
 				onChange={ () => {
 					setPostMeta( {
-						...postMeta,
 						relate_posts: ! postMeta.relate_posts,
 						related_posts: normalizedRelatedPosts,
 					} );


### PR DESCRIPTION
## Summary

This PR fixes map and layer editor settings that could appear to save successfully but then revert after reloading the editor.

The affected flows are the map and layer sidebars, the embedded map editor preview, map block settings, map layer settings, and the related posts selector. These screens often send partial metadata or partial block attribute updates. Before this change, several handlers passed only the changed fragment to `editPost( { meta } )` or rebuilt block attributes from a stale `attributes` object. In practice, one control could overwrite metadata owned by another control, and stale editor state could win during a save.

The PR makes those updates safer by merging partial metadata writes with the current edited post meta from `core/editor` at the moment of dispatch. It also defaults missing edited meta to `{}` so sidebar code does not assume a fully hydrated meta object before the editor has finished loading.

For JEO maps and layers, it also hides WordPress' legacy Custom Fields metabox while preserving REST metadata support. The plugin edits these values through dedicated sidebars, but the legacy metabox can keep stale values in the DOM and resubmit them after a REST editor save. That stale submission can overwrite the sidebar-managed state, which is why fields such as layer attribution, layer legend type, and map related-post settings could fail to stick.

## What changed

- Map and layer sidebar metadata setters now merge changed keys into the current edited post meta instead of replacing the whole meta object with a partial payload.
- The related posts selector now preserves the rest of the edited meta when toggling related-post settings.
- The map editor preview uses the latest edited meta when it writes preview-driven map settings.
- Map block settings and layer list settings now call `setAttributes` with only the attributes being changed instead of spreading a possibly stale attributes object back into the block.
- Layer validation now unlocks autosave as well as normal saving once layer type options become valid again.
- JEO map and layer post types remove the `postcustom` metabox in the editor, preventing stale custom field form state from overwriting REST-managed sidebar values.

## Motivation and decisions

This came from local testing in `infoamazonia.local`, where layer configuration values such as attribution name and legend type, and map configuration values such as “use related posts”, were not reliably persisting.

I chose not to remove REST metadata support or change the stored meta schema. The dedicated editor UI still writes the same metadata keys. The fix is deliberately narrower: preserve all other edited meta when writing one subset, avoid stale block attribute spreads, and prevent the legacy custom-fields UI from submitting old values for the same keys.

The Custom Fields metabox removal is limited to the JEO map and layer post types. That keeps the admin surface aligned with the plugin's actual editing model without changing global WordPress behavior.

## Validation

- `npm ci`
- `npm run build`
- `npm run test:unit -- --runInBand`
- `npm run build:report`
- The same changes were previously copied into the local `infoamazonia.local` plugin and validated in the WordPress editor before this PR was split out.

The local build still prints WP-CLI PHP deprecation warnings from the installed WP-CLI PHAR, but the build completes successfully.
