### PR TITLE
Address release 3.0.0 code quality review

### DIFF
--- a/src/js/src/discovery/blocks/stories.js
+++ b/src/js/src/discovery/blocks/stories.js
@@ -498,11 +498,7 @@ class Stories extends Component {
 
 			const hoveredClusterKey = `${ clusterId }:${ pointCount }`;
 
-			if (
-				clusterId &&
-				pointCount &&
-				this.hoveredClusterKey === hoveredClusterKey
-			) {
+			if ( this.hoveredClusterKey === hoveredClusterKey ) {
 				return;
 			}
 


### PR DESCRIPTION
## Summary
- Applies the `github-code-quality` inline review suggestion from #614.
- Removes redundant `clusterId` and `pointCount` truthiness checks after the existing early-return guard in `handleClusterMouseMove`.
- No functional behavior change.

## Validation
- `npm run test:unit -- src/js/src/discovery/blocks/stories.test.js --runInBand`
- `git diff --check`

## Context
Follow-up before pushing the `3.0.0` tag, because #614 had already been merged when the code-quality comment was reviewed.
