### PR TITLE
Standardize build asset versioning

### DIFF
--- a/.github/workflows/wordpress-smoke.yml
+++ b/.github/workflows/wordpress-smoke.yml
@@ -58,6 +58,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -67,6 +72,12 @@ jobs:
 
       - name: Show PHP version
         run: php -v
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build plugin assets
+        run: npm run build:assets
 
       - name: Wait for MariaDB
         env:

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -466,17 +466,22 @@ class Jeo {
 	 * @return void
 	 */
 	public function register_assets() {
-		$asset_file            = include JEO_BASEPATH . '/js/build/postsSidebar.asset.php';
+		$asset_file            = require JEO_BASEPATH . '/js/build/postsSidebar.asset.php';
 		$layer_type_handles    = \Jeo\Layer_Types::get_instance()->get_layer_type_script_handles();
 		$legend_script_handles = \jeo_legend_types()->get_registered_script_handles();
 
 		$deps = array_merge(
 			array( 'lodash' ),
-			$asset_file['dependencies'] ?? array(),
+			$asset_file['dependencies'],
 			$legend_script_handles
 		);
 
-		wp_register_style( 'jeo-js', JEO_BASEURL . '/js/build/postsSidebar.css', array(), JEO_VERSION );
+		wp_register_style(
+			'jeo-js',
+			JEO_BASEURL . '/js/build/postsSidebar.css',
+			array(),
+			$asset_file['version']
+		);
 		wp_register_script(
 			'jeo-js',
 			JEO_BASEURL . '/js/build/postsSidebar.js',
@@ -525,11 +530,13 @@ class Jeo {
 			)
 		);
 
+		$mapgl_loader_assets = require JEO_BASEPATH . '/js/build/mapglLoader.asset.php';
+
 		wp_register_script(
 			'mapgl',
 			JEO_BASEURL . '/js/build/mapglLoader.js',
-			$mapgl_script_deps,
-			JEO_VERSION,
+			array_merge( $mapgl_loader_assets['dependencies'], $mapgl_script_deps ),
+			$mapgl_loader_assets['version'],
 			true,
 		);
 
@@ -537,7 +544,7 @@ class Jeo {
 			'mapgl',
 			JEO_BASEURL . '/js/build/mapglLoader.css',
 			$mapgl_style_deps,
-			JEO_VERSION,
+			$mapgl_loader_assets['version'],
 		);
 
 		wp_localize_script(
@@ -570,36 +577,38 @@ class Jeo {
 			)
 		);
 
-		$mapgl_react_assets = include JEO_BASEPATH . '/js/build/mapglReact.asset.php';
+		$mapgl_react_assets = require JEO_BASEPATH . '/js/build/mapglReact.asset.php';
 
 		wp_register_script(
 			'mapgl-react',
 			JEO_BASEURL . '/js/build/mapglReact.js',
-			array_merge( $mapgl_react_assets['dependencies'] ?? array(), array( 'mapgl' ) ),
-			$mapgl_react_assets['version'] ?? JEO_VERSION,
+			array_merge( $mapgl_react_assets['dependencies'], array( 'mapgl' ) ),
+			$mapgl_react_assets['version'],
 			true,
 		);
 
+		// phpcs:disable WordPress.WP.EnqueuedResourceParameters.MissingVersion -- Virtual style dependency handle has no source URL.
 		wp_register_style(
 			'mapgl-react-style',
 			false,
 			array( 'mapgl' ),
-			JEO_VERSION,
+			null,
 		);
+		// phpcs:enable WordPress.WP.EnqueuedResourceParameters.MissingVersion
 
-		$map_blocks_assets = include JEO_BASEPATH . '/js/build/mapBlocks.asset.php';
+		$map_blocks_assets = require JEO_BASEPATH . '/js/build/mapBlocks.asset.php';
 
 		wp_register_style(
 			'jeo-map-blocks',
 			JEO_BASEURL . '/js/build/mapBlocks.css',
 			array( 'mapgl', 'mapgl-react-style' ),
-			$map_blocks_assets['version'] ?? JEO_VERSION,
+			$map_blocks_assets['version'],
 		);
 		wp_register_script(
 			'jeo-map-blocks',
 			JEO_BASEURL . '/js/build/mapBlocks.js',
 			array_merge(
-				$map_blocks_assets['dependencies'] ?? array(),
+				$map_blocks_assets['dependencies'],
 				array( 'jeo-layer', 'mapgl-react' ),
 				$layer_type_handles,
 				$legend_script_handles
@@ -990,12 +999,11 @@ class Jeo {
 	public function enqueue_scripts() {
 		if ( $this->should_load_assets() ) {
 			$legend_script_handles = \jeo_legend_types()->get_registered_script_handles();
-			$jeo_map_assets        = include JEO_BASEPATH . '/js/build/jeoMap.asset.php';
-			$jeo_map_version       = $jeo_map_assets['version'] ?? JEO_VERSION;
+			$jeo_map_assets        = require JEO_BASEPATH . '/js/build/jeoMap.asset.php';
 			$jeo_map_dependencies  = array_values(
 				array_unique(
 					array_merge(
-						$jeo_map_assets['dependencies'] ?? array(),
+						$jeo_map_assets['dependencies'],
 						array( 'mapgl', 'jquery' ),
 						$legend_script_handles
 					)
@@ -1004,12 +1012,17 @@ class Jeo {
 
 			wp_enqueue_style( 'mapgl' );
 			wp_enqueue_script( 'mapgl' );
-			wp_enqueue_style( 'jeo-map', JEO_BASEURL . '/js/build/jeoMap.css', array( 'mapgl' ), $jeo_map_version );
+			wp_enqueue_style(
+				'jeo-map',
+				JEO_BASEURL . '/js/build/jeoMap.css',
+				array( 'mapgl' ),
+				$jeo_map_assets['version']
+			);
 			wp_enqueue_script(
 				'jeo-map',
 				JEO_BASEURL . '/js/build/jeoMap.js',
 				$jeo_map_dependencies,
-				$jeo_map_version,
+				$jeo_map_assets['version'],
 				true
 			);
 
@@ -1044,20 +1057,36 @@ class Jeo {
 						'jeomap_js_images',
 						array(
 							'/js/src/icons/news-marker' => array(
-								'url'       => JEO_BASEURL . '/js/src/icons/news-marker.png',
+								'url'       => add_query_arg(
+									'ver',
+									JEO_VERSION,
+									JEO_BASEURL . '/js/src/icons/news-marker.png'
+								),
 								'icon_size' => 0.1,
 							),
 							'/js/src/icons/news-marker-hover' => array(
-								'url'       => JEO_BASEURL . '/js/src/icons/news-marker-hover.png',
+								'url'       => add_query_arg(
+									'ver',
+									JEO_VERSION,
+									JEO_BASEURL . '/js/src/icons/news-marker-hover.png'
+								),
 								'icon_size' => 0.1,
 							),
 							'/js/src/icons/news'        => array(
-								'url'        => JEO_BASEURL . '/js/src/icons/news.png',
+								'url'        => add_query_arg(
+									'ver',
+									JEO_VERSION,
+									JEO_BASEURL . '/js/src/icons/news.png'
+								),
 								'icon_size'  => 0.13,
 								'text_color' => '#202202',
 							),
 							'/js/src/icons/cluster'     => array(
-								'url' => JEO_BASEURL . '/js/src/icons/cluster.png',
+								'url' => add_query_arg(
+									'ver',
+									JEO_VERSION,
+									JEO_BASEURL . '/js/src/icons/cluster.png'
+								),
 							),
 						)
 					),
@@ -1082,9 +1111,20 @@ class Jeo {
 	public function enqueue_discovery_scripts() {
 		$current_language = $this->get_current_language();
 
-		$discovery_assets = include JEO_BASEPATH . '/js/build/discovery.asset.php';
-		wp_enqueue_style( 'discovery-map', JEO_BASEURL . '/js/build/discovery.css', array(), JEO_VERSION );
-		wp_enqueue_script( 'discovery-map', JEO_BASEURL . '/js/build/discovery.js', array_merge( $discovery_assets['dependencies'] ?? array(), array( 'jeo-map' ) ), JEO_VERSION, true );
+		$discovery_assets = require JEO_BASEPATH . '/js/build/discovery.asset.php';
+		wp_enqueue_style(
+			'discovery-map',
+			JEO_BASEURL . '/js/build/discovery.css',
+			array(),
+			$discovery_assets['version']
+		);
+		wp_enqueue_script(
+			'discovery-map',
+			JEO_BASEURL . '/js/build/discovery.js',
+			array_merge( $discovery_assets['dependencies'], array( 'jeo-map' ) ),
+			$discovery_assets['version'],
+			true
+		);
 
 		wp_set_script_translations( 'discovery-map', 'jeo', JEO_BASEPATH . 'languages' );
 
@@ -1118,9 +1158,20 @@ class Jeo {
 	 * @return void
 	 */
 	public function enqueue_storymap_scripts() {
-		$storymap_assets = include JEO_BASEPATH . '/js/build/jeoStorymap.asset.php';
-		wp_enqueue_style( 'jeo-storymap', JEO_BASEURL . '/js/build/jeoStorymap.css', array( 'jeo-map' ), JEO_VERSION );
-		wp_enqueue_script( 'jeo-storymap', JEO_BASEURL . '/js/build/jeoStorymap.js', array_merge( $storymap_assets['dependencies'] ?? array(), array( 'jeo-map', 'mapgl-react' ) ), JEO_VERSION, true );
+		$storymap_assets = require JEO_BASEPATH . '/js/build/jeoStorymap.asset.php';
+		wp_enqueue_style(
+			'jeo-storymap',
+			JEO_BASEURL . '/js/build/jeoStorymap.css',
+			array( 'jeo-map' ),
+			$storymap_assets['version']
+		);
+		wp_enqueue_script(
+			'jeo-storymap',
+			JEO_BASEURL . '/js/build/jeoStorymap.js',
+			array_merge( $storymap_assets['dependencies'], array( 'jeo-map', 'mapgl-react' ) ),
+			$storymap_assets['version'],
+			true
+		);
 
 		wp_set_script_translations( 'jeo-storymap', 'jeo', JEO_BASEPATH . 'languages' );
 	}

--- a/src/includes/layer-types/class-layer-types.php
+++ b/src/includes/layer-types/class-layer-types.php
@@ -168,11 +168,11 @@ class Layer_Types {
 	 * @return void
 	 */
 	public function register_assets() {
-		$asset_file = include JEO_BASEPATH . '/js/build/JeoLayer.asset.php';
+		$asset_file = require JEO_BASEPATH . '/js/build/JeoLayer.asset.php';
 		wp_register_script(
 			'jeo-layer',
 			JEO_BASEURL . '/js/build/JeoLayer.js',
-			array( 'mapgl' ),
+			array_merge( $asset_file['dependencies'], array( 'mapgl' ) ),
 			$asset_file['version'],
 			true,
 		);

--- a/src/includes/legend-types/class-legend-types.php
+++ b/src/includes/legend-types/class-legend-types.php
@@ -161,11 +161,11 @@ class Legend_Types {
 	 * @return void
 	 */
 	public function register_assets() {
-		$asset_file = include JEO_BASEPATH . '/js/build/JeoLegend.asset.php';
+		$asset_file = require JEO_BASEPATH . '/js/build/JeoLegend.asset.php';
 		wp_register_script(
 			'jeo-legend',
 			JEO_BASEURL . '/js/build/JeoLegend.js',
-			array( 'mapgl' ),
+			array_merge( $asset_file['dependencies'], array( 'mapgl' ) ),
 			$asset_file['version'],
 			true,
 		);

--- a/src/includes/loaders.php
+++ b/src/includes/loaders.php
@@ -421,11 +421,13 @@ add_action( 'wp_head', 'jeo_custom_settings_css_wrap' );
 function jeo_scripts_typography() {
 	$primary_font_url = jeo_normalize_asset_url( \jeo_settings()->get_option( 'jeo_typography' ) );
 	if ( '' !== $primary_font_url ) {
-		wp_enqueue_style( 'jeo-font', $primary_font_url, array(), JEO_VERSION );
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- Administrator-configured URLs should manage their own cache policy.
+		wp_enqueue_style( 'jeo-font', $primary_font_url, array(), null );
 	}
 	$secondary_font_url = jeo_normalize_asset_url( \jeo_settings()->get_option( 'jeo_typography-stories' ) );
 	if ( '' !== $secondary_font_url ) {
-		wp_enqueue_style( 'jeo-font-stories', $secondary_font_url, array(), JEO_VERSION );
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- Administrator-configured URLs should manage their own cache policy.
+		wp_enqueue_style( 'jeo-font-stories', $secondary_font_url, array(), null );
 	}
 }
 add_action( 'wp_enqueue_scripts', 'jeo_scripts_typography' );

--- a/src/includes/sidebars/class-sidebars.php
+++ b/src/includes/sidebars/class-sidebars.php
@@ -49,16 +49,21 @@ class Sidebars {
 	 * @return void
 	 */
 	public function load_assets() {
-		$layers_sidebar_asset = include JEO_BASEPATH . '/js/build/layersSidebar.asset.php';
-		$maps_sidebar_asset   = include JEO_BASEPATH . '/js/build/mapsSidebar.asset.php';
+		$layers_sidebar_asset = require JEO_BASEPATH . '/js/build/layersSidebar.asset.php';
+		$maps_sidebar_asset   = require JEO_BASEPATH . '/js/build/mapsSidebar.asset.php';
 		$layer_type_handles   = \Jeo\Layer_Types::get_instance()->get_layer_type_script_handles();
 
-		wp_enqueue_style( 'jeo-layers-sidebar', JEO_BASEURL . '/js/build/layersSidebar.css', array( 'mapgl', 'mapgl-react-style' ), JEO_VERSION );
+		wp_enqueue_style(
+			'jeo-layers-sidebar',
+			JEO_BASEURL . '/js/build/layersSidebar.css',
+			array( 'mapgl', 'mapgl-react-style' ),
+			$layers_sidebar_asset['version']
+		);
 		wp_enqueue_script(
 			'jeo-layers-sidebar',
 			JEO_BASEURL . '/js/build/layersSidebar.js',
 			array_merge(
-				$layers_sidebar_asset['dependencies'] ?? array(),
+				$layers_sidebar_asset['dependencies'],
 				array( 'mapgl-react' ),
 				$layer_type_handles
 			),
@@ -68,12 +73,17 @@ class Sidebars {
 
 		wp_set_script_translations( 'jeo-layers-sidebar', 'jeo', JEO_BASEPATH . 'languages' );
 
-		wp_enqueue_style( 'jeo-maps-sidebar', JEO_BASEURL . '/js/build/mapsSidebar.css', array( 'mapgl', 'mapgl-react-style' ), JEO_VERSION );
+		wp_enqueue_style(
+			'jeo-maps-sidebar',
+			JEO_BASEURL . '/js/build/mapsSidebar.css',
+			array( 'mapgl', 'mapgl-react-style' ),
+			$maps_sidebar_asset['version']
+		);
 		wp_enqueue_script(
 			'jeo-maps-sidebar',
 			JEO_BASEURL . '/js/build/mapsSidebar.js',
 			array_merge(
-				$maps_sidebar_asset['dependencies'] ?? array(),
+				$maps_sidebar_asset['dependencies'],
 				array( 'mapgl-react' ),
 				$layer_type_handles
 			),

--- a/src/languages/jeo-es_CO.po
+++ b/src/languages/jeo-es_CO.po
@@ -36,15 +36,15 @@ msgstr "Mapas interactivos para el editor de bloques de WordPress"
 msgid "InfoAmazonia"
 msgstr "InfoAmazonia"
 
-#: includes/class-jeo.php:561
+#: includes/class-jeo.php:568
 msgid "Mapbox was selected as the rendering library, but no Mapbox API key is configured. Falling back to MapLibre."
 msgstr "Se seleccionó Mapbox como biblioteca de renderizado, pero no hay ninguna clave de API de Mapbox configurada. Se volverá a MapLibre."
 
-#: includes/class-jeo.php:562
+#: includes/class-jeo.php:569
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr "Se seleccionó Mapbox como biblioteca de renderizado, pero no se pudo cargar el SDK externo de Mapbox. Se volverá a MapLibre."
 
-#: includes/class-jeo.php:1026
+#: includes/class-jeo.php:1039
 msgid "Read more"
 msgstr "Leer más"
 
@@ -207,7 +207,7 @@ msgid "Layer type not registered"
 msgstr "Tipo de capa no registrada"
 
 #. translators: Explore is the name of JEO's discovery page feature.
-#: includes/loaders.php:490
+#: includes/loaders.php:492
 #: templates/embed-discovery.php:18
 #: js/build/discovery.js:6
 msgid "Explore"

--- a/src/languages/jeo-pt_BR.po
+++ b/src/languages/jeo-pt_BR.po
@@ -36,15 +36,15 @@ msgstr "Mapas interativos para o editor de blocos do WordPress"
 msgid "InfoAmazonia"
 msgstr "InfoAmazonia"
 
-#: includes/class-jeo.php:561
+#: includes/class-jeo.php:568
 msgid "Mapbox was selected as the rendering library, but no Mapbox API key is configured. Falling back to MapLibre."
 msgstr "Mapbox foi selecionado como biblioteca de renderização, mas nenhuma chave de API do Mapbox está configurada. Voltando para MapLibre."
 
-#: includes/class-jeo.php:562
+#: includes/class-jeo.php:569
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr "Mapbox foi selecionado como biblioteca de renderização, mas o SDK externo do Mapbox não pôde ser carregado. Voltando para MapLibre."
 
-#: includes/class-jeo.php:1026
+#: includes/class-jeo.php:1039
 msgid "Read more"
 msgstr "Ler mais"
 
@@ -207,7 +207,7 @@ msgid "Layer type not registered"
 msgstr "Tipo de camada não registrado"
 
 #. translators: Explore is the name of JEO's discovery page feature.
-#: includes/loaders.php:490
+#: includes/loaders.php:492
 #: templates/embed-discovery.php:18
 #: js/build/discovery.js:6
 msgid "Explore"

--- a/src/languages/jeo.pot
+++ b/src/languages/jeo.pot
@@ -44,15 +44,15 @@ msgstr ""
 msgid "Request context."
 msgstr ""
 
-#: includes/class-jeo.php:561
+#: includes/class-jeo.php:568
 msgid "Mapbox was selected as the rendering library, but no Mapbox API key is configured. Falling back to MapLibre."
 msgstr ""
 
-#: includes/class-jeo.php:562
+#: includes/class-jeo.php:569
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr ""
 
-#: includes/class-jeo.php:1026
+#: includes/class-jeo.php:1039
 msgid "Read more"
 msgstr ""
 
@@ -221,7 +221,7 @@ msgid "<p>JEO can connect to third-party services depending on your configuratio
 msgstr ""
 
 #. translators: Explore is the name of JEO's discovery page feature.
-#: includes/loaders.php:490
+#: includes/loaders.php:492
 #: templates/embed-discovery.php:18
 #: js/build/discovery.js:6
 msgid "Explore"


### PR DESCRIPTION
## Summary

Fixes #604 by making asset versioning explicit across the plugin:

- Require the generated `*.asset.php` metadata for every bundled `src/js/build` entrypoint that is enqueued from PHP.
- Use the generated content-hash version for both JavaScript bundles and their matching CSS sidecars.
- Remove silent `JEO_VERSION` fallbacks from build-generated assets so incomplete release builds fail visibly instead of serving mixed cache versions.
- Keep `JEO_VERSION` for local static plugin assets by adding explicit `?ver=JEO_VERSION` cache busting to the map icon URLs passed through `jeoMapVars.images`.
- Leave local layer/legend/settings helper scripts on `JEO_VERSION` and keep external Mapbox SDK assets on the vendor SDK version.
- Stop appending the plugin version to administrator-configured typography stylesheet URLs, allowing those URLs to control their own cache policy.
- Build the ignored webpack outputs before the WordPress smoke matrix activates the plugin, because bootstrap now deliberately requires generated asset metadata.
- Refresh the affected POT/PO line references after the PHP enqueue changes.

## Why

Issue #604 describes a production cache-mixing risk where rebuilt packages can produce new `@wordpress/scripts` content hashes for some files while other related assets continue using the unchanged public plugin version. That can let Cloudflare or browser caches serve an incompatible mix of webpack runtime and dependent bundles.

This PR aligns the enqueued URL versions with the generated asset metadata for build outputs, while preserving plugin-version cache busting only for static plugin files that are not part of the build pipeline.

## Validation

Local checks:

- `php -l src/includes/class-jeo.php && php -l src/includes/sidebars/class-sidebars.php && php -l src/includes/layer-types/class-layer-types.php && php -l src/includes/legend-types/class-legend-types.php && php -l src/includes/loaders.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist src/includes/class-jeo.php src/includes/sidebars/class-sidebars.php src/includes/layer-types/class-layer-types.php src/includes/legend-types/class-legend-types.php src/includes/loaders.php`
- `git diff --check`
- `rg -n 'include .*js/build/.*asset\.php|\?\? JEO_VERSION|js/build/.*JEO_VERSION' src/includes || true`
- `npm run build:assets`
- `npm run test:unit -- --runInBand`

GitHub checks on the latest PR SHA are passing, including the WordPress smoke matrix, language file validation, Node frontend checks, PHPCS/WPCS, PHPCompatibilityWP, Plugin Check, and Dependency Review.