### PR TITLE
Split GitHub release from WordPress.org deploy

### DIFF
--- a/.github/workflows/deploy-wordpress-org.yml
+++ b/.github/workflows/deploy-wordpress-org.yml
@@ -1,4 +1,4 @@
-name: Deploy to WordPress.org
+name: Release
 on:
   push:
     tags:
@@ -9,7 +9,7 @@ permissions:
   contents: write
 jobs:
   tag:
-    name: Stable tag deploy
+    name: Stable tag release
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -43,19 +43,26 @@ jobs:
         build-dir: ${{ runner.temp }}/plugin-check-build/jeo
         slug: jeo
         include-experimental: false
+    - name: Build GitHub release zip
+      run: |
+        rm -rf "${RUNNER_TEMP}/github-release"
+        mkdir -p "${RUNNER_TEMP}/github-release/jeo"
+        rsync -a --delete src/ "${RUNNER_TEMP}/github-release/jeo/"
+        cd "${RUNNER_TEMP}/github-release"
+        zip -qr "${RUNNER_TEMP}/jeo.zip" jeo
+    - name: Publish GitHub release
+      uses: softprops/action-gh-release@v3
+      with:
+        files: ${{ runner.temp }}/jeo.zip
+        generate_release_notes: true
     - name: WordPress Plugin Deploy
-      id: wordpress_org_deploy
+      if: vars.WPORG_DEPLOY_ENABLED == 'true'
       uses: 10up/action-wordpress-plugin-deploy@stable
       with:
-        generate-zip: true
+        generate-zip: false
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: jeo # optional, remove if GitHub repo name matches SVN slug, including capitalization
         BUILD_DIR: src
         ASSETS_DIR: .wordpress-org
-    - name: Publish GitHub release
-      uses: softprops/action-gh-release@v3
-      with:
-        files: ${{ steps.wordpress_org_deploy.outputs.zip-path }}
-        generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -155,11 +155,12 @@ rsync --archive --progress --human-readable --delete ./src/ /path/to/wordpress/w
 
 ## Releasing
 
-WordPress.org releases are built from `src/`, not from the repository root.
-The deploy workflow also publishes assets from `.wordpress-org/`.
-When a stable release tag is pushed, the workflow also creates a GitHub Release
-that keeps GitHub's source-code archives and attaches a built `jeo.zip`
-artifact generated from `src/`.
+Release packages are built from `src/`, not from the repository root.
+When a stable release tag is pushed, the release workflow creates a GitHub
+Release that keeps GitHub's source-code archives and attaches a built `jeo.zip`
+artifact generated from `src/`. WordPress.org deployment uses the same `src/`
+tree and publishes assets from `.wordpress-org/`, but it only runs when the
+`WPORG_DEPLOY_ENABLED` repository variable is set to `true`.
 
 Prerelease branches may carry a SemVer prerelease such as `3.1.0-rc.1` while
 WordPress.org stays on the latest stable release. Before creating a stable
@@ -171,7 +172,7 @@ release tag, run `npm run sync:version` and keep these files aligned:
 - `package-lock.json`
 - `.wordpress-org/`
 
-The deploy workflow now validates that:
+The release workflow now validates that:
 
 - the plugin version in `src/jeo.php` matches `JEO_VERSION`
 - `package.json` and the root package entry in `package-lock.json` match the plugin version
@@ -181,8 +182,11 @@ The deploy workflow now validates that:
 
 Pull requests and pushes also run the same staged Plugin Check build through `.github/workflows/plugin-check.yml`, so WordPress.org compliance failures are caught before the release tag workflow.
 
-Pre-release tags such as `-rc` are intentionally blocked from the WordPress.org deploy pipeline.
-Stable tag releases only proceed to WordPress.org deployment after Plugin Check passes; a failing check blocks the release before any publish step runs.
+Pre-release tags such as `-rc` are intentionally blocked from the stable release pipeline.
+Stable tag releases only publish a GitHub Release after Plugin Check passes; a
+failing check blocks all publish steps. WordPress.org deployment runs after the
+GitHub Release step only when `WPORG_DEPLOY_ENABLED=true`, so the same tag
+workflow can be rerun later after WordPress.org SVN access is available.
 
 Release validation and packaging should use:
 


### PR DESCRIPTION
## Summary
- Builds the GitHub Release `jeo.zip` directly from `src/` in the stable tag workflow.
- Publishes the GitHub Release before any WordPress.org/SVN deploy step.
- Gates the WordPress.org deploy step behind the `WPORG_DEPLOY_ENABLED=true` repository variable so stable tags can be published on GitHub while WordPress.org access is unavailable.
- Documents the new release/deploy behavior in the README.

## Validation
- `git diff --check`
- YAML parsed successfully with Ruby/Psych
- `actionlint .github/workflows/deploy-wordpress-org.yml`
- Local zip-generation smoke test using the new workflow commands

## Notes
The stable tag workflow can be rerun later with `WPORG_DEPLOY_ENABLED=true` after WordPress.org SVN/listing access is restored.
