### PR TITLE
Restore jeowp distribution slug

### DIFF
--- a/.github/actions/wordpress-plugin-check/action.yml
+++ b/.github/actions/wordpress-plugin-check/action.yml
@@ -4,7 +4,7 @@ description: Install WordPress, install the Plugin Check plugin, and run checks 
 inputs:
   plugin-slug:
     description: WordPress plugin slug to install and check.
-    default: jeo
+    default: jeowp
   plugin-build-dir:
     description: Built plugin directory to copy into the WordPress installation.
     required: true

--- a/.github/workflows/deploy-wordpress-org.yml
+++ b/.github/workflows/deploy-wordpress-org.yml
@@ -26,7 +26,7 @@ jobs:
           --health-retries=10
     env:
       WP_PATH: /tmp/wordpress
-      PLUGIN_BUILD_DIR: /tmp/plugin-check-build/jeo
+      PLUGIN_BUILD_DIR: /tmp/plugin-check-build/jeowp
       PLUGIN_CHECK_RESULTS: /tmp/plugin-check-results.txt
     steps:
     - uses: actions/checkout@v6
@@ -65,20 +65,20 @@ jobs:
       uses: actions/upload-artifact@v7
       if: ${{ always() }}
       with:
-        name: plugin-check-results-jeo
+        name: plugin-check-results-jeowp
         path: ${{ env.PLUGIN_CHECK_RESULTS }}
         if-no-files-found: ignore
     - name: Build GitHub release zip
       run: |
         rm -rf "${RUNNER_TEMP}/github-release"
-        mkdir -p "${RUNNER_TEMP}/github-release/jeo"
-        rsync -a --delete src/ "${RUNNER_TEMP}/github-release/jeo/"
+        mkdir -p "${RUNNER_TEMP}/github-release/jeowp"
+        rsync -a --delete src/ "${RUNNER_TEMP}/github-release/jeowp/"
         cd "${RUNNER_TEMP}/github-release"
-        zip -qr "${RUNNER_TEMP}/jeo.zip" jeo
+        zip -qr "${RUNNER_TEMP}/jeowp.zip" jeowp
     - name: Publish GitHub release
       uses: softprops/action-gh-release@v3
       with:
-        files: ${{ runner.temp }}/jeo.zip
+        files: ${{ runner.temp }}/jeowp.zip
         generate_release_notes: true
     - name: WordPress Plugin Deploy
       if: vars.WPORG_DEPLOY_ENABLED == 'true'
@@ -88,6 +88,6 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        SLUG: jeo # optional, remove if GitHub repo name matches SVN slug, including capitalization
+        SLUG: jeowp # optional, remove if GitHub repo name matches SVN slug, including capitalization
         BUILD_DIR: src
         ASSETS_DIR: .wordpress-org

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -27,7 +27,7 @@ jobs:
           --health-retries=10
     env:
       WP_PATH: /tmp/wordpress
-      PLUGIN_BUILD_DIR: /tmp/plugin-check-build/jeo
+      PLUGIN_BUILD_DIR: /tmp/plugin-check-build/jeowp
       PLUGIN_CHECK_RESULTS: /tmp/plugin-check-results.txt
 
     steps:
@@ -68,6 +68,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
-          name: plugin-check-results-jeo
+          name: plugin-check-results-jeowp
           path: ${{ env.PLUGIN_CHECK_RESULTS }}
           if-no-files-found: ignore

--- a/.github/workflows/wordpress-languages.yml
+++ b/.github/workflows/wordpress-languages.yml
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: true
         uses: holyhope/test-wordpress-languages-github-action@v4.0.2
         with:
-          slug: jeo
+          slug: jeowp
           source: src
           pot_file: src/languages/jeo.pot
           domain: jeo

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src/js/build
 src/languages/*.mo
 src/languages/*.json
 jeo.zip
+jeowp.zip
 .env
 
 /wordpress/

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ git clone git@github.com:InfoAmazonia/jeo-plugin.git
 Set up a WordPress installation. This could be a dedicated installation to develop Jeo or you can use an existing instance you have.
 (Note: This plugin requires WordPress 6.6+)
 
-Then create a symbolic link inside of `wp-content/plugins/jeo` pointing to the `src` folder in this repository.
+Then create a symbolic link inside of `wp-content/plugins/jeowp` pointing to the `src` folder in this repository.
 
 ```bash
-ln -s /path/to/jeo-plugin/src /path/to/wordpress/wp-content/plugins/jeo
+ln -s /path/to/jeo-plugin/src /path/to/wordpress/wp-content/plugins/jeowp
 ```
 
 ## Building the plugin
@@ -150,14 +150,14 @@ them for local testing and release packaging.
 If you prefer copying files instead of symlinking them into a local WordPress install, use:
 
 ```bash
-rsync --archive --progress --human-readable --delete ./src/ /path/to/wordpress/wp-content/plugins/jeo/
+rsync --archive --progress --human-readable --delete ./src/ /path/to/wordpress/wp-content/plugins/jeowp/
 ```
 
 ## Releasing
 
 Release packages are built from `src/`, not from the repository root.
 When a stable release tag is pushed, the release workflow creates a GitHub
-Release that keeps GitHub's source-code archives and attaches a built `jeo.zip`
+Release that keeps GitHub's source-code archives and attaches a built `jeowp.zip`
 artifact generated from `src/`. WordPress.org deployment uses the same `src/`
 tree and publishes assets from `.wordpress-org/`, but it only runs when the
 `WPORG_DEPLOY_ENABLED` repository variable is set to `true`.
@@ -178,7 +178,7 @@ The release workflow now validates that:
 - `package.json` and the root package entry in `package-lock.json` match the plugin version
 - the `Stable tag` in `src/readme.txt` matches the plugin version for the tagged stable release
 - the release tag is a stable `x.y.z` version
-- the built release tree from `src/` passes WordPress Plugin Check when staged as `jeo/`
+- the built release tree from `src/` passes WordPress Plugin Check when staged as `jeowp/`
 
 Pull requests and pushes also run the same staged Plugin Check build through `.github/workflows/plugin-check.yml`, so WordPress.org compliance failures are caught before the release tag workflow.
 
@@ -195,8 +195,8 @@ npm ci
 npm run build
 ```
 
-The attached `jeo.zip` mirrors the WordPress.org deploy package: it contains
-the built contents of `src/` under the `jeo/` plugin slug directory, including
+The attached `jeowp.zip` mirrors the WordPress.org deploy package: it contains
+the built contents of `src/` under the `jeowp/` plugin slug directory, including
 generated `*.mo` and `*.json` translation catalogs, ready for manual
 installation in WordPress.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "jeo",
+	"name": "jeowp",
 	"version": "3.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "jeo",
+			"name": "jeowp",
 			"version": "3.0.0",
 			"license": "GPL-3.0-only",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "jeo",
+	"name": "jeowp",
 	"version": "3.0.0",
 	"description": "Interactive maps for the WordPress block editor",
 	"main": "index.js",
@@ -26,7 +26,7 @@
 		"sync:version": "node scripts/sync-plugin-version.mjs",
 		"start": "wp-scripts start",
 		"build:assets": "wp-scripts build && node scripts/patch-build-compliance.mjs",
-		"i18n:pot": "wp i18n make-pot src src/languages/jeo.pot --slug=jeo --domain=jeo --exclude=js/src",
+		"i18n:pot": "wp i18n make-pot src src/languages/jeo.pot --slug=jeowp --domain=jeo --exclude=js/src",
 		"i18n:po": "wp i18n update-po src/languages/jeo.pot src/languages",
 		"i18n:mo": "wp i18n make-mo src/languages",
 		"i18n:json": "wp i18n make-json src/languages --no-purge",

--- a/scripts/wordpress-smoke-check.php
+++ b/scripts/wordpress-smoke-check.php
@@ -32,8 +32,8 @@ foreach ( $required_post_types as $required_post_type ) {
 }
 
 $active_plugins = (array) get_option( 'active_plugins', array() );
-if ( ! in_array( 'jeo/jeo.php', $active_plugins, true ) ) {
-	fwrite( STDERR, "Plugin jeo/jeo.php is not active.\n" );
+if ( ! in_array( 'jeowp/jeo.php', $active_plugins, true ) ) {
+	fwrite( STDERR, "Plugin jeowp/jeo.php is not active.\n" );
 	exit( 1 );
 }
 

--- a/scripts/wordpress-smoke.sh
+++ b/scripts/wordpress-smoke.sh
@@ -19,7 +19,7 @@ WP_DB_NAME="${WP_DB_NAME:-wordpress}"
 WP_DB_USER="${WP_DB_USER:-wordpress}"
 WP_DB_PASSWORD="${WP_DB_PASSWORD:-wordpress}"
 WP_DB_HOST="${WP_DB_HOST:-127.0.0.1:3306}"
-PLUGIN_SLUG="${PLUGIN_SLUG:-jeo}"
+PLUGIN_SLUG="${PLUGIN_SLUG:-jeowp}"
 PLUGIN_SOURCE="${PLUGIN_SOURCE:-${REPO_ROOT}/src}"
 
 if [[ -n "${WP_CLI_PHP}" ]]; then

--- a/src/languages/jeo-es_CO.po
+++ b/src/languages/jeo-es_CO.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: JEO 3.0.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/jeo\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/jeowp\n"
 "Last-Translator: Stefano Wrobleski\n"
 "Language-Team: InfoAmazonia\n"
 "MIME-Version: 1.0\n"

--- a/src/languages/jeo-pt_BR.po
+++ b/src/languages/jeo-pt_BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: JEO 3.0.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/jeo\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/jeowp\n"
 "Last-Translator: Stefano Wrobleski\n"
 "Language-Team: InfoAmazonia\n"
 "MIME-Version: 1.0\n"

--- a/src/languages/jeo.pot
+++ b/src/languages/jeo.pot
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: JEO Maps 3.0.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/jeo\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/jeowp\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"


### PR DESCRIPTION
> Post-merge update: this PR restored the WordPress.org distribution slug to `jeowp`. After WordPress.org plugin-team feedback that the text domain should also match the plugin slug, follow-up PR #619 aligns the plugin text domain and translation catalogs with `jeowp` as well.

## Summary

This PR restores the WordPress.org distribution slug from `jeo` back to `jeowp` across the release, packaging, validation, and local smoke-test paths.

It keeps the existing runtime/API namespace intact: block names, REST routes, option keys, PHP functions, script handles, CSS classes, and the `jeo` text domain are intentionally not renamed here.

## What changed

- Updates WordPress.org release/deploy configuration to stage, package, and deploy as `jeowp`.
- Updates the shared Plugin Check action default and CI artifact names to use the `jeowp` distribution slug.
- Updates the WordPress language validation slug while keeping the existing `jeo` domain and catalog filenames.
- Updates local smoke-test expectations so WordPress sees the active plugin as `jeowp/jeo.php`.
- Updates npm package metadata, release documentation, and ignored local zip artifacts for `jeowp.zip`.
- Updates translation catalog support URLs to point at the `jeowp` WordPress.org listing.

## Why

The previous slug change moved distribution/release plumbing to `jeo`, but the WordPress.org plugin listing and public plugin URL are `jeowp`. Returning the distribution slug to `jeowp` keeps release artifacts and WordPress.org deployment aligned with that listing without renaming the plugin's internal public surface.

## Validation

- `npm run test:unit`
- `npm run build:release`
- `npm run build:report`
- `node scripts/validate-release-meta.mjs`
- `composer validate --no-check-publish`
- `vendor/bin/phpcs --standard=phpcs.xml.dist --ignore='*/.worktrees/*'`
- `vendor/bin/phpcs --standard=phpcs-compat.xml.dist --ignore='*/.worktrees/*'`
- `python3 -m mkdocs build --clean`
- `msgfmt --check --statistics -o /tmp/jeo-pt_BR.mo src/languages/jeo-pt_BR.po`
- `msgfmt --check --statistics -o /tmp/jeo-es_CO.mo src/languages/jeo-es_CO.po`
- `WP_CLI_PHP=/opt/homebrew/opt/php@8.4/bin/php WP_DIR=/tmp/jeo-plugin-wordpress-smoke WP_VERSION=7.0 WP_SITE_URL=http://127.0.0.1 WP_DB_HOST=127.0.0.1 WP_DB_NAME=wordpress WP_DB_USER=wordpress WP_DB_PASSWORD=wordpress bash scripts/wordpress-smoke.sh`
- Local WordPress Plugin Check reproduction against a staged `jeowp` package exited successfully.

## Notes

Local WP-CLI commands on PHP 8.5 emitted upstream deprecation noise, so the i18n and WordPress checks were rerun with PHP 8.4 to match CI. The local Plugin Check analyzer still reports non-blocking observations for the intentionally preserved `jeo` text domain and the pre-existing `wp` substring in the historical `jeowp` slug.
