### PR TITLE
Disable hierarchy for JEO post types

### DIFF
--- a/src/includes/layers/class-layers.php
+++ b/src/includes/layers/class-layers.php
@@ -68,7 +68,7 @@ class Layers {
 
 		$args = array(
 			'labels'              => $labels,
-			'hierarchical'        => true,
+			'hierarchical'        => false,
 			'description'         => __( 'JEO Layers', 'jeo' ),
 			'supports'            => array( 'title', 'editor', 'page-attributes', 'custom-fields' ),
 			'rewrite'             => array( 'slug' => 'layers' ),

--- a/src/includes/maps/class-maps.php
+++ b/src/includes/maps/class-maps.php
@@ -72,7 +72,7 @@ class Maps {
 
 		$args = array(
 			'labels'              => $labels,
-			'hierarchical'        => true,
+			'hierarchical'        => false,
 			'description'         => __( 'JEO Maps', 'jeo' ),
 			'supports'            => array( 'author', 'title', 'editor', 'excerpt', 'thumbnail', 'page-attributes', 'custom-fields', 'newspack_blocks', 'revisions' ),
 			'rewrite'             => array( 'slug' => 'maps' ),

--- a/src/includes/storymap/class-storymap.php
+++ b/src/includes/storymap/class-storymap.php
@@ -50,6 +50,7 @@ class Storymap {
 		add_filter( 'the_posts', array( $this, 'prime_lightweight_admin_list_cache' ), 10, 2 );
 		add_filter( 'manage_' . $this->post_type . '_posts_columns', array( $this, 'remove_expensive_admin_list_columns' ), 20 );
 		add_filter( 'quick_edit_dropdown_pages_args', array( $this, 'disable_admin_parent_dropdown' ) );
+		add_filter( 'heartbeat_received', array( $this, 'disable_admin_list_lock_heartbeat' ), 9, 3 );
 		add_action( 'shutdown', array( $this, 'clear_lightweight_admin_list_cache' ) );
 
 		add_filter( 'rest_prepare_storymap', array( $this, 'prepare_rest_response' ), 10, 2 );
@@ -86,7 +87,7 @@ class Storymap {
 
 		$args = array(
 			'labels'              => $labels,
-			'hierarchical'        => true,
+			'hierarchical'        => false,
 			'description'         => __( 'JEO Story Map', 'jeo' ),
 			'supports'            => array( 'author', 'title', 'editor', 'excerpt', 'thumbnail', 'page-attributes', 'custom-fields', 'newspack_blocks', 'revisions' ),
 			'rewrite'             => array( 'slug' => 'storymap' ),
@@ -391,6 +392,32 @@ class Storymap {
 		$dropdown_args['post_type'] = '__jeo_no_storymap_parent_options';
 
 		return $dropdown_args;
+	}
+
+	/**
+	 * Disable list-table edit-lock checks for storymaps.
+	 *
+	 * The posts list heartbeat sends every visible row to wp_check_locked_posts().
+	 * On content-heavy storymap screens, that AJAX request can exhaust memory even
+	 * after the initial list query has been made lightweight. Post edit screens
+	 * still keep their regular heartbeat lock behavior.
+	 *
+	 * @param array  $response  Heartbeat response.
+	 * @param array  $data      Heartbeat request data.
+	 * @param string $screen_id Current screen ID.
+	 * @return array
+	 */
+	public function disable_admin_list_lock_heartbeat( $response, $data, $screen_id ) {
+		if ( 'edit-' . $this->post_type !== $screen_id ) {
+			return $response;
+		}
+		if ( empty( $data['wp-check-locked-posts'] ) ) {
+			return $response;
+		}
+
+		remove_filter( 'heartbeat_received', 'wp_check_locked_posts', 10 );
+
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR registers JEO maps, layers, and storymaps as non-hierarchical custom post types.

It also disables the WordPress list-table edit-lock heartbeat check only on the storymap admin list. The initial storymap list query was already optimized to avoid loading full `post_content`, but WordPress still sent every visible storymap row through `wp_check_locked_posts()` via `admin-ajax.php`. On InfoAmazonia's local copy, that residual heartbeat request still exhausted the 256 MB PHP memory limit when 91 storymaps were visible.

## Why

JEO's `map`, `map-layer`, and `storymap` post types do not appear to use WordPress parent/child relationships in the InfoAmazonia dataset. Production-style checks showed zero non-trash posts with `post_parent != 0` for these post types.

Keeping these CPTs hierarchical makes WordPress treat their admin lists more like page trees. For heavy storymaps, that can trigger expensive admin behaviors that are not useful for JEO and can load or inspect too much data at once.

## What changed

- Set `hierarchical` to `false` for maps, layers, and storymaps.
- Kept `page-attributes` support intact so existing page-attribute/menu-order behavior is not removed by this PR.
- Added a storymap-only heartbeat guard for the `edit-storymap` list screen.
- The heartbeat change removes only the list-table `wp-check-locked-posts` processing; individual post edit screens keep their regular WordPress heartbeat and lock behavior.

## Local validation

Validated against the local InfoAmazonia copy at `infoamazonia.local`:

- Confirmed `map`, `map-layer`, and `storymap` now register with `hierarchical=false`.
- Confirmed all three still report `page-attributes` support.
- Confirmed no JEO map/layer/storymap posts in the local dataset use `post_parent`.
- Opened admin lists for maps, layers, and storymaps successfully.
- Confirmed the storymap list renders 91 rows without the previous fatal memory error.
- Reproduced the previous heartbeat failure with 91 storymaps before the guard, then confirmed the same request returns HTTP 200 after the guard.
- Opened editor screens for representative map, layer, and storymap posts.
- Opened representative public map and storymap pages and confirmed they render without PHP fatal errors.

## Checks

- `php -l src/includes/maps/class-maps.php`
- `php -l src/includes/layers/class-layers.php`
- `php -l src/includes/storymap/class-storymap.php`
- `git diff --check -- src/includes/maps/class-maps.php src/includes/layers/class-layers.php src/includes/storymap/class-storymap.php`
- `/Users/stefano/GitHub/jeo-plugin/vendor/bin/phpcs --standard=/Users/stefano/GitHub/jeo-plugin-disable-hierarchy-pr/phpcs.xml.dist src/includes/maps/class-maps.php src/includes/layers/class-layers.php src/includes/storymap/class-storymap.php`
