### PR TITLE
Reuse built assets in WordPress smoke matrix

### DIFF
--- a/.github/workflows/wordpress-smoke.yml
+++ b/.github/workflows/wordpress-smoke.yml
@@ -6,9 +6,36 @@ on:
   workflow_dispatch:
 
 jobs:
+  build-smoke-assets:
+    name: Build smoke test assets
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build plugin assets
+        run: npm run build:assets
+
+      - name: Upload smoke test assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: wordpress-smoke-assets
+          path: src/js/build
+          if-no-files-found: error
+          retention-days: 1
+
   wordpress-smoke:
     name: ${{ matrix.label }}
     runs-on: ubuntu-latest
+    needs: build-smoke-assets
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -58,10 +85,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - name: Download smoke test assets
+        uses: actions/download-artifact@v7
         with:
-          node-version: 24
-          cache: npm
+          name: wordpress-smoke-assets
+          path: src/js/build
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -72,12 +100,6 @@ jobs:
 
       - name: Show PHP version
         run: php -v
-
-      - name: Install frontend dependencies
-        run: npm ci
-
-      - name: Build plugin assets
-        run: npm run build:assets
 
       - name: Wait for MariaDB
         env:


### PR DESCRIPTION
## Summary

Addresses the follow-up from the PR #607 review comment:
https://github.com/InfoAmazonia/jeo-plugin/pull/607#discussion_r3383718042

- Builds the ignored webpack outputs once in a dedicated `build-smoke-assets` job.
- Uploads `src/js/build` as a short-lived `wordpress-smoke-assets` artifact.
- Makes the WordPress smoke matrix depend on that job and download the generated build directory before plugin activation.
- Removes the repeated `actions/setup-node`, `npm ci`, and `npm run build:assets` steps from every matrix entry.

## Why

PR #607 made the WordPress smoke tests build assets inside each matrix job so the plugin could require generated `*.asset.php` metadata during bootstrap. That fixed the missing asset metadata failure, but repeated the same Node install and webpack build six times.

This keeps the required generated assets available for every smoke job while avoiding repeated frontend dependency installation and repeated asset builds across the matrix.

## Validation

Local checks:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/wordpress-smoke.yml"); puts "YAML ok"'`
- `git diff --check`
- `npm run build:assets`
- `actionlint .github/workflows/wordpress-smoke.yml`

Note: `actionlint` still reports the pre-existing ShellCheck `SC2016` warning in the inline PHP script used by the MariaDB wait step. I confirmed the same warning exists on `upstream/release/3.0.0`, so this PR does not introduce it.

GitHub checks are passing on this PR. The new `Build smoke test assets` job passed, and all WordPress smoke matrix jobs passed after downloading the generated build artifact.