### PR TITLE
Fix public map initialization numeric options

### DIFF
--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -933,15 +933,26 @@ class Jeo {
 	public function enqueue_scripts() {
 		if ( $this->should_load_assets() ) {
 			$legend_script_handles = \jeo_legend_types()->get_registered_script_handles();
+			$jeo_map_assets       = include JEO_BASEPATH . '/js/build/jeoMap.asset.php';
+			$jeo_map_version      = $jeo_map_assets['version'] ?? JEO_VERSION;
+			$jeo_map_dependencies = array_values(
+				array_unique(
+					array_merge(
+						$jeo_map_assets['dependencies'] ?? array(),
+						array( 'mapgl', 'jquery' ),
+						$legend_script_handles
+					)
+				)
+			);
 
 			wp_enqueue_style( 'mapgl' );
 			wp_enqueue_script( 'mapgl' );
-			wp_enqueue_style( 'jeo-map', JEO_BASEURL . '/js/build/jeoMap.css', array( 'mapgl' ), JEO_VERSION );
+			wp_enqueue_style( 'jeo-map', JEO_BASEURL . '/js/build/jeoMap.css', array( 'mapgl' ), $jeo_map_version );
 			wp_enqueue_script(
 				'jeo-map',
 				JEO_BASEURL . '/js/build/jeoMap.js',
-				array_merge( array( 'mapgl', 'jquery' ), $legend_script_handles ),
-				JEO_VERSION,
+				$jeo_map_dependencies,
+				$jeo_map_version,
 				true
 			);
 

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -933,9 +933,9 @@ class Jeo {
 	public function enqueue_scripts() {
 		if ( $this->should_load_assets() ) {
 			$legend_script_handles = \jeo_legend_types()->get_registered_script_handles();
-			$jeo_map_assets       = include JEO_BASEPATH . '/js/build/jeoMap.asset.php';
-			$jeo_map_version      = $jeo_map_assets['version'] ?? JEO_VERSION;
-			$jeo_map_dependencies = array_values(
+			$jeo_map_assets        = include JEO_BASEPATH . '/js/build/jeoMap.asset.php';
+			$jeo_map_version       = $jeo_map_assets['version'] ?? JEO_VERSION;
+			$jeo_map_dependencies  = array_values(
 				array_unique(
 					array_merge(
 						$jeo_map_assets['dependencies'] ?? array(),

--- a/src/js/src/jeo-map/class-jeo-map.js
+++ b/src/js/src/jeo-map/class-jeo-map.js
@@ -9,6 +9,8 @@ import { buildRelatedPostsGeoJson } from '../shared/story-geojson';
 import { EMPTY_STYLE } from '../shared/styles';
 import { normalizeOptionalUrl } from '../shared/url-normalization';
 import { waitMapEvent } from '../shared/wait';
+import { toFiniteNumber } from './map-numbers';
+import { getPanLimitsMaxBounds } from './pan-limits';
 import { compileEtaTemplate } from './template-compiler';
 
 import '../../../css/jeo-map.scss';
@@ -126,11 +128,17 @@ export default class JeoMap {
 				});
 
 				if ( this.getArg( 'layers' ) && this.getArg( 'layers' ).length > 0 ) {
-					map.setZoom( this.getArg( 'initial_zoom' ) );
-					map.setCenter( [
-						this.getArg( 'center_lon' ),
-						this.getArg( 'center_lat' ),
-					] );
+					const initialZoom = toFiniteNumber( this.getArg( 'initial_zoom' ) );
+					const centerLon = toFiniteNumber( this.getArg( 'center_lon' ) );
+					const centerLat = toFiniteNumber( this.getArg( 'center_lat' ) );
+
+					if ( initialZoom !== null ) {
+						map.setZoom( initialZoom );
+					}
+
+					if ( centerLon !== null && centerLat !== null ) {
+						map.setCenter( [ centerLon, centerLat ] );
+					}
 
 					map.addControl(
 						new mapgl.NavigationControl( { showCompass: false } ),
@@ -154,24 +162,22 @@ export default class JeoMap {
 						map.addControl( new mapgl.FullscreenControl(), `top-${inlineStart}` );
 					}
 
-					if (
-						this.getArg( 'pan_limits' ) &&
-						this.getArg( 'pan_limits' ).east &&
-						this.getArg( 'pan_limits' ).north &&
-						this.getArg( 'pan_limits' ).south &&
-						this.getArg( 'pan_limits' ).west
-					) {
-						map.setMaxBounds( [
-							[this.getArg( 'pan_limits' ).south, this.getArg( 'pan_limits' ).west], // Southwest coordinates
-							[this.getArg( 'pan_limits' ).north, this.getArg( 'pan_limits' ).east] // Northeast coordinates
-						] );
+					const panLimitsMaxBounds = getPanLimitsMaxBounds(
+						this.getArg( 'pan_limits' )
+					);
+
+					if ( panLimitsMaxBounds ) {
+						map.setMaxBounds( panLimitsMaxBounds );
 					}
 
-					if ( this.getArg( 'min_zoom' ) ) {
-						map.setMinZoom( this.getArg( 'min_zoom' ) );
+					const minZoom = toFiniteNumber( this.getArg( 'min_zoom' ) );
+					const maxZoom = toFiniteNumber( this.getArg( 'max_zoom' ) );
+
+					if ( minZoom !== null ) {
+						map.setMinZoom( minZoom );
 					}
-					if ( this.getArg( 'max_zoom' ) ) {
-						map.setMaxZoom( this.getArg( 'max_zoom' ) );
+					if ( maxZoom !== null ) {
+						map.setMaxZoom( maxZoom );
 					}
 
 					// Only used for manipulating the map from outside Jeo

--- a/src/js/src/jeo-map/map-numbers.js
+++ b/src/js/src/jeo-map/map-numbers.js
@@ -1,0 +1,8 @@
+export function toFiniteNumber( value ) {
+	if ( value === '' || value === undefined || value === null || value === false ) {
+		return null;
+	}
+
+	const numberValue = Number( value );
+	return Number.isFinite( numberValue ) ? numberValue : null;
+}

--- a/src/js/src/jeo-map/pan-limits.js
+++ b/src/js/src/jeo-map/pan-limits.js
@@ -1,0 +1,21 @@
+import { toFiniteNumber } from './map-numbers';
+
+export function getPanLimitsMaxBounds( panLimits ) {
+	if ( ! panLimits || typeof panLimits !== 'object' ) {
+		return null;
+	}
+
+	const east = toFiniteNumber( panLimits.east );
+	const north = toFiniteNumber( panLimits.north );
+	const south = toFiniteNumber( panLimits.south );
+	const west = toFiniteNumber( panLimits.west );
+
+	if ( [ east, north, south, west ].some( ( value ) => value === null ) ) {
+		return null;
+	}
+
+	return [
+		[ west, south ],
+		[ east, north ],
+	];
+}

--- a/src/js/src/jeo-map/pan-limits.test.js
+++ b/src/js/src/jeo-map/pan-limits.test.js
@@ -1,0 +1,68 @@
+import { getPanLimitsMaxBounds } from './pan-limits';
+import { toFiniteNumber } from './map-numbers';
+
+describe( 'toFiniteNumber', () => {
+	it( 'coerces numeric strings and preserves zero values', () => {
+		expect( toFiniteNumber( '20' ) ).toBe( 20 );
+		expect( toFiniteNumber( '3' ) ).toBe( 3 );
+		expect( toFiniteNumber( 0 ) ).toBe( 0 );
+		expect( toFiniteNumber( '0' ) ).toBe( 0 );
+	} );
+
+	it( 'returns null for missing or non-numeric values', () => {
+		expect( toFiniteNumber( '' ) ).toBeNull();
+		expect( toFiniteNumber( undefined ) ).toBeNull();
+		expect( toFiniteNumber( null ) ).toBeNull();
+		expect( toFiniteNumber( false ) ).toBeNull();
+		expect( toFiniteNumber( 'not a number' ) ).toBeNull();
+	} );
+} );
+
+describe( 'getPanLimitsMaxBounds', () => {
+	it( 'returns Mapbox/MapLibre bounds in longitude-latitude order', () => {
+		expect(
+			getPanLimitsMaxBounds( {
+				east: -6.0484710101644055,
+				north: 5.0559606245613935,
+				south: -16.66983997060082,
+				west: -105.58460382266483,
+			} )
+		).toEqual( [
+			[ -105.58460382266483, -16.66983997060082 ],
+			[ -6.0484710101644055, 5.0559606245613935 ],
+		] );
+	} );
+
+	it( 'coerces numeric strings and preserves zero values', () => {
+		expect(
+			getPanLimitsMaxBounds( {
+				east: '0',
+				north: '0',
+				south: '-10',
+				west: '-20',
+			} )
+		).toEqual( [
+			[ -20, -10 ],
+			[ 0, 0 ],
+		] );
+	} );
+
+	it( 'returns null when a pan limit is missing or non-numeric', () => {
+		expect(
+			getPanLimitsMaxBounds( {
+				east: -6,
+				north: 5,
+				south: -16,
+			} )
+		).toBeNull();
+
+		expect(
+			getPanLimitsMaxBounds( {
+				east: -6,
+				north: 5,
+				south: -16,
+				west: '',
+			} )
+		).toBeNull();
+	} );
+} );


### PR DESCRIPTION
## Summary
- pass pan limits to Mapbox and MapLibre as longitude-latitude coordinate pairs
- coerce public map zoom and center values before calling map runtime setters
- enqueue the public `jeoMap` bundle with its generated asset hash so updated builds are not hidden behind long-lived CDN cache entries

## Root Cause
The failing preview map stored pan limits as `{ east, north, south, west }`, but JEO passed them to `setMaxBounds()` as `[[south, west], [north, east]]`. Mapbox GL and MapLibre GL expect `[longitude, latitude]`, so the west value `-105.58460382266483` was interpreted as a latitude and rejected.

After that was fixed and the cached bundle was purged, Mapbox GL v3.20 exposed another public initialization issue: WordPress preview metadata provides zoom values as strings. Passing `"3"` to `setMinZoom()` and then `"20"` to `setMaxZoom()` makes Mapbox compare strings lexicographically, so `"20" >= "3"` fails.

The public map bundle was also enqueued with the static plugin version, which allowed Cloudflare to continue serving an old `jeoMap.js?ver=3.0.0-rc.3` after installing a rebuilt plugin package.

## Validation
- `npx wp-scripts test-unit-js src/js/src/jeo-map/pan-limits.test.js`
- `npm run test:unit`
- `npm run build`
