### PR TITLE
Share WordPress Plugin Check release workflow

### DIFF
--- a/.github/actions/wordpress-plugin-check/action.yml
+++ b/.github/actions/wordpress-plugin-check/action.yml
@@ -1,0 +1,126 @@
+name: WordPress Plugin Check
+description: Install WordPress, install the Plugin Check plugin, and run checks against a built plugin directory.
+
+inputs:
+  plugin-slug:
+    description: WordPress plugin slug to install and check.
+    default: jeo
+  plugin-build-dir:
+    description: Built plugin directory to copy into the WordPress installation.
+    required: true
+  results-path:
+    description: Path where the JSON Plugin Check output should be written.
+    required: true
+  wp-path:
+    description: WordPress installation path.
+    default: /tmp/wordpress
+  wp-version:
+    description: WordPress version to install.
+    default: latest
+  wp-url:
+    description: Local WordPress site URL.
+    default: http://localhost:8880
+  db-name:
+    description: WordPress database name.
+    default: wordpress
+  db-user:
+    description: WordPress database user.
+    default: root
+  db-pass:
+    description: WordPress database password.
+    default: root
+  db-host:
+    description: WordPress database host.
+    default: 127.0.0.1:3306
+
+runs:
+  using: composite
+  steps:
+    - name: Install WordPress and Plugin Check
+      shell: bash
+      env:
+        DB_HOST: ${{ inputs.db-host }}
+        DB_NAME: ${{ inputs.db-name }}
+        DB_PASS: ${{ inputs.db-pass }}
+        DB_USER: ${{ inputs.db-user }}
+        PLUGIN_BUILD_DIR: ${{ inputs.plugin-build-dir }}
+        PLUGIN_SLUG: ${{ inputs.plugin-slug }}
+        WP_PATH: ${{ inputs.wp-path }}
+        WP_URL: ${{ inputs.wp-url }}
+        WP_VERSION: ${{ inputs.wp-version }}
+      run: |
+        set -euo pipefail
+
+        rm -rf "$WP_PATH"
+
+        wp core download --path="$WP_PATH" --version="$WP_VERSION" --force
+        wp config create \
+          --path="$WP_PATH" \
+          --dbname="$DB_NAME" \
+          --dbuser="$DB_USER" \
+          --dbpass="$DB_PASS" \
+          --dbhost="$DB_HOST" \
+          --skip-check \
+          --force
+        wp core install \
+          --path="$WP_PATH" \
+          --url="$WP_URL" \
+          --title="Plugin Check" \
+          --admin_user=admin \
+          --admin_password=password \
+          --admin_email=admin@example.com \
+          --skip-email
+        wp plugin install \
+          --path="$WP_PATH" \
+          https://downloads.wordpress.org/plugin/plugin-check.zip \
+          --activate
+
+        rm -rf "$WP_PATH/wp-content/plugins/$PLUGIN_SLUG"
+        mkdir -p "$WP_PATH/wp-content/plugins/$PLUGIN_SLUG"
+        rsync -a --delete "$PLUGIN_BUILD_DIR/" "$WP_PATH/wp-content/plugins/$PLUGIN_SLUG/"
+
+    - name: Run WordPress Plugin Check
+      shell: bash
+      env:
+        PLUGIN_CHECK_RESULTS: ${{ inputs.results-path }}
+        PLUGIN_SLUG: ${{ inputs.plugin-slug }}
+        WP_PATH: ${{ inputs.wp-path }}
+      run: |
+        set -euo pipefail
+
+        echo "::group::Debugging information"
+        wp --path="$WP_PATH" cli info
+        wp --path="$WP_PATH" plugin list
+        wp --path="$WP_PATH" --require="$WP_PATH/wp-content/plugins/plugin-check/cli.php" plugin list-checks
+        wp --path="$WP_PATH" --require="$WP_PATH/wp-content/plugins/plugin-check/cli.php" plugin list-check-categories
+        echo "::endgroup::"
+
+        echo "::group::Install dependencies"
+        DEPENDENCIES_RAW=$(wp --path="$WP_PATH" plugin get "$PLUGIN_SLUG" --field=requires_plugins | tr ',' ' ' | xargs || true)
+
+        if [ -z "$DEPENDENCIES_RAW" ]; then
+          echo "Plugin has no dependencies"
+        else
+          read -r -a DEPENDENCIES <<< "$DEPENDENCIES_RAW"
+          echo "Installing plugin dependencies: $DEPENDENCIES_RAW"
+          wp --path="$WP_PATH" plugin install --activate "${DEPENDENCIES[@]}"
+        fi
+        echo "::endgroup::"
+
+        wp --path="$WP_PATH" plugin activate "$PLUGIN_SLUG"
+
+        echo "::group::Run Plugin Check"
+        set +e
+        wp --path="$WP_PATH" \
+          --require="$WP_PATH/wp-content/plugins/plugin-check/cli.php" \
+          plugin check "$PLUGIN_SLUG" \
+          --format=json \
+          --slug="$PLUGIN_SLUG" \
+          --exclude-files=.wp-env.json \
+          > "$PLUGIN_CHECK_RESULTS"
+        status=$?
+        set -e
+        cat "$PLUGIN_CHECK_RESULTS"
+        echo "::endgroup::"
+
+        exit "$status"

--- a/.github/workflows/deploy-wordpress-org.yml
+++ b/.github/workflows/deploy-wordpress-org.yml
@@ -11,6 +11,23 @@ jobs:
   tag:
     name: Stable tag release
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: wordpress
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - '3306:3306'
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      WP_PATH: /tmp/wordpress
+      PLUGIN_BUILD_DIR: /tmp/plugin-check-build/jeo
+      PLUGIN_CHECK_RESULTS: /tmp/plugin-check-results.txt
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
@@ -21,6 +38,7 @@ jobs:
       with:
         php-version: '8.4'
         coverage: none
+        extensions: mysqli
         tools: wp-cli
     - name: Install frontend dependencies
       run: |
@@ -35,14 +53,21 @@ jobs:
     - name: Prepare Plugin Check build
       run: |
         rm -rf "${RUNNER_TEMP}/plugin-check-build"
-        mkdir -p "${RUNNER_TEMP}/plugin-check-build/jeo"
-        rsync -a --delete src/ "${RUNNER_TEMP}/plugin-check-build/jeo/"
+        mkdir -p "$PLUGIN_BUILD_DIR"
+        rsync -a --delete src/ "$PLUGIN_BUILD_DIR/"
     - name: Run WordPress Plugin Check
-      uses: wordpress/plugin-check-action@v1
+      uses: ./.github/actions/wordpress-plugin-check
       with:
-        build-dir: ${{ runner.temp }}/plugin-check-build/jeo
-        slug: jeo
-        include-experimental: false
+        plugin-build-dir: ${{ env.PLUGIN_BUILD_DIR }}
+        results-path: ${{ env.PLUGIN_CHECK_RESULTS }}
+        wp-path: ${{ env.WP_PATH }}
+    - name: Upload Plugin Check results
+      uses: actions/upload-artifact@v7
+      if: ${{ always() }}
+      with:
+        name: plugin-check-results-jeo
+        path: ${{ env.PLUGIN_CHECK_RESULTS }}
+        if-no-files-found: ignore
     - name: Build GitHub release zip
       run: |
         rm -rf "${RUNNER_TEMP}/github-release"

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -57,69 +57,12 @@ jobs:
           mkdir -p "$PLUGIN_BUILD_DIR"
           rsync -a --delete src/ "$PLUGIN_BUILD_DIR/"
 
-      - name: Install WordPress and Plugin Check
-        run: |
-          wp core download --path="$WP_PATH" --version=latest --force
-          wp config create \
-            --path="$WP_PATH" \
-            --dbname=wordpress \
-            --dbuser=root \
-            --dbpass=root \
-            --dbhost=127.0.0.1:3306 \
-            --skip-check \
-            --force
-          wp core install \
-            --path="$WP_PATH" \
-            --url=http://localhost:8880 \
-            --title="Plugin Check" \
-            --admin_user=admin \
-            --admin_password=password \
-            --admin_email=admin@example.com \
-            --skip-email
-          wp plugin install \
-            --path="$WP_PATH" \
-            https://downloads.wordpress.org/plugin/plugin-check.zip \
-            --activate
-          rsync -a --delete "$PLUGIN_BUILD_DIR/" "$WP_PATH/wp-content/plugins/jeo/"
-
       - name: Run WordPress Plugin Check
-        run: |
-          echo "::group::Debugging information"
-          wp --path="$WP_PATH" cli info
-          wp --path="$WP_PATH" plugin list
-          wp --path="$WP_PATH" --require="$WP_PATH/wp-content/plugins/plugin-check/cli.php" plugin list-checks
-          wp --path="$WP_PATH" --require="$WP_PATH/wp-content/plugins/plugin-check/cli.php" plugin list-check-categories
-          echo "::endgroup::"
-
-          echo "::group::Install dependencies"
-          DEPENDENCIES_RAW=$(wp --path="$WP_PATH" plugin get jeo --field=requires_plugins | tr ',' ' ')
-
-          if [ -z "$DEPENDENCIES_RAW" ]; then
-            echo "Plugin has no dependencies"
-          else
-            read -r -a DEPENDENCIES <<< "$DEPENDENCIES_RAW"
-            echo "Installing plugin dependencies: $DEPENDENCIES_RAW"
-            wp --path="$WP_PATH" plugin install --activate "${DEPENDENCIES[@]}"
-          fi
-          echo "::endgroup::"
-
-          wp --path="$WP_PATH" plugin activate jeo
-
-          echo "::group::Run Plugin Check"
-          set +e
-          wp --path="$WP_PATH" \
-            --require="$WP_PATH/wp-content/plugins/plugin-check/cli.php" \
-            plugin check jeo \
-            --format=json \
-            --slug=jeo \
-            --exclude-files=.wp-env.json \
-            > "$PLUGIN_CHECK_RESULTS"
-          status=$?
-          set -e
-          cat "$PLUGIN_CHECK_RESULTS"
-          echo "::endgroup::"
-
-          exit "$status"
+        uses: ./.github/actions/wordpress-plugin-check
+        with:
+          plugin-build-dir: ${{ env.PLUGIN_BUILD_DIR }}
+          results-path: ${{ env.PLUGIN_CHECK_RESULTS }}
+          wp-path: ${{ env.WP_PATH }}
 
       - name: Upload Plugin Check results
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Add a reusable local GitHub Action for installing WordPress, installing the Plugin Check plugin, and running Plugin Check via WP-CLI.
- Reuse that action in the dedicated Plugin Check workflow.
- Switch the stable tag release workflow away from wordpress/plugin-check-action@v1 and onto the same WP-CLI path that passes in PR checks.

## Why
The 3.0.0 stable tag workflow failed inside wordpress/plugin-check-action@v1 before Plugin Check actually ran because wp-env reported an uninitialized environment after wp-env start. The dedicated WordPress Plugin Check workflow already uses a more explicit WP-CLI setup and passed for the same commit/tag.

## Testing
- ruby YAML parse for the local action and both workflows
- actionlint .github/workflows/plugin-check.yml .github/workflows/deploy-wordpress-org.yml
- git diff --check