### PR TITLE
Restore map embed footer styling

### DIFF
--- a/src/css/jeo-map.scss
+++ b/src/css/jeo-map.scss
@@ -968,6 +968,28 @@
 	padding: 0 10px 10px;
 }
 
+.embed-footer {
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	height: 35px;
+	background: #242424;
+	padding: 5px;
+	inset-inline-start: 0px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	img {
+		height: 30px;
+	}
+
+	&.discovery {
+		inset-inline-start: 0;
+		bottom: 0;
+	}
+}
+
 // Bar scale legend
 
 .barscale-left-label {


### PR DESCRIPTION
## Summary

This PR restores the footer styling used on public map embed pages.

The JEO 3.x embed template still renders the footer logo, but the footer styles only existed in the Discovery stylesheet. Standard map embeds load the shared map stylesheet instead, so the footer fell back to theme/default styles: the bar became white and the logo was aligned to the right.

## Changes

- Add the `.embed-footer` rule to the shared map stylesheet used by map embeds.
- Restore the dark `#242424` footer background.
- Center the footer logo with flex alignment.
- Keep the embedded footer logo constrained to the legacy 30px height.

## Impact

Public map embed pages now match the JEO 2.x footer appearance while keeping the existing template markup and configured footer logo behavior.

## Validation

- Verified locally on the InfoAmazonia site after activating the JEO 3.x plugin.
- Ran `git diff --check` on the isolated PR branch.
