### PR TITLE
Forward-port smoke asset reuse to develop

### DIFF
--- a/.github/workflows/wordpress-smoke.yml
+++ b/.github/workflows/wordpress-smoke.yml
@@ -6,9 +6,36 @@ on:
   workflow_dispatch:
 
 jobs:
+  build-smoke-assets:
+    name: Build smoke test assets
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build plugin assets
+        run: npm run build:assets
+
+      - name: Upload smoke test assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: wordpress-smoke-assets
+          path: src/js/build
+          if-no-files-found: error
+          retention-days: 1
+
   wordpress-smoke:
     name: ${{ matrix.label }}
     runs-on: ubuntu-latest
+    needs: build-smoke-assets
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -58,10 +85,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - name: Download smoke test assets
+        uses: actions/download-artifact@v7
         with:
-          node-version: 24
-          cache: npm
+          name: wordpress-smoke-assets
+          path: src/js/build
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -72,12 +100,6 @@ jobs:
 
       - name: Show PHP version
         run: php -v
-
-      - name: Install frontend dependencies
-        run: npm ci
-
-      - name: Build plugin assets
-        run: npm run build:assets
 
       - name: Wait for MariaDB
         env:


### PR DESCRIPTION
## Summary

Forward-ports the CI optimization merged into `release/3.0.0` in #608 back to `develop`.

- Builds `src/js/build` once in the WordPress smoke workflow.
- Uploads the generated build directory as a short-lived `wordpress-smoke-assets` artifact.
- Downloads that artifact in each WordPress matrix job before plugin activation.
- Avoids repeating `actions/setup-node`, `npm ci`, and `npm run build:assets` in every smoke matrix job.

## Why

#608 addressed the review concern from #607:
https://github.com/InfoAmazonia/jeo-plugin/pull/607#discussion_r3383718042

That fix landed first on `release/3.0.0`, but `develop` needs the same workflow shape so the branches do not diverge and future work keeps the less wasteful smoke test setup.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/wordpress-smoke.yml"); puts "YAML ok"'`
- `git diff --check upstream/develop...HEAD`
- `npm run build:assets`
- `actionlint .github/workflows/wordpress-smoke.yml`

Note: `actionlint` still reports the pre-existing ShellCheck `SC2016` warning in the MariaDB wait step. The same warning exists on `upstream/develop`, so this PR does not introduce it.