### PR TITLE
Address WordPress.org review follow-up items

### DIFF
--- a/scripts/patch-build-compliance.mjs
+++ b/scripts/patch-build-compliance.mjs
@@ -4,7 +4,8 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve( path.dirname( fileURLToPath( import.meta.url ) ), '..' );
 const BUILD_DIR = path.join( ROOT, 'src', 'js', 'build' );
-const TEXT_EXTENSIONS = new Set( [ '.css', '.js', '.json', '.map', '.php', '.svg', '.txt' ] );
+const BUILD_SOURCE_MAP_EXTENSION = '.map';
+const TEXT_EXTENSIONS = new Set( [ '.css', '.js', '.json', '.php', '.svg', '.txt' ] );
 const REPLACEMENTS = [
 	{
 		search: /https:\/\/raw\.githubusercontent\.com\/ajv-validator\/ajv\/master\/lib\/refs\/([^"'`]+?)(?=[#"'`])/g,
@@ -33,8 +34,15 @@ function listFiles( dir ) {
 }
 
 let filesPatched = 0;
+let sourceMapsRemoved = 0;
 
 for ( const file of listFiles( BUILD_DIR ) ) {
+	if ( path.extname( file ) === BUILD_SOURCE_MAP_EXTENSION ) {
+		fs.unlinkSync( file );
+		sourceMapsRemoved += 1;
+		continue;
+	}
+
 	if ( ! TEXT_EXTENSIONS.has( path.extname( file ) ) ) {
 		continue;
 	}
@@ -56,4 +64,8 @@ for ( const file of listFiles( BUILD_DIR ) ) {
 
 if ( filesPatched > 0 ) {
 	console.log( `Patched WordPress.org compliance references in ${ filesPatched } build file(s).` );
+}
+
+if ( sourceMapsRemoved > 0 ) {
+	console.log( `Removed ${ sourceMapsRemoved } stale build source map(s).` );
 }

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -1330,6 +1330,23 @@ class Jeo {
 	}
 
 	/**
+	 * Stop or defer rendering for embeds that need a special response.
+	 *
+	 * @param WP_Post $post Embed post.
+	 * @return void
+	 */
+	private function enforce_embed_rendering_rules( WP_Post $post ): void {
+		if ( $this->is_embed_disabled( $post ) ) {
+			wp_safe_redirect( home_url() );
+			exit();
+		}
+
+		if ( post_password_required( $post ) ) {
+			$this->render_embed_password_form( $post );
+		}
+	}
+
+	/**
 	 * Serve the public embed templates for maps, story maps, and discovery.
 	 *
 	 * @return void
@@ -1361,14 +1378,7 @@ class Jeo {
 
 			setup_postdata( $post );
 
-			if ( $this->is_embed_disabled( $post ) ) {
-				wp_safe_redirect( home_url() );
-				exit();
-			}
-
-			if ( post_password_required( $post ) ) {
-				$this->render_embed_password_form( $post );
-			}
+			$this->enforce_embed_rendering_rules( $post );
 
 			add_filter( 'the_content', array( $this, 'storymap_content' ), 1 );
 
@@ -1390,14 +1400,7 @@ class Jeo {
 			$this->wp_die_embed_not_available();
 		}
 
-		if ( $this->is_embed_disabled( $map_post ) ) {
-			wp_safe_redirect( home_url() );
-			exit();
-		}
-
-		if ( post_password_required( $map_post ) ) {
-			$this->render_embed_password_form( $map_post );
-		}
+		$this->enforce_embed_rendering_rules( $map_post );
 
 		$map_meta = get_post_meta( $map_id );
 		$args     = array();

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -1246,90 +1246,210 @@ class Jeo {
 	}
 
 	/**
+	 * Determine whether a post can be rendered through a public embed request.
+	 *
+	 * @param WP_Post $post Post requested by the embed endpoint.
+	 * @return bool
+	 */
+	private function can_render_embed_post( WP_Post $post ): bool {
+		if ( is_post_publicly_viewable( $post ) ) {
+			return true;
+		}
+
+		return current_user_can( 'read_post', $post->ID ) || current_user_can( 'edit_post', $post->ID );
+	}
+
+	/**
+	 * Return a validated post for an embed request.
+	 *
+	 * @param int    $post_id   Requested post ID.
+	 * @param string $post_type Expected post type.
+	 * @return WP_Post|null
+	 */
+	private function get_embed_post( int $post_id, string $post_type ) {
+		$post = get_post( $post_id );
+
+		if ( ! $post instanceof WP_Post || $post_type !== $post->post_type ) {
+			return null;
+		}
+
+		if ( ! $this->can_render_embed_post( $post ) ) {
+			return null;
+		}
+
+		return $post;
+	}
+
+	/**
+	 * Determine whether a post has embeds disabled.
+	 *
+	 * @param WP_Post $post Embed post.
+	 * @return bool
+	 */
+	private function is_embed_disabled( WP_Post $post ): bool {
+		return '1' === get_post_meta( $post->ID, 'disable_embed', true );
+	}
+
+	/**
+	 * Stop rendering an unavailable embed.
+	 *
+	 * @return never
+	 */
+	private function wp_die_embed_not_available() {
+		wp_die(
+			esc_html__( 'This JEO embed is not available.', 'jeowp' ),
+			esc_html__( 'Embed not available', 'jeowp' ),
+			array( 'response' => 404 )
+		);
+	}
+
+	/**
+	 * Render the standard WordPress password form inside the embed shell.
+	 *
+	 * @param WP_Post $post Password-protected post.
+	 * @return never
+	 */
+	private function render_embed_password_form( WP_Post $post ) {
+		?>
+		<!DOCTYPE html>
+		<html style="margin: 0 !important;">
+			<head>
+				<meta name="viewport" content="width=device-width, initial-scale=1" />
+				<title><?php echo esc_html( get_the_title( $post ) ); ?></title>
+				<?php wp_head(); ?>
+			</head>
+			<body style="margin: 0 !important; padding: 1rem !important;">
+				<?php
+				echo get_the_password_form( $post ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core renders the password form markup for protected posts.
+				?>
+				<?php wp_footer(); ?>
+			</body>
+		</html>
+		<?php
+		exit();
+	}
+
+	/**
 	 * Serve the public embed templates for maps, story maps, and discovery.
 	 *
 	 * @return void
 	 */
 	public function register_embed_template_redirect() {
-		if ( get_query_var( 'jeo_embed' ) === 'map' ) {
-			$storymap_id     = filter_input( INPUT_GET, 'storymap_id', FILTER_VALIDATE_INT );
-			$discovery       = filter_input( INPUT_GET, 'discovery', FILTER_DEFAULT );
-			$discovery       = is_string( $discovery ) ? sanitize_text_field( $discovery ) : false;
-			$map_id          = filter_input( INPUT_GET, 'map_id', FILTER_VALIDATE_INT );
-			$full_width      = filter_input( INPUT_GET, 'width', FILTER_VALIDATE_INT );
-			$popup_width_arg = filter_input( INPUT_GET, 'popup_width', FILTER_VALIDATE_INT );
-			$height          = filter_input( INPUT_GET, 'height', FILTER_VALIDATE_INT );
-			$selected_layers = filter_input( INPUT_GET, 'selected-layers', FILTER_DEFAULT );
-			$selected_layers = is_string( $selected_layers ) ? sanitize_text_field( $selected_layers ) : '';
+		if ( get_query_var( 'jeo_embed' ) !== 'map' ) {
+			return;
+		}
 
-			add_filter( 'show_admin_bar', '__return_false' );
-			show_admin_bar( false );
-			remove_action( 'wp_head', '_admin_bar_bump_cb' );
-			if ( $storymap_id ) {
-				$post = get_post( $storymap_id );
-				setup_postdata( $post );
-				add_filter( 'the_content', array( $this, 'storymap_content' ), 1 );
+		$storymap_id     = filter_input( INPUT_GET, 'storymap_id', FILTER_VALIDATE_INT );
+		$discovery       = filter_input( INPUT_GET, 'discovery', FILTER_DEFAULT );
+		$discovery       = is_string( $discovery ) ? sanitize_text_field( $discovery ) : false;
+		$map_id          = filter_input( INPUT_GET, 'map_id', FILTER_VALIDATE_INT );
+		$full_width      = filter_input( INPUT_GET, 'width', FILTER_VALIDATE_INT );
+		$popup_width_arg = filter_input( INPUT_GET, 'popup_width', FILTER_VALIDATE_INT );
+		$height          = filter_input( INPUT_GET, 'height', FILTER_VALIDATE_INT );
+		$selected_layers = filter_input( INPUT_GET, 'selected-layers', FILTER_DEFAULT );
+		$selected_layers = is_string( $selected_layers ) ? sanitize_text_field( $selected_layers ) : '';
 
-				require JEO_BASEPATH . '/templates/embed-storymap.php';
+		add_filter( 'show_admin_bar', '__return_false' );
+		show_admin_bar( false );
+		remove_action( 'wp_head', '_admin_bar_bump_cb' );
+
+		if ( $storymap_id ) {
+			$post = $this->get_embed_post( $storymap_id, 'storymap' );
+			if ( ! $post instanceof WP_Post ) {
+				$this->wp_die_embed_not_available();
+			}
+
+			setup_postdata( $post );
+
+			if ( $this->is_embed_disabled( $post ) ) {
+				wp_safe_redirect( home_url() );
 				exit();
 			}
-			if ( ! $discovery ) {
-				if ( $map_id ) {
-					$map_meta = get_post_meta( $map_id );
-					$args     = (array) maybe_unserialize( $map_meta['related_posts'][0] );
 
-					$args['per_page'] = 1;
-					$request          = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-					$request->set_query_params( $args );
-					$response = rest_do_request( $request );
-					$server   = rest_get_server();
-					$data     = $server->response_to_data( $response, false );
+			if ( post_password_required( $post ) ) {
+				$this->render_embed_password_form( $post );
+			}
 
-					$have_related_posts = ( ! empty( $map_meta['relate_posts'][0] ) && ! empty( $data ) );
+			add_filter( 'the_content', array( $this, 'storymap_content' ), 1 );
 
-					if ( $full_width ) {
-						$popup_width = $popup_width_arg ? $popup_width_arg : 220;
-						$map_width   = $full_width ? $full_width : 600;
+			require JEO_BASEPATH . '/templates/embed-storymap.php';
+			exit();
+		}
 
-						if ( $have_related_posts ) {
-							$map_width = $full_width - $popup_width;
-						}
+		if ( $discovery ) {
+			require JEO_BASEPATH . '/templates/embed-discovery.php';
+			exit();
+		}
 
-						$height = $height ? $height : 600;
+		if ( ! $map_id ) {
+			return;
+		}
 
-						$map_style       = "width: {$map_width}px; height: {$height}px;";
-						$container_style = "position: fixed; width: {$full_width}px; height: {$height}px;";
-						$popup_style     = "width: {$popup_width}px; height: {$height}px;";
-					} else {
-						$container_style = 'position: fixed; width: 100%; height: 100%;';
+		$map_post = $this->get_embed_post( $map_id, 'map' );
+		if ( ! $map_post instanceof WP_Post ) {
+			$this->wp_die_embed_not_available();
+		}
 
-						if ( $have_related_posts ) {
-							$map_style   = 'width: 70%; height: calc(100% - 35px);';
-							$popup_style = 'width: 30%; height: calc(100% - 35px);';
-						} else {
-							$map_style   = 'width: 100%; height: calc(100% - 35px);';
-							$popup_style = $container_style;
-						}
-					}
+		if ( $this->is_embed_disabled( $map_post ) ) {
+			wp_safe_redirect( home_url() );
+			exit();
+		}
 
-					if ( function_exists( 'wpml_get_language_information' ) ) {
-						global $sitepress;
-						$post_language_information = wpml_get_language_information( null, $map_id );
-						if ( ! is_wp_error( $post_language_information ) ) {
-							$sitepress->switch_lang( $post_language_information['language_code'], true );
-							switch_to_locale( $post_language_information['locale'] );
-						}
-					}
+		if ( post_password_required( $map_post ) ) {
+			$this->render_embed_password_form( $map_post );
+		}
 
-					require JEO_BASEPATH . '/templates/embed.php';
-					exit();
+		$map_meta = get_post_meta( $map_id );
+		$args     = array();
+		if ( isset( $map_meta['related_posts'][0] ) ) {
+			$args = (array) maybe_unserialize( $map_meta['related_posts'][0] );
+		}
 
-				}
+		$args['per_page'] = 1;
+		$request          = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_query_params( $args );
+		$response = rest_do_request( $request );
+		$server   = rest_get_server();
+		$data     = $server->response_to_data( $response, false );
+
+		$have_related_posts = ( ! empty( $map_meta['relate_posts'][0] ) && ! empty( $data ) );
+
+		if ( $full_width ) {
+			$popup_width = $popup_width_arg ? $popup_width_arg : 220;
+			$map_width   = $full_width ? $full_width : 600;
+
+			if ( $have_related_posts ) {
+				$map_width = $full_width - $popup_width;
+			}
+
+			$height = $height ? $height : 600;
+
+			$map_style       = "width: {$map_width}px; height: {$height}px;";
+			$container_style = "position: fixed; width: {$full_width}px; height: {$height}px;";
+			$popup_style     = "width: {$popup_width}px; height: {$height}px;";
+		} else {
+			$container_style = 'position: fixed; width: 100%; height: 100%;';
+
+			if ( $have_related_posts ) {
+				$map_style   = 'width: 70%; height: calc(100% - 35px);';
+				$popup_style = 'width: 30%; height: calc(100% - 35px);';
 			} else {
-				require JEO_BASEPATH . '/templates/embed-discovery.php';
-				exit();
+				$map_style   = 'width: 100%; height: calc(100% - 35px);';
+				$popup_style = $container_style;
 			}
 		}
+
+		if ( function_exists( 'wpml_get_language_information' ) ) {
+			global $sitepress;
+			$post_language_information = wpml_get_language_information( null, $map_id );
+			if ( ! is_wp_error( $post_language_information ) ) {
+				$sitepress->switch_lang( $post_language_information['language_code'], true );
+				switch_to_locale( $post_language_information['locale'] );
+			}
+		}
+
+		require JEO_BASEPATH . '/templates/embed.php';
+		exit();
 	}
 
 	/**
@@ -1355,6 +1475,10 @@ class Jeo {
 
 			$preview_post = $this->get_preview_post( $post_id );
 			if ( $preview_post instanceof WP_Post ) {
+				if ( post_password_required( $preview_post ) ) {
+					return get_the_password_form( $preview_post );
+				}
+
 				return $this->sanitize_storymap_content( do_blocks( $preview_post->post_content ) );
 			}
 		}

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -1168,7 +1168,7 @@ class Jeo {
 		if ( function_exists( 'icl_object_id' ) ) {
 			wp_localize_script(
 				'discovery-map',
-				'languageParams',
+				'jeowpLanguageParams',
 				array(
 					'currentLang' => $current_language,
 				)
@@ -1177,7 +1177,7 @@ class Jeo {
 
 		wp_localize_script(
 			'discovery-map',
-			'mapPreferences',
+			'jeowpMapPreferences',
 			array(
 				'map_defaults' => array(
 					'zoom' => intval( sanitize_text_field( \jeo_settings()->get_option( 'map_default_zoom' ) ) ),

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -931,8 +931,43 @@ class Jeo {
 		add_filter( 'option_use_smilies', '__return_false' );
 
 		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'story-map-container' ) );
+		$properties_json    = wp_json_encode( $saved_data );
+		if ( false === $properties_json ) {
+			$properties_json = '{}';
+		}
 
-		return '<div ' . $wrapper_attributes . ' data-properties="' . htmlentities( wp_json_encode( $saved_data ) ) . '" ></div>';
+		return '<div ' . $wrapper_attributes . ' data-properties="' . esc_attr( $properties_json ) . '" ></div>';
+	}
+
+	/**
+	 * Return the HTML allowlist for rendered story map content.
+	 *
+	 * Story map rendering stores its frontend payload in data attributes, so the
+	 * default post allowlist needs a small extension for those attributes.
+	 *
+	 * @return array
+	 */
+	private function get_storymap_allowed_html() {
+		$allowed = wp_kses_allowed_html( 'post' );
+
+		$allowed['div'] = array_merge(
+			$allowed['div'] ?? array(),
+			array(
+				'data-*' => true,
+			)
+		);
+
+		return $allowed;
+	}
+
+	/**
+	 * Sanitize rendered story map block output before returning it to the screen.
+	 *
+	 * @param string $content Rendered story map HTML.
+	 * @return string
+	 */
+	private function sanitize_storymap_content( string $content ): string {
+		return wp_kses( $content, $this->get_storymap_allowed_html() );
 	}
 
 	/**
@@ -1320,7 +1355,7 @@ class Jeo {
 
 			$preview_post = $this->get_preview_post( $post_id );
 			if ( $preview_post instanceof WP_Post ) {
-				return do_blocks( $preview_post->post_content );
+				return $this->sanitize_storymap_content( do_blocks( $preview_post->post_content ) );
 			}
 		}
 

--- a/src/includes/layers/class-layers.php
+++ b/src/includes/layers/class-layers.php
@@ -35,7 +35,6 @@ class Layers {
 		add_action( 'init', array( $this, 'register_post_type' ) );
 		add_action( 'admin_init', array( $this, 'add_capabilities' ) );
 		add_action( 'add_meta_boxes', array( $this, 'remove_custom_fields_meta_box' ), 99 );
-		add_filter( "rest_{$this->post_type}_collection_params", array( $this, 'rest_collection_params' ) );
 		$this->register_rest_meta_validation();
 	}
 
@@ -253,18 +252,6 @@ class Layers {
 
 			$role_obj->add_cap( 'delete_map-layer' );
 		}
-	}
-
-	/**
-	 * Relax the REST per_page limit for layers.
-	 *
-	 * @param array $params REST collection params.
-	 * @return array
-	 */
-	public function rest_collection_params( $params ) {
-		$params['per_page']['minimum'] = -1;
-		unset( $params['per_page']['maximum'] );
-		return $params;
 	}
 
 	/**

--- a/src/includes/maps/class-maps.php
+++ b/src/includes/maps/class-maps.php
@@ -710,7 +710,7 @@ class Maps {
 				$source_url       = get_post_meta( $layer_post->ID, 'source_url', true );
 				$attribution      = get_post_meta( $layer_post->ID, 'attribution', true );
 				$attribution_name = get_post_meta( $layer_post->ID, 'attribution_name', true );
-				$layer_content    = $this->render_layer_content( $layer_post );
+				$layer_content    = wp_kses_post( $this->render_layer_content( $layer_post ) );
 
 				if ( $source_url || $attribution || $attribution_name ) {
 					include $template;

--- a/src/includes/menu/class-menu.php
+++ b/src/includes/menu/class-menu.php
@@ -36,12 +36,12 @@ class Menu {
 		add_menu_page(
 			__( 'JEO', 'jeowp' ),
 			__( 'JEO', 'jeowp' ),
-			'read',
+			// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Registered by Maps::add_capabilities().
+			'edit_maps',
 			'jeo-main-menu',
 			'',
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode,WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Encodes a bundled local SVG into a menu-icon data URI.
-			'data:image/svg+xml;base64,' . base64_encode( file_get_contents( JEO_BASEPATH . '/js/src/icons/jeo.svg' ) ),
-			10
+			'data:image/svg+xml;base64,' . base64_encode( file_get_contents( JEO_BASEPATH . '/js/src/icons/jeo.svg' ) )
 		);
 	}
 }

--- a/src/jeo.php
+++ b/src/jeo.php
@@ -14,7 +14,7 @@
  * Requires at least: 6.6
  * Requires PHP:      8.0
  * License:           GPL-3.0-only
- * License URI:       https://github.com/InfoAmazonia/jeo-plugin/blob/master/LICENSE
+ * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:       jeowp
  * Domain Path:       /languages
  */

--- a/src/js/src/discovery/blocks/map-layers.js
+++ b/src/js/src/discovery/blocks/map-layers.js
@@ -158,8 +158,8 @@ class MapLayers extends Component {
 			mapsUrl.searchParams.append( key, requestParams[ key ] )
 		);
 
-		if ( 'languageParams' in window ) {
-			mapsUrl.searchParams.append( 'lang', languageParams.currentLang );
+		if ( window.jeowpLanguageParams?.currentLang ) {
+			mapsUrl.searchParams.append( 'lang', window.jeowpLanguageParams.currentLang );
 		}
 
 		return fetch( mapsUrl )
@@ -208,8 +208,8 @@ class MapLayers extends Component {
 				orderby: 'include',
 				per_page: chunk.length,
 				_fields: MAP_COLLECTION_FIELDS,
-				...( 'languageParams' in window && window.languageParams?.currentLang
-					? { lang: languageParams.currentLang }
+				...( 'jeowpLanguageParams' in window && window.jeowpLanguageParams?.currentLang
+					? { lang: window.jeowpLanguageParams.currentLang }
 					: {} ),
 			} );
 
@@ -229,8 +229,8 @@ class MapLayers extends Component {
 			const path = addQueryArgs( jeoMapVars.layersUrl, {
 				include: chunk,
 				context: 'view',
-				...( "languageParams" in window && window.languageParams?.currentLang
-					? { lang: languageParams.currentLang }
+				...( 'jeowpLanguageParams' in window && window.jeowpLanguageParams?.currentLang
+					? { lang: window.jeowpLanguageParams.currentLang }
 					: {} ),
 			} );
 

--- a/src/js/src/discovery/blocks/stories-helpers.js
+++ b/src/js/src/discovery/blocks/stories-helpers.js
@@ -44,7 +44,7 @@ export function normalizeStoriesTagIds( value ) {
 
 export function resolveStoryDateLocale( {
 	siteLocale = typeof window !== 'undefined'
-		? window.languageParams?.currentLang
+		? window.jeowpLanguageParams?.currentLang
 		: '',
 	documentLocale = typeof document !== 'undefined'
 		? document.documentElement?.lang

--- a/src/js/src/discovery/blocks/stories.js
+++ b/src/js/src/discovery/blocks/stories.js
@@ -217,8 +217,8 @@ function getStoryCategoryIds( stories = [] ) {
 }
 
 function appendLanguageParam( url ) {
-	if ( 'languageParams' in window && window.languageParams?.currentLang ) {
-		url.searchParams.append( 'lang', window.languageParams.currentLang );
+	if ( 'jeowpLanguageParams' in window && window.jeowpLanguageParams?.currentLang ) {
+		url.searchParams.append( 'lang', window.jeowpLanguageParams.currentLang );
 	}
 }
 

--- a/src/js/src/discovery/index.js
+++ b/src/js/src/discovery/index.js
@@ -158,9 +158,10 @@ class Discovery extends Component {
 		window.addEventListener( 'orientationchange', this.syncViewportHeight );
 		window.addEventListener( 'load', this.syncViewportHeight );
 
+		const mapDefaults = window.jeowpMapPreferences.map_defaults;
 		const additionalMapOptions = {
-			center: [ mapPreferences.map_defaults.lng, mapPreferences.map_defaults.lat],
-			zoom: mapPreferences.map_defaults.zoom,
+			center: [ mapDefaults.lng, mapDefaults.lat ],
+			zoom: mapDefaults.zoom,
 		};
 
 		if ( this.getParamFromUrl( 'discovery' ) || this.getParamFromUrl( 'share' ) ) {

--- a/src/js/src/shared/rest-records.js
+++ b/src/js/src/shared/rest-records.js
@@ -10,11 +10,11 @@ const appendLanguageQuery = ( query = {} ) => {
 
 	if (
 		typeof window !== 'undefined' &&
-		'languageParams' in window &&
-		window.languageParams?.currentLang &&
+		'jeowpLanguageParams' in window &&
+		window.jeowpLanguageParams?.currentLang &&
 		typeof nextQuery.lang === 'undefined'
 	) {
-		nextQuery.lang = window.languageParams.currentLang;
+		nextQuery.lang = window.jeowpLanguageParams.currentLang;
 	}
 
 	return nextQuery;

--- a/src/languages/jeowp-es_CO.po
+++ b/src/languages/jeowp-es_CO.po
@@ -44,7 +44,7 @@ msgstr "Se seleccionó Mapbox como biblioteca de renderizado, pero no hay ningun
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr "Se seleccionó Mapbox como biblioteca de renderizado, pero no se pudo cargar el SDK externo de Mapbox. Se volverá a MapLibre."
 
-#: includes/class-jeo.php:1039
+#: includes/class-jeo.php:1075
 msgid "Read more"
 msgstr "Leer más"
 
@@ -96,118 +96,118 @@ msgstr "Ciudad"
 msgid "City sub-level 1"
 msgstr "Ciudad sub-nivel 1"
 
-#: includes/layers/class-layers.php:50
-#: includes/layers/class-layers.php:61
+#: includes/layers/class-layers.php:49
+#: includes/layers/class-layers.php:60
 #: js/build/jeoMap.js:2
 #: js/build/mapBlocks.js:1
 msgid "Layers"
 msgstr "Capas"
 
-#: includes/layers/class-layers.php:51
+#: includes/layers/class-layers.php:50
 msgid "Layer"
 msgstr "Capa"
 
+#: includes/layers/class-layers.php:51
 #: includes/layers/class-layers.php:52
-#: includes/layers/class-layers.php:53
 msgid "Add new layer"
 msgstr "Añadir nueva capa"
 
-#: includes/layers/class-layers.php:54
+#: includes/layers/class-layers.php:53
 msgid "Edit layer"
 msgstr "Editar capa"
 
-#: includes/layers/class-layers.php:55
+#: includes/layers/class-layers.php:54
 msgid "New layer"
 msgstr "Nueva capa"
 
-#: includes/layers/class-layers.php:56
+#: includes/layers/class-layers.php:55
 msgid "View layer"
 msgstr "Ver capa"
 
-#: includes/layers/class-layers.php:57
+#: includes/layers/class-layers.php:56
 msgid "View layers"
 msgstr "Ver capas"
 
-#: includes/layers/class-layers.php:58
+#: includes/layers/class-layers.php:57
 msgid "Search layers"
 msgstr "Buscar capas"
 
-#: includes/layers/class-layers.php:59
+#: includes/layers/class-layers.php:58
 msgid "No layer found"
 msgstr "Ninguna capa encontrada"
 
-#: includes/layers/class-layers.php:60
+#: includes/layers/class-layers.php:59
 msgid "No layer found in the trash"
 msgstr "Ninguna capa encontrada en la papelera"
 
-#: includes/layers/class-layers.php:62
+#: includes/layers/class-layers.php:61
 msgid "Layer published."
 msgstr "Capa publicada."
 
-#: includes/layers/class-layers.php:63
+#: includes/layers/class-layers.php:62
 msgid "Layer published privately."
 msgstr "Capa publicada como privada."
 
-#: includes/layers/class-layers.php:64
+#: includes/layers/class-layers.php:63
 msgid "Layer reverted to draft."
 msgstr "Capa revertida a borrador."
 
-#: includes/layers/class-layers.php:65
+#: includes/layers/class-layers.php:64
 msgid "Layer scheduled."
 msgstr "Capa programada."
 
-#: includes/layers/class-layers.php:66
+#: includes/layers/class-layers.php:65
 msgid "Layer updated."
 msgstr "Capa actualizada."
 
-#: includes/layers/class-layers.php:72
+#: includes/layers/class-layers.php:71
 msgid "JEO Layers"
 msgstr "Capas JEO"
 
-#: includes/layers/class-layers.php:109
+#: includes/layers/class-layers.php:108
 msgid "The layer type"
 msgstr "Tipo de capa"
 
-#: includes/layers/class-layers.php:121
+#: includes/layers/class-layers.php:120
 msgid "Layer attribution as text or HTML with a link"
 msgstr "Atribución de la capa como texto o HTML con un enlace"
 
-#: includes/layers/class-layers.php:138
+#: includes/layers/class-layers.php:137
 msgid "Layer type-specific options"
 msgstr "Opciones específicas del tipo de capa"
 
-#: includes/layers/class-layers.php:150
+#: includes/layers/class-layers.php:149
 msgid "The URL to download the source data of the layer"
 msgstr "URL para descargar los datos de la fuente de la capa"
 
-#: includes/layers/class-layers.php:162
+#: includes/layers/class-layers.php:161
 msgid "Label for the attribution URL link"
 msgstr "Etiqueta del enlace de URL de atribución"
 
-#: includes/layers/class-layers.php:174
+#: includes/layers/class-layers.php:173
 msgid "The legend type"
 msgstr "Tipo de leyenda"
 
-#: includes/layers/class-layers.php:191
+#: includes/layers/class-layers.php:190
 msgid "Legend type-specific options"
 msgstr "Opciones específicas del tipo de leyenda"
 
-#: includes/layers/class-layers.php:203
+#: includes/layers/class-layers.php:202
 #: js/build/layersSidebar.js:7
 msgid "Use legend"
 msgstr "Usar leyenda"
 
-#: includes/layers/class-layers.php:215
+#: includes/layers/class-layers.php:214
 #: js/build/layersSidebar.js:7
 msgid "Legend title"
 msgstr "Título de leyenda"
 
-#: includes/layers/class-layers.php:278
+#: includes/layers/class-layers.php:265
 msgid "Layer type not registered"
 msgstr "Tipo de capa no registrada"
 
 #. translators: Explore is the name of JEO's discovery page feature.
-#: includes/loaders.php:492
+#: includes/loaders.php:476
 #: templates/embed-discovery.php:18
 #: js/build/discovery.js:6
 msgid "Explore"
@@ -2007,3 +2007,11 @@ msgstr "Ej. https://ejemplo.com/wp-content/uploads/fonts/jeo-story-font.css"
 #, js-format
 msgid "By %s"
 msgstr "Por %s"
+
+#: includes/class-jeo.php:1300
+msgid "This JEO embed is not available."
+msgstr "Este embed de JEO no está disponible."
+
+#: includes/class-jeo.php:1301
+msgid "Embed not available"
+msgstr "Embed no disponible"

--- a/src/languages/jeowp-pt_BR.po
+++ b/src/languages/jeowp-pt_BR.po
@@ -44,7 +44,7 @@ msgstr "Mapbox foi selecionado como biblioteca de renderização, mas nenhuma ch
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr "Mapbox foi selecionado como biblioteca de renderização, mas o SDK externo do Mapbox não pôde ser carregado. Voltando para MapLibre."
 
-#: includes/class-jeo.php:1039
+#: includes/class-jeo.php:1075
 msgid "Read more"
 msgstr "Ler mais"
 
@@ -96,118 +96,118 @@ msgstr "Cidade"
 msgid "City sub-level 1"
 msgstr "Sub-nível de cidade 1"
 
-#: includes/layers/class-layers.php:50
-#: includes/layers/class-layers.php:61
+#: includes/layers/class-layers.php:49
+#: includes/layers/class-layers.php:60
 #: js/build/jeoMap.js:2
 #: js/build/mapBlocks.js:1
 msgid "Layers"
 msgstr "Camadas"
 
-#: includes/layers/class-layers.php:51
+#: includes/layers/class-layers.php:50
 msgid "Layer"
 msgstr "Camada"
 
+#: includes/layers/class-layers.php:51
 #: includes/layers/class-layers.php:52
-#: includes/layers/class-layers.php:53
 msgid "Add new layer"
 msgstr "Adicionar nova camada"
 
-#: includes/layers/class-layers.php:54
+#: includes/layers/class-layers.php:53
 msgid "Edit layer"
 msgstr "Editar camada"
 
-#: includes/layers/class-layers.php:55
+#: includes/layers/class-layers.php:54
 msgid "New layer"
 msgstr "Nova camada"
 
-#: includes/layers/class-layers.php:56
+#: includes/layers/class-layers.php:55
 msgid "View layer"
 msgstr "Ver camada"
 
-#: includes/layers/class-layers.php:57
+#: includes/layers/class-layers.php:56
 msgid "View layers"
 msgstr "Ver camadas"
 
-#: includes/layers/class-layers.php:58
+#: includes/layers/class-layers.php:57
 msgid "Search layers"
 msgstr "Pesquisar camadas"
 
-#: includes/layers/class-layers.php:59
+#: includes/layers/class-layers.php:58
 msgid "No layer found"
 msgstr "Nenhuma camada encontrada"
 
-#: includes/layers/class-layers.php:60
+#: includes/layers/class-layers.php:59
 msgid "No layer found in the trash"
 msgstr "Nenhuma camada encontrada na lixeira"
 
-#: includes/layers/class-layers.php:62
+#: includes/layers/class-layers.php:61
 msgid "Layer published."
 msgstr "Camada publicada."
 
-#: includes/layers/class-layers.php:63
+#: includes/layers/class-layers.php:62
 msgid "Layer published privately."
 msgstr "Camada publicada em privado."
 
-#: includes/layers/class-layers.php:64
+#: includes/layers/class-layers.php:63
 msgid "Layer reverted to draft."
 msgstr "Camada movida para rascunho."
 
-#: includes/layers/class-layers.php:65
+#: includes/layers/class-layers.php:64
 msgid "Layer scheduled."
 msgstr "Camada agendada."
 
-#: includes/layers/class-layers.php:66
+#: includes/layers/class-layers.php:65
 msgid "Layer updated."
 msgstr "Camada atualizada."
 
-#: includes/layers/class-layers.php:72
+#: includes/layers/class-layers.php:71
 msgid "JEO Layers"
 msgstr "Camadas JEO"
 
-#: includes/layers/class-layers.php:109
+#: includes/layers/class-layers.php:108
 msgid "The layer type"
 msgstr "Tipo da camada"
 
-#: includes/layers/class-layers.php:121
+#: includes/layers/class-layers.php:120
 msgid "Layer attribution as text or HTML with a link"
 msgstr "Atribuição da camada em texto ou HTML com um link"
 
-#: includes/layers/class-layers.php:138
+#: includes/layers/class-layers.php:137
 msgid "Layer type-specific options"
 msgstr "Opções específicas do tipo de camada"
 
-#: includes/layers/class-layers.php:150
+#: includes/layers/class-layers.php:149
 msgid "The URL to download the source data of the layer"
 msgstr "O URL para baixar os dados de origem da camada"
 
-#: includes/layers/class-layers.php:162
+#: includes/layers/class-layers.php:161
 msgid "Label for the attribution URL link"
 msgstr "Rótulo do link de URL da atribuição"
 
-#: includes/layers/class-layers.php:174
+#: includes/layers/class-layers.php:173
 msgid "The legend type"
 msgstr "Tipo da legenda"
 
-#: includes/layers/class-layers.php:191
+#: includes/layers/class-layers.php:190
 msgid "Legend type-specific options"
 msgstr "Opções específicas do tipo de legenda"
 
-#: includes/layers/class-layers.php:203
+#: includes/layers/class-layers.php:202
 #: js/build/layersSidebar.js:7
 msgid "Use legend"
 msgstr "Usar legenda"
 
-#: includes/layers/class-layers.php:215
+#: includes/layers/class-layers.php:214
 #: js/build/layersSidebar.js:7
 msgid "Legend title"
 msgstr "Título da legenda"
 
-#: includes/layers/class-layers.php:278
+#: includes/layers/class-layers.php:265
 msgid "Layer type not registered"
 msgstr "Tipo de camada não registrado"
 
 #. translators: Explore is the name of JEO's discovery page feature.
-#: includes/loaders.php:492
+#: includes/loaders.php:476
 #: templates/embed-discovery.php:18
 #: js/build/discovery.js:6
 msgid "Explore"
@@ -2007,3 +2007,11 @@ msgstr "Ex. https://exemplo.com/wp-content/uploads/fonts/jeo-story-font.css"
 #, js-format
 msgid "By %s"
 msgstr "Por %s"
+
+#: includes/class-jeo.php:1300
+msgid "This JEO embed is not available."
+msgstr "Este embed JEO não está disponível."
+
+#: includes/class-jeo.php:1301
+msgid "Embed not available"
+msgstr "Embed indisponível"

--- a/src/languages/jeowp.pot
+++ b/src/languages/jeowp.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-12T19:44:32+00:00\n"
+"POT-Creation-Date: 2026-06-16T16:48:11+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: jeowp\n"
@@ -52,8 +52,16 @@ msgstr ""
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr ""
 
-#: includes/class-jeo.php:1039
+#: includes/class-jeo.php:1075
 msgid "Read more"
+msgstr ""
+
+#: includes/class-jeo.php:1300
+msgid "This JEO embed is not available."
+msgstr ""
+
+#: includes/class-jeo.php:1301
+msgid "Embed not available"
 msgstr ""
 
 #: includes/geocode/class-geocode-handler.php:130
@@ -104,113 +112,113 @@ msgstr ""
 msgid "City sub-level 1"
 msgstr ""
 
-#: includes/layers/class-layers.php:50
-#: includes/layers/class-layers.php:61
+#: includes/layers/class-layers.php:49
+#: includes/layers/class-layers.php:60
 #: js/build/jeoMap.js:2
 #: js/build/mapBlocks.js:1
 msgid "Layers"
 msgstr ""
 
-#: includes/layers/class-layers.php:51
+#: includes/layers/class-layers.php:50
 msgid "Layer"
 msgstr ""
 
+#: includes/layers/class-layers.php:51
 #: includes/layers/class-layers.php:52
-#: includes/layers/class-layers.php:53
 msgid "Add new layer"
 msgstr ""
 
-#: includes/layers/class-layers.php:54
+#: includes/layers/class-layers.php:53
 msgid "Edit layer"
 msgstr ""
 
-#: includes/layers/class-layers.php:55
+#: includes/layers/class-layers.php:54
 msgid "New layer"
 msgstr ""
 
-#: includes/layers/class-layers.php:56
+#: includes/layers/class-layers.php:55
 msgid "View layer"
 msgstr ""
 
-#: includes/layers/class-layers.php:57
+#: includes/layers/class-layers.php:56
 msgid "View layers"
 msgstr ""
 
-#: includes/layers/class-layers.php:58
+#: includes/layers/class-layers.php:57
 msgid "Search layers"
 msgstr ""
 
-#: includes/layers/class-layers.php:59
+#: includes/layers/class-layers.php:58
 msgid "No layer found"
 msgstr ""
 
-#: includes/layers/class-layers.php:60
+#: includes/layers/class-layers.php:59
 msgid "No layer found in the trash"
 msgstr ""
 
-#: includes/layers/class-layers.php:62
+#: includes/layers/class-layers.php:61
 msgid "Layer published."
 msgstr ""
 
-#: includes/layers/class-layers.php:63
+#: includes/layers/class-layers.php:62
 msgid "Layer published privately."
 msgstr ""
 
-#: includes/layers/class-layers.php:64
+#: includes/layers/class-layers.php:63
 msgid "Layer reverted to draft."
 msgstr ""
 
-#: includes/layers/class-layers.php:65
+#: includes/layers/class-layers.php:64
 msgid "Layer scheduled."
 msgstr ""
 
-#: includes/layers/class-layers.php:66
+#: includes/layers/class-layers.php:65
 msgid "Layer updated."
 msgstr ""
 
-#: includes/layers/class-layers.php:72
+#: includes/layers/class-layers.php:71
 msgid "JEO Layers"
 msgstr ""
 
-#: includes/layers/class-layers.php:109
+#: includes/layers/class-layers.php:108
 msgid "The layer type"
 msgstr ""
 
-#: includes/layers/class-layers.php:121
+#: includes/layers/class-layers.php:120
 msgid "Layer attribution as text or HTML with a link"
 msgstr ""
 
-#: includes/layers/class-layers.php:138
+#: includes/layers/class-layers.php:137
 msgid "Layer type-specific options"
 msgstr ""
 
-#: includes/layers/class-layers.php:150
+#: includes/layers/class-layers.php:149
 msgid "The URL to download the source data of the layer"
 msgstr ""
 
-#: includes/layers/class-layers.php:162
+#: includes/layers/class-layers.php:161
 msgid "Label for the attribution URL link"
 msgstr ""
 
-#: includes/layers/class-layers.php:174
+#: includes/layers/class-layers.php:173
 msgid "The legend type"
 msgstr ""
 
-#: includes/layers/class-layers.php:191
+#: includes/layers/class-layers.php:190
 msgid "Legend type-specific options"
 msgstr ""
 
-#: includes/layers/class-layers.php:203
+#: includes/layers/class-layers.php:202
 #: js/build/layersSidebar.js:7
 msgid "Use legend"
 msgstr ""
 
-#: includes/layers/class-layers.php:215
+#: includes/layers/class-layers.php:214
 #: js/build/layersSidebar.js:7
 msgid "Legend title"
 msgstr ""
 
-#: includes/layers/class-layers.php:278
+#: includes/layers/class-layers.php:265
 msgid "Layer type not registered"
 msgstr ""
 
@@ -221,7 +229,7 @@ msgid "<p>JEO can connect to third-party services depending on your configuratio
 msgstr ""
 
 #. translators: Explore is the name of JEO's discovery page feature.
-#: includes/loaders.php:492
+#: includes/loaders.php:476
 #: templates/embed-discovery.php:18
 #: js/build/discovery.js:6
 msgid "Explore"

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -5,7 +5,7 @@ Stable tag: 3.0.0
 Requires PHP: 8.0
 Requires at least: 6.6
 License: GPL-3.0-only
-License URI: https://github.com/InfoAmazonia/jeo-plugin/blob/master/LICENSE
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Version: 3.0.0
 
 Geojournalism platform for building maps, geolocating posts, and publishing interactive storymaps in WordPress.

--- a/src/templates/embed-storymap.php
+++ b/src/templates/embed-storymap.php
@@ -8,14 +8,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-
-$disable_embed = get_post_meta( get_the_ID(), 'disable_embed', true ) === '1';
-$storymap_id   = filter_input( INPUT_GET, 'storymap_id', FILTER_VALIDATE_INT );
-
-if ( $disable_embed ) {
-	wp_safe_redirect( home_url() );
-	exit();
-}
 ?>
 <!DOCTYPE html>
 <html style="margin: 0px !important;">

--- a/src/templates/embed.php
+++ b/src/templates/embed.php
@@ -8,13 +8,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-
-$disable_embed = get_post_meta( $map_id, 'disable_embed', true ) === '1';
-
-if ( $disable_embed ) {
-	wp_safe_redirect( home_url() );
-	exit();
-}
 ?>
 <!DOCTYPE html>
 <html style="margin: 0px !important;">

--- a/src/templates/map-content-layers-list.php
+++ b/src/templates/map-content-layers-list.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <h3><?php echo esc_html( get_the_title( $layer_post ) ); ?></h3>
 <?php echo wp_kses_post( get_the_post_thumbnail( $layer_post ) ); ?>
-<?php echo $layer_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- WordPress filters render trusted post content for the selected layer. ?>
+<?php echo wp_kses_post( $layer_content ); ?>
 <?php if ( strlen( $attribution ) > 0 ) : ?>
 	<?php if ( strlen( $attribution_name ) > 0 ) : ?>
 		<?php esc_html_e( 'Attribution:', 'jeowp' ); ?> <a href="<?php echo esc_url( $attribution ); ?>"><?php echo esc_html( $attribution_name ); ?></a>


### PR DESCRIPTION
## Summary

Refs #622.

This PR addresses the WordPress.org review follow-up items for JEO 3.0.0 review readiness.

## Scope

1. Use the canonical GNU GPLv3 license URL for the `GPL-3.0-only` plugin metadata.
2. Keep the `jeo-map` inline style handle from `d5495fb8` and validate that pages now emit `jeo-map-inline-css` instead of the previous generic custom CSS handle.
3. Harden rendered content escaping for story maps and map layer content.
4. Move the JEO admin menu out of the core admin group by relying on the map editing capability and default plugin menu positioning.
5. Restore native REST pagination limits for `wp/v2/map-layer`, while keeping the dedicated JEO route for fetching selected map layers by ID.
6. Enforce WordPress-like visibility behavior for map and story map embeds, including missing posts, non-public posts, disabled embeds, and password-protected content.
7. Prefix discovery runtime globals with `jeowp` and remove stale build source maps during release asset compliance patching so packages do not retain old global names in ignored generated artifacts.

Note: the branch is based on `develop`, where item 2 already exists as `d5495fb8`. Because of that, GitHub's commit comparison against `develop` shows the six new commits in this branch; the PR scope still covers and validates all seven items above.

## Validation

- `npm run build`
- `npm run test:unit -- --runInBand`
- `vendor/bin/phpcs --standard=phpcs.xml.dist '--ignore=.worktrees/*'`
- `php -l` on touched PHP files
- `git diff --check`
- Local HTTP checks against the representative `infoamazonia.local` pages from #622
- Playwright smoke checks for maps, storymaps, embeds, and discovery globals

Observed local browser noise was limited to existing theme-side JS errors, mixed-content warnings, and external Mapbox tile 404s; plugin assets loaded successfully.
