### PR TITLE
Replace Mapbox Static Tiles style overlays with composed Mapbox GL styles

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -14,7 +14,7 @@
 	{
 		"name": "mapBlocks",
 		"path": "src/js/build/mapBlocks.js",
-		"limit": "1300 KB",
+		"limit": "1310 KB",
 		"brotli": false
 	},
 	{
@@ -26,7 +26,7 @@
 	{
 		"name": "discovery",
 		"path": "src/js/build/discovery.js",
-		"limit": "286 KB",
+		"limit": "305 KB",
 		"brotli": false
 	},
 	{
@@ -44,7 +44,7 @@
 	{
 		"name": "jeoMap",
 		"path": "src/js/build/jeoMap.js",
-		"limit": "91 KB",
+		"limit": "100 KB",
 		"brotli": false
 	},
 	{

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,6 +15,7 @@
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/.worktrees/*</exclude-pattern>
 	<exclude-pattern>*/wp-content/*</exclude-pattern>
 	<exclude-pattern>*/js/build/*</exclude-pattern>
 </ruleset>

--- a/src/css/jeo-map.scss
+++ b/src/css/jeo-map.scss
@@ -497,6 +497,16 @@
 		}
 	}
 
+	.maplibregl-ctrl-group {
+		.maplibregl-ctrl-zoom-in {
+			border-radius: 5px 5px 0 0;
+		}
+
+		.maplibregl-ctrl-zoom-out {
+			border-radius: 0 0 5px 5px;
+		}
+	}
+
 	.layers-wrapper a {
 		text-decoration: none !important;
 	}

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -46,6 +46,7 @@ class Jeo {
 	protected function init() {
 		\jeo_menu();
 		\jeo_maps();
+		\jeo_map_style_composer();
 		\jeo_layers();
 		\jeo_geocode_handler();
 		\jeo_settings();
@@ -618,6 +619,19 @@ class Jeo {
 		);
 
 		wp_set_script_translations( 'jeo-map-blocks', 'jeowp', JEO_BASEPATH . 'languages' );
+
+		wp_localize_script(
+			'jeo-map-blocks',
+			'jeoMapVars',
+			array(
+				'jsonUrl'                 => rest_url( 'wp/v2/' ),
+				'layersUrl'               => rest_url( 'jeo/v1/map-layer' ),
+				'composedStyleUrlBase'    => rest_url( 'jeo/v1/map-style/' ),
+				'composedStyleComposeUrl' => rest_url( 'jeo/v1/map-style/compose' ),
+				'nonce'                   => $this->get_rest_nonce(),
+				'currentLang'             => $this->get_current_language(),
+			)
+		);
 	}
 
 	/**
@@ -1070,26 +1084,28 @@ class Jeo {
 				'jeo-map',
 				'jeoMapVars',
 				array(
-					'jsonUrl'          => rest_url( 'wp/v2/' ),
-					'layersUrl'        => rest_url( 'jeo/v1/map-layer' ),
-					'string_read_more' => esc_html__( 'Read more', 'jeowp' ),
-					'jeoUrl'           => JEO_BASEURL,
-					'nonce'            => $this->get_rest_nonce(),
-					'currentLang'      => $current_language,
+					'jsonUrl'                 => rest_url( 'wp/v2/' ),
+					'layersUrl'               => rest_url( 'jeo/v1/map-layer' ),
+					'composedStyleUrlBase'    => rest_url( 'jeo/v1/map-style/' ),
+					'composedStyleComposeUrl' => rest_url( 'jeo/v1/map-style/compose' ),
+					'string_read_more'        => esc_html__( 'Read more', 'jeowp' ),
+					'jeoUrl'                  => JEO_BASEURL,
+					'nonce'                   => $this->get_rest_nonce(),
+					'currentLang'             => $current_language,
 						// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Bundled templates are read from the local plugin directory at runtime.
-					'templates'        => array(
+					'templates'               => array(
 						'moreInfo'  => file_get_contents( jeo_get_template( 'map-more-info.ejs' ) ),
 						'popup'     => file_get_contents( jeo_get_template( 'generic-popup.ejs' ) ),
 						'postPopup' => file_get_contents( jeo_get_template( 'post-popup.ejs' ) ),
 					),
 						// phpcs:enable
-					'cluster'          => apply_filters(
+					'cluster'                 => apply_filters(
 						'jeomap_js_cluster',
 						array(
 							'circle_color' => '#ffffff',
 						)
 					),
-					'images'           => apply_filters(
+					'images'                  => apply_filters(
 						'jeomap_js_images',
 						array(
 							'/js/src/icons/news-marker' => array(

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -109,6 +109,20 @@ class Jeo {
 	}
 
 	/**
+	 * Return the default glyph endpoint used when composed styles omit glyphs.
+	 *
+	 * @return string
+	 */
+	private function get_composed_style_default_glyphs(): string {
+		return trim(
+			(string) apply_filters(
+				'jeo_mapbox_composed_style_default_glyphs',
+				'mapbox://fonts/mapbox/{fontstack}/{range}.pbf'
+			)
+		);
+	}
+
+	/**
 	 * Determine whether the current request is a preview for the given post.
 	 *
 	 * @param int $post_id Post ID.
@@ -628,6 +642,7 @@ class Jeo {
 				'layersUrl'               => rest_url( 'jeo/v1/map-layer' ),
 				'composedStyleUrlBase'    => rest_url( 'jeo/v1/map-style/' ),
 				'composedStyleComposeUrl' => rest_url( 'jeo/v1/map-style/compose' ),
+				'composedStyleDefaultGlyphs' => $this->get_composed_style_default_glyphs(),
 				'nonce'                   => $this->get_rest_nonce(),
 				'currentLang'             => $this->get_current_language(),
 			)
@@ -1088,6 +1103,7 @@ class Jeo {
 					'layersUrl'               => rest_url( 'jeo/v1/map-layer' ),
 					'composedStyleUrlBase'    => rest_url( 'jeo/v1/map-style/' ),
 					'composedStyleComposeUrl' => rest_url( 'jeo/v1/map-style/compose' ),
+					'composedStyleDefaultGlyphs' => $this->get_composed_style_default_glyphs(),
 					'string_read_more'        => esc_html__( 'Read more', 'jeowp' ),
 					'jeoUrl'                  => JEO_BASEURL,
 					'nonce'                   => $this->get_rest_nonce(),

--- a/src/includes/class-jeo.php
+++ b/src/includes/class-jeo.php
@@ -638,13 +638,13 @@ class Jeo {
 			'jeo-map-blocks',
 			'jeoMapVars',
 			array(
-				'jsonUrl'                 => rest_url( 'wp/v2/' ),
-				'layersUrl'               => rest_url( 'jeo/v1/map-layer' ),
-				'composedStyleUrlBase'    => rest_url( 'jeo/v1/map-style/' ),
-				'composedStyleComposeUrl' => rest_url( 'jeo/v1/map-style/compose' ),
+				'jsonUrl'                    => rest_url( 'wp/v2/' ),
+				'layersUrl'                  => rest_url( 'jeo/v1/map-layer' ),
+				'composedStyleUrlBase'       => rest_url( 'jeo/v1/map-style/' ),
+				'composedStyleComposeUrl'    => rest_url( 'jeo/v1/map-style/compose' ),
 				'composedStyleDefaultGlyphs' => $this->get_composed_style_default_glyphs(),
-				'nonce'                   => $this->get_rest_nonce(),
-				'currentLang'             => $this->get_current_language(),
+				'nonce'                      => $this->get_rest_nonce(),
+				'currentLang'                => $this->get_current_language(),
 			)
 		);
 	}
@@ -1099,29 +1099,29 @@ class Jeo {
 				'jeo-map',
 				'jeoMapVars',
 				array(
-					'jsonUrl'                 => rest_url( 'wp/v2/' ),
-					'layersUrl'               => rest_url( 'jeo/v1/map-layer' ),
-					'composedStyleUrlBase'    => rest_url( 'jeo/v1/map-style/' ),
-					'composedStyleComposeUrl' => rest_url( 'jeo/v1/map-style/compose' ),
+					'jsonUrl'                    => rest_url( 'wp/v2/' ),
+					'layersUrl'                  => rest_url( 'jeo/v1/map-layer' ),
+					'composedStyleUrlBase'       => rest_url( 'jeo/v1/map-style/' ),
+					'composedStyleComposeUrl'    => rest_url( 'jeo/v1/map-style/compose' ),
 					'composedStyleDefaultGlyphs' => $this->get_composed_style_default_glyphs(),
-					'string_read_more'        => esc_html__( 'Read more', 'jeowp' ),
-					'jeoUrl'                  => JEO_BASEURL,
-					'nonce'                   => $this->get_rest_nonce(),
-					'currentLang'             => $current_language,
+					'string_read_more'           => esc_html__( 'Read more', 'jeowp' ),
+					'jeoUrl'                     => JEO_BASEURL,
+					'nonce'                      => $this->get_rest_nonce(),
+					'currentLang'                => $current_language,
 						// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Bundled templates are read from the local plugin directory at runtime.
-					'templates'               => array(
+					'templates'                  => array(
 						'moreInfo'  => file_get_contents( jeo_get_template( 'map-more-info.ejs' ) ),
 						'popup'     => file_get_contents( jeo_get_template( 'generic-popup.ejs' ) ),
 						'postPopup' => file_get_contents( jeo_get_template( 'post-popup.ejs' ) ),
 					),
 						// phpcs:enable
-					'cluster'                 => apply_filters(
+					'cluster'                    => apply_filters(
 						'jeomap_js_cluster',
 						array(
 							'circle_color' => '#ffffff',
 						)
 					),
-					'images'                  => apply_filters(
+					'images'                     => apply_filters(
 						'jeomap_js_images',
 						array(
 							'/js/src/icons/news-marker' => array(

--- a/src/includes/layer-types/mapbox.js
+++ b/src/includes/layer-types/mapbox.js
@@ -1,11 +1,6 @@
 ( () => {
 	const { __ } = wp.i18n;
 
-	const MAPBOX_RASTER_ATTRIBUTION =
-	'&copy; <a href="https://www.mapbox.com/about/maps/">Mapbox</a> ' +
-	'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
-	'<a href="https://www.mapbox.com/map-feedback/">Improve this map</a>';
-
 	window.JeoLayerTypes.registerLayerType( 'mapbox', {
 	label: __( 'Mapbox Style', 'jeowp' ),
 
@@ -15,40 +10,6 @@
 		if ( styleUrl ) {
 			return map.setStyle( styleUrl );
 		}
-	},
-
-	addLayer( map, attributes, addLayerParams = null ) {
-		const layerId = attributes.layer_id;
-		const layerTypeOptions = attributes.layer_type_options || {};
-
-		if ( ! map.getSource( layerId ) ) {
-			const accessToken = layerTypeOptions.access_token || jeo_settings.mapbox_key;
-
-			const styleId = layerTypeOptions.style_id?.replace( 'mapbox://styles/', '' );
-
-			map.addSource( layerId, {
-				type: 'raster',
-				tiles: [
-					`https://api.mapbox.com/styles/v1/${ styleId }/tiles/512/{z}/{x}/{y}@2x?access_token=${ accessToken }`,
-				],
-				attribution: MAPBOX_RASTER_ATTRIBUTION,
-			} );
-		}
-
-		const layer = {
-			id: layerId,
-			source: layerId,
-			type: 'raster',
-			layout: {
-				visibility: attributes.visible ? 'visible' : 'none',
-			},
-		};
-
-		if ( addLayerParams ) {
-			return map.addLayer( layer, ...addLayerParams );
-		}
-
-		return map.addLayer( layer );
 	},
 
 	_groupInteractionsByEventType( interactions ) {
@@ -129,7 +90,8 @@
 					} );
 
 					map.on( 'mousemove', function ( e ) {
-						const features = map.queryRenderedFeatures( e.point );
+						const point = { x: e.point.x, y: e.point.y };
+						const features = map.queryRenderedFeatures( point );
 						const isOverlapping = features.some( f => interactionsIds.includes( f.layer.id ) );
 						if ( isOverlapping ) {
 							map.getCanvas().style.cursor = 'pointer';

--- a/src/includes/layer-types/mapbox.js
+++ b/src/includes/layer-types/mapbox.js
@@ -148,7 +148,7 @@
 	getStyleLayers( attributes ) {
 		return new Promise( ( resolve, reject ) => {
 			if ( ! attributes ) {
-				resolve( null );
+				return resolve( null );
 			}
 
 			let formLayers = [];
@@ -183,7 +183,7 @@
 		return new Promise( function ( resolve ) {
 			// cache
 			if ( self._styleDefinitions[ attributes.layer_id ] ) {
-				resolve( self._styleDefinitions[ attributes.layer_id ] );
+				return resolve( self._styleDefinitions[ attributes.layer_id ] );
 			}
 
 			const layerTypeOptions = attributes.layer_type_options || {};
@@ -209,7 +209,7 @@
 		return new Promise( function ( resolve, reject ) {
 			// cache
 			if ( self._styleLayers[ attributes.layer_id ] ) {
-				resolve( self._styleLayers[ attributes.layer_id ] );
+				return resolve( self._styleLayers[ attributes.layer_id ] );
 			}
 
 			const layerTypeOptions = attributes.layer_type_options || {};

--- a/src/includes/loaders.php
+++ b/src/includes/loaders.php
@@ -60,6 +60,15 @@ function jeo_maps() {
 }
 
 /**
+ * Gets the instance of the Map Style Composer Class
+ *
+ * @return \Jeo\Map_Style_Composer Map style composer instance
+ */
+function jeo_map_style_composer() {
+	return \Jeo\Map_Style_Composer::get_instance();
+}
+
+/**
  * Gets the instance of the main Layers Class
  *
  * @return \Jeo\Layers Layers instance

--- a/src/includes/maps/class-map-style-composer.php
+++ b/src/includes/maps/class-map-style-composer.php
@@ -108,6 +108,21 @@ class Map_Style_Composer {
 
 		register_rest_route(
 			'jeo/v1',
+			'/map-style/layer/(?P<id>\d+)/refresh',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'refresh_layer_cache_response' ),
+				'permission_callback' => array( $this, 'can_refresh_layer_request' ),
+				'args'                => array(
+					'id' => array(
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'jeo/v1',
 			'/map-style/(?P<scope>preview|onetime)/(?P<hash>[a-f0-9]{16})/style',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
@@ -183,6 +198,21 @@ class Map_Style_Composer {
 	}
 
 	/**
+	 * Check whether the current request can force refresh a layer cache.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return bool
+	 */
+	public function can_refresh_layer_request( WP_REST_Request $request ) {
+		$layer_id = absint( $request['id'] );
+		$post     = get_post( $layer_id );
+
+		return $post instanceof WP_Post &&
+			'map-layer' === $post->post_type &&
+			current_user_can( 'edit_post', $layer_id );
+	}
+
+	/**
 	 * Check whether the current request can read a virtual artifact.
 	 *
 	 * @param WP_REST_Request $request REST request.
@@ -205,9 +235,13 @@ class Map_Style_Composer {
 	 * @return WP_REST_Response
 	 */
 	public function get_metadata_response( WP_REST_Request $request ) {
+		$map_id        = absint( $request['id'] );
+		$force_refresh = rest_sanitize_boolean( $request->get_param( 'refresh' ) ) &&
+			current_user_can( 'edit_post', $map_id );
+
 		$result = $this->get_or_create_artifacts(
-			absint( $request['id'] ),
-			rest_sanitize_boolean( $request->get_param( 'refresh' ) )
+			$map_id,
+			$force_refresh
 		);
 
 		if ( is_wp_error( $result ) ) {
@@ -338,6 +372,49 @@ class Map_Style_Composer {
 	}
 
 	/**
+	 * Force refresh composed map style artifacts for maps using a layer.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response
+	 */
+	public function refresh_layer_cache_response( WP_REST_Request $request ) {
+		$layer_id  = absint( $request['id'] );
+		$map_ids   = $this->get_map_ids_for_layer( $layer_id );
+		$results   = array();
+		$refreshed = 0;
+		$failed    = 0;
+
+		foreach ( $map_ids as $map_id ) {
+			$result = $this->get_or_create_artifacts( absint( $map_id ), true );
+
+			if ( is_wp_error( $result ) ) {
+				++$failed;
+				$results[] = array(
+					'mapId' => absint( $map_id ),
+					'error' => $result->get_error_message(),
+				);
+				continue;
+			}
+
+			++$refreshed;
+			$results[] = array(
+				'mapId' => absint( $map_id ),
+				'hash'  => $result['hash'] ?? null,
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'layerId'   => $layer_id,
+				'mapIds'    => array_map( 'absint', $map_ids ),
+				'refreshed' => $refreshed,
+				'failed'    => $failed,
+				'results'   => $results,
+			)
+		);
+	}
+
+	/**
 	 * Clear map cache metadata when a map changes.
 	 *
 	 * @param int     $post_id Post ID.
@@ -363,6 +440,18 @@ class Map_Style_Composer {
 	public function invalidate_layer_cache( $post_id, $post, $update ) {
 		unset( $post, $update );
 
+		foreach ( $this->get_map_ids_for_layer( $post_id ) as $map_id ) {
+			$this->invalidate_map_cache( absint( $map_id ), null, true );
+		}
+	}
+
+	/**
+	 * Get map IDs that reference a layer in serialized map settings.
+	 *
+	 * @param int $layer_id Layer post ID.
+	 * @return int[]
+	 */
+	private function get_map_ids_for_layer( $layer_id ) {
 		$maps = get_posts(
 			array(
 				'post_type'      => 'map',
@@ -372,16 +461,14 @@ class Map_Style_Composer {
 				'meta_query'     => array(
 					array(
 						'key'     => 'layers',
-						'value'   => 's:2:"id";i:' . absint( $post_id ) . ';',
+						'value'   => 's:2:"id";i:' . absint( $layer_id ) . ';',
 						'compare' => 'LIKE',
 					),
 				),
 			)
 		);
 
-		foreach ( $maps as $map_id ) {
-			$this->invalidate_map_cache( absint( $map_id ), null, true );
-		}
+		return array_map( 'absint', $maps );
 	}
 
 	/**

--- a/src/includes/maps/class-map-style-composer.php
+++ b/src/includes/maps/class-map-style-composer.php
@@ -24,12 +24,12 @@ class Map_Style_Composer {
 
 	use Singleton;
 
-	const CACHE_DIR             = 'jeo-mapbox-composed-styles';
-	const CACHE_VERSION         = 11;
-	const TOKEN_PLACEHOLDER     = '__JEO_MAPBOX_ACCESS_TOKEN__';
-	const FALLBACK_SPRITE       = 'mapbox://sprites/mapbox/streets-v11';
-	const VIRTUAL_SCOPE_PREVIEW = 'preview';
-	const VIRTUAL_SCOPE_ONETIME = 'onetime';
+	const CACHE_DIR               = 'jeo-mapbox-composed-styles';
+	const CACHE_VERSION           = 11;
+	const TOKEN_PLACEHOLDER       = '__JEO_MAPBOX_ACCESS_TOKEN__';
+	const DEFAULT_FALLBACK_SPRITE = 'mapbox://sprites/mapbox/streets-v11';
+	const VIRTUAL_SCOPE_PREVIEW   = 'preview';
+	const VIRTUAL_SCOPE_ONETIME   = 'onetime';
 
 	/**
 	 * Register hooks.
@@ -1372,6 +1372,22 @@ class Map_Style_Composer {
 	}
 
 	/**
+	 * Return the fallback sprite root used for common missing Mapbox icons.
+	 *
+	 * Return an empty value from the filter to disable fallback sprite loading.
+	 *
+	 * @return string
+	 */
+	private function get_fallback_sprite() {
+		return trim(
+			(string) apply_filters(
+				'jeo_mapbox_composed_style_fallback_sprite',
+				self::DEFAULT_FALLBACK_SPRITE
+			)
+		);
+	}
+
+	/**
 	 * Merge sprites used by remote styles.
 	 *
 	 * @param array $bundles Style bundles.
@@ -1403,6 +1419,8 @@ class Map_Style_Composer {
 		if ( ! function_exists( 'imagecreatefromstring' ) ) {
 			return new WP_Error( 'jeo_mapbox_composer_gd_missing', __( 'The PHP GD extension is required to merge Mapbox sprites.', 'jeowp' ) );
 		}
+
+		$fallback_sprite = $this->get_fallback_sprite();
 
 		foreach ( array( 1, 2 ) as $ratio ) {
 			$entries        = array();
@@ -1440,8 +1458,8 @@ class Map_Style_Composer {
 				}
 
 				$missing = array_diff( $this->collect_style_image_names( $bundle['style'] ), array_keys( $fetched['json'] ) );
-				if ( ! empty( $missing ) && null === $fallback_cache ) {
-					$fallback_cache = $this->fetch_sprite( self::FALLBACK_SPRITE, $bundle['ref']['token'], $ratio );
+				if ( ! empty( $missing ) && null === $fallback_cache && '' !== $fallback_sprite ) {
+					$fallback_cache = $this->fetch_sprite( $fallback_sprite, $bundle['ref']['token'], $ratio );
 				}
 
 				if ( ! empty( $missing ) && is_array( $fallback_cache ) ) {

--- a/src/includes/maps/class-map-style-composer.php
+++ b/src/includes/maps/class-map-style-composer.php
@@ -372,7 +372,7 @@ class Map_Style_Composer {
 				'meta_query'     => array(
 					array(
 						'key'     => 'layers',
-						'value'   => (string) absint( $post_id ),
+						'value'   => 's:2:"id";i:' . absint( $post_id ) . ';',
 						'compare' => 'LIKE',
 					),
 				),

--- a/src/includes/maps/class-map-style-composer.php
+++ b/src/includes/maps/class-map-style-composer.php
@@ -1,0 +1,2414 @@
+<?php
+/**
+ * Compose Mapbox styles for saved maps.
+ *
+ * @package Jeo
+ */
+
+namespace Jeo;
+
+use WP_Error;
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Build cached Mapbox Style JSON artifacts from JEO map/layer metadata.
+ */
+class Map_Style_Composer {
+
+	use Singleton;
+
+	const CACHE_DIR             = 'jeo-mapbox-composed-styles';
+	const CACHE_VERSION         = 11;
+	const TOKEN_PLACEHOLDER     = '__JEO_MAPBOX_ACCESS_TOKEN__';
+	const FALLBACK_SPRITE       = 'mapbox://sprites/mapbox/streets-v11';
+	const VIRTUAL_SCOPE_PREVIEW = 'preview';
+	const VIRTUAL_SCOPE_ONETIME = 'onetime';
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	protected function init() {
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+		add_action( 'save_post_map', array( $this, 'invalidate_map_cache' ), 10, 3 );
+		add_action( 'save_post_map-layer', array( $this, 'invalidate_layer_cache' ), 10, 3 );
+	}
+
+	/**
+	 * Register composer REST routes.
+	 *
+	 * @return void
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			'jeo/v1',
+			'/map-style/(?P<id>\d+)',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_metadata_response' ),
+				'permission_callback' => array( $this, 'can_read_map_request' ),
+				'args'                => array(
+					'id'      => array(
+						'sanitize_callback' => 'absint',
+					),
+					'refresh' => array(
+						'sanitize_callback' => 'rest_sanitize_boolean',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'jeo/v1',
+			'/map-style/(?P<id>\d+)/style',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_style_response' ),
+				'permission_callback' => array( $this, 'can_read_map_request' ),
+				'args'                => array(
+					'id' => array(
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'jeo/v1',
+			'/map-style/(?P<id>\d+)/manifest',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_manifest_response' ),
+				'permission_callback' => array( $this, 'can_read_map_request' ),
+				'args'                => array(
+					'id' => array(
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'jeo/v1',
+			'/map-style/compose',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'get_virtual_metadata_response' ),
+				'permission_callback' => array( $this, 'can_create_virtual_request' ),
+			)
+		);
+
+		register_rest_route(
+			'jeo/v1',
+			'/map-style/(?P<scope>preview|onetime)/(?P<hash>[a-f0-9]{16})/style',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_virtual_style_response' ),
+				'permission_callback' => array( $this, 'can_read_virtual_request' ),
+				'args'                => array(
+					'scope' => array(
+						'sanitize_callback' => 'sanitize_key',
+					),
+					'hash'  => array(
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'jeo/v1',
+			'/map-style/(?P<scope>preview|onetime)/(?P<hash>[a-f0-9]{16})/manifest',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_virtual_manifest_response' ),
+				'permission_callback' => array( $this, 'can_read_virtual_request' ),
+				'args'                => array(
+					'scope' => array(
+						'sanitize_callback' => 'sanitize_key',
+					),
+					'hash'  => array(
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Check whether the current request can read a map.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return bool
+	 */
+	public function can_read_map_request( WP_REST_Request $request ) {
+		return $this->can_read_map( absint( $request['id'] ) );
+	}
+
+	/**
+	 * Check whether the current request can compose a virtual style.
+	 *
+	 * Preview styles represent unsaved editor state and require edit access.
+	 * Public one-time maps are limited later to published layer posts only.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return bool
+	 */
+	public function can_create_virtual_request( WP_REST_Request $request ) {
+		$params = $this->normalize_array( $request->get_json_params() );
+		$scope  = $this->normalize_virtual_scope( $params['scope'] ?? self::VIRTUAL_SCOPE_PREVIEW );
+
+		if ( self::VIRTUAL_SCOPE_ONETIME === $scope ) {
+			return true;
+		}
+
+		if ( ! is_user_logged_in() || ! current_user_can( 'edit_posts' ) ) {
+			return false;
+		}
+
+		$post_id = absint( $params['postId'] ?? 0 );
+		if ( $post_id && ! current_user_can( 'edit_post', $post_id ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether the current request can read a virtual artifact.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return bool
+	 */
+	public function can_read_virtual_request( WP_REST_Request $request ) {
+		$scope = $this->normalize_virtual_scope( $request['scope'] ?? '' );
+
+		if ( self::VIRTUAL_SCOPE_ONETIME === $scope ) {
+			return true;
+		}
+
+		return is_user_logged_in() && current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Return composed style metadata.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response
+	 */
+	public function get_metadata_response( WP_REST_Request $request ) {
+		$result = $this->get_or_create_artifacts(
+			absint( $request['id'] ),
+			rest_sanitize_boolean( $request->get_param( 'refresh' ) )
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return rest_ensure_response(
+				array(
+					'enabled' => false,
+					'error'   => $result->get_error_message(),
+				)
+			);
+		}
+
+		$response = $result;
+		unset( $response['stylePath'], $response['manifestPath'] );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Return the composed style JSON.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_style_response( WP_REST_Request $request ) {
+		$result = $this->get_or_create_artifacts( absint( $request['id'] ) );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$style = $this->read_json_file( $result['stylePath'], false );
+		if ( is_wp_error( $style ) ) {
+			return $style;
+		}
+
+		$response = new WP_REST_Response( $style );
+		$response->header( 'Cache-Control', 'public, max-age=300' );
+		return $response;
+	}
+
+	/**
+	 * Return the composed style manifest.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_manifest_response( WP_REST_Request $request ) {
+		$result = $this->get_or_create_artifacts( absint( $request['id'] ) );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$manifest = $this->read_json_file( $result['manifestPath'] );
+		if ( is_wp_error( $manifest ) ) {
+			return $manifest;
+		}
+
+		$response = new WP_REST_Response( $manifest );
+		$response->header( 'Cache-Control', 'public, max-age=300' );
+		return $response;
+	}
+
+	/**
+	 * Return metadata for a virtual style composed from a payload.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response
+	 */
+	public function get_virtual_metadata_response( WP_REST_Request $request ) {
+		$result = $this->get_or_create_virtual_artifacts( $this->normalize_array( $request->get_json_params() ) );
+
+		if ( is_wp_error( $result ) ) {
+			return rest_ensure_response(
+				array(
+					'enabled' => false,
+					'error'   => $result->get_error_message(),
+				)
+			);
+		}
+
+		$response = $result;
+		unset( $response['stylePath'], $response['manifestPath'] );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Return a virtual composed style JSON.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_virtual_style_response( WP_REST_Request $request ) {
+		$paths = $this->get_virtual_artifact_paths( $request['scope'], $request['hash'] );
+		if ( is_wp_error( $paths ) ) {
+			return $paths;
+		}
+
+		$style = $this->read_json_file( $paths['stylePath'], false );
+		if ( is_wp_error( $style ) ) {
+			return $style;
+		}
+
+		$response = new WP_REST_Response( $style );
+		$response->header( 'Cache-Control', 'public, max-age=300' );
+		return $response;
+	}
+
+	/**
+	 * Return a virtual composed style manifest.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_virtual_manifest_response( WP_REST_Request $request ) {
+		$paths = $this->get_virtual_artifact_paths( $request['scope'], $request['hash'] );
+		if ( is_wp_error( $paths ) ) {
+			return $paths;
+		}
+
+		$manifest = $this->read_json_file( $paths['manifestPath'] );
+		if ( is_wp_error( $manifest ) ) {
+			return $manifest;
+		}
+
+		$response = new WP_REST_Response( $manifest );
+		$response->header( 'Cache-Control', 'public, max-age=300' );
+		return $response;
+	}
+
+	/**
+	 * Clear map cache metadata when a map changes.
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post Post object.
+	 * @param bool    $update Whether this is an update.
+	 * @return void
+	 */
+	public function invalidate_map_cache( $post_id, $post, $update ) {
+		unset( $post, $update );
+		delete_post_meta( $post_id, '_jeo_mapbox_composed_style_hash' );
+		delete_post_meta( $post_id, '_jeo_mapbox_composed_style_warnings' );
+		delete_post_meta( $post_id, '_jeo_mapbox_composed_style_error' );
+	}
+
+	/**
+	 * Clear cache metadata for maps that reference a changed layer.
+	 *
+	 * @param int     $post_id Layer post ID.
+	 * @param WP_Post $post Layer post object.
+	 * @param bool    $update Whether this is an update.
+	 * @return void
+	 */
+	public function invalidate_layer_cache( $post_id, $post, $update ) {
+		unset( $post, $update );
+
+		$maps = get_posts(
+			array(
+				'post_type'      => 'map',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'meta_query'     => array(
+					array(
+						'key'     => 'layers',
+						'value'   => (string) absint( $post_id ),
+						'compare' => 'LIKE',
+					),
+				),
+			)
+		);
+
+		foreach ( $maps as $map_id ) {
+			$this->invalidate_map_cache( absint( $map_id ), null, true );
+		}
+	}
+
+	/**
+	 * Return whether composed styles are enabled.
+	 *
+	 * @return bool
+	 */
+	private function is_enabled() {
+		return (bool) apply_filters( 'jeo_mapbox_composed_styles_enabled', true );
+	}
+
+	/**
+	 * Check map read permission.
+	 *
+	 * @param int $map_id Map post ID.
+	 * @return bool
+	 */
+	private function can_read_map( $map_id ) {
+		$post = get_post( $map_id );
+		if ( ! $post instanceof WP_Post || 'map' !== $post->post_type ) {
+			return false;
+		}
+
+		if ( 'publish' === get_post_status( $post ) ) {
+			return true;
+		}
+
+		return current_user_can( 'edit_post', $map_id );
+	}
+
+	/**
+	 * Build or reuse cached artifacts.
+	 *
+	 * @param int  $map_id Map post ID.
+	 * @param bool $force_refresh Whether to force regeneration.
+	 * @return array|WP_Error
+	 */
+	private function get_or_create_artifacts( $map_id, $force_refresh = false ) {
+		if ( ! $this->is_enabled() ) {
+			return new WP_Error( 'jeo_mapbox_composer_disabled', __( 'Mapbox composed styles are disabled.', 'jeowp' ) );
+		}
+
+		$context = $this->build_context( $map_id );
+		if ( is_wp_error( $context ) ) {
+			update_post_meta( $map_id, '_jeo_mapbox_composed_style_error', $context->get_error_message() );
+			return $context;
+		}
+
+		$hash  = $this->calculate_hash( $context );
+		$paths = $this->get_artifact_paths( $map_id, $hash );
+		if ( is_wp_error( $paths ) ) {
+			update_post_meta( $map_id, '_jeo_mapbox_composed_style_error', $paths->get_error_message() );
+			return $paths;
+		}
+
+		if (
+			! $force_refresh &&
+			file_exists( $paths['stylePath'] ) &&
+			file_exists( $paths['manifestPath'] )
+		) {
+			return $this->build_metadata( $map_id, $hash, $paths );
+		}
+
+		if ( ! wp_mkdir_p( $paths['dir'] ) ) {
+			return new WP_Error( 'jeo_mapbox_composer_cache_dir', __( 'Could not create the Mapbox composed style cache directory.', 'jeowp' ) );
+		}
+
+		$composed = $this->compose_context( $context, $paths );
+		if ( is_wp_error( $composed ) ) {
+			update_post_meta( $map_id, '_jeo_mapbox_composed_style_error', $composed->get_error_message() );
+			return $composed;
+		}
+
+		$this->write_json_file( $paths['stylePath'], $this->prepare_style_for_json( $composed['style'] ) );
+		$this->write_json_file( $paths['manifestPath'], $composed['manifest'] );
+		$this->write_json_file( $paths['reportPath'], $composed['report'] );
+
+		update_post_meta( $map_id, '_jeo_mapbox_composed_style_hash', $hash );
+		update_post_meta( $map_id, '_jeo_mapbox_composed_style_warnings', $composed['report']['warnings'] );
+		delete_post_meta( $map_id, '_jeo_mapbox_composed_style_error' );
+
+		return $this->build_metadata( $map_id, $hash, $paths, $composed['report'] );
+	}
+
+	/**
+	 * Build or reuse cached artifacts for an editor/public payload.
+	 *
+	 * @param array $payload Request payload.
+	 * @return array|WP_Error
+	 */
+	private function get_or_create_virtual_artifacts( array $payload ) {
+		if ( ! $this->is_enabled() ) {
+			return new WP_Error( 'jeo_mapbox_composer_disabled', __( 'Mapbox composed styles are disabled.', 'jeowp' ) );
+		}
+
+		$context = $this->build_virtual_context( $payload );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
+		$this->maybe_cleanup_virtual_cache( $context['scope'] );
+
+		$hash  = $this->calculate_virtual_hash( $context );
+		$paths = $this->get_virtual_artifact_paths( $context['scope'], $hash );
+		if ( is_wp_error( $paths ) ) {
+			return $paths;
+		}
+
+		if (
+			file_exists( $paths['stylePath'] ) &&
+			file_exists( $paths['manifestPath'] )
+		) {
+			return $this->build_virtual_metadata( $context['scope'], $hash, $paths );
+		}
+
+		if ( ! wp_mkdir_p( $paths['dir'] ) ) {
+			return new WP_Error( 'jeo_mapbox_composer_cache_dir', __( 'Could not create the Mapbox composed style cache directory.', 'jeowp' ) );
+		}
+
+		$composed = $this->compose_context( $context, $paths );
+		if ( is_wp_error( $composed ) ) {
+			return $composed;
+		}
+
+		$this->write_json_file( $paths['stylePath'], $this->prepare_style_for_json( $composed['style'] ) );
+		$this->write_json_file( $paths['manifestPath'], $composed['manifest'] );
+		$this->write_json_file( $paths['reportPath'], $composed['report'] );
+
+		return $this->build_virtual_metadata( $context['scope'], $hash, $paths, $composed['report'] );
+	}
+
+	/**
+	 * Create metadata returned to the frontend.
+	 *
+	 * @param int        $map_id Map post ID.
+	 * @param string     $hash Cache hash.
+	 * @param array      $paths Artifact paths.
+	 * @param array|null $report Optional fresh report.
+	 * @return array
+	 */
+	private function build_metadata( $map_id, $hash, array $paths, $report = null ) {
+		if ( null === $report && file_exists( $paths['reportPath'] ) ) {
+			$report = $this->read_json_file( $paths['reportPath'] );
+		}
+
+		$warnings = array();
+		if ( is_array( $report ) && isset( $report['warnings'] ) && is_array( $report['warnings'] ) ) {
+			$warnings = $report['warnings'];
+		}
+
+		return array(
+			'enabled'      => true,
+			'mapId'        => $map_id,
+			'hash'         => $hash,
+			'style'        => rest_url( sprintf( 'jeo/v1/map-style/%d/style?hash=%s', $map_id, rawurlencode( $hash ) ) ),
+			'manifest'     => rest_url( sprintf( 'jeo/v1/map-style/%d/manifest?hash=%s', $map_id, rawurlencode( $hash ) ) ),
+			'warnings'     => $warnings,
+			'stylePath'    => $paths['stylePath'],
+			'manifestPath' => $paths['manifestPath'],
+		);
+	}
+
+	/**
+	 * Create virtual metadata returned to the frontend.
+	 *
+	 * @param string     $scope Virtual cache scope.
+	 * @param string     $hash Cache hash.
+	 * @param array      $paths Artifact paths.
+	 * @param array|null $report Optional fresh report.
+	 * @return array
+	 */
+	private function build_virtual_metadata( $scope, $hash, array $paths, $report = null ) {
+		$scope = $this->normalize_virtual_scope( $scope );
+
+		if ( null === $report && file_exists( $paths['reportPath'] ) ) {
+			$report = $this->read_json_file( $paths['reportPath'] );
+		}
+
+		$warnings = array();
+		if ( is_array( $report ) && isset( $report['warnings'] ) && is_array( $report['warnings'] ) ) {
+			$warnings = $report['warnings'];
+		}
+
+		return array(
+			'enabled'      => true,
+			'scope'        => $scope,
+			'hash'         => $hash,
+			'style'        => rest_url( sprintf( 'jeo/v1/map-style/%s/%s/style', $scope, rawurlencode( $hash ) ) ),
+			'manifest'     => rest_url( sprintf( 'jeo/v1/map-style/%s/%s/manifest', $scope, rawurlencode( $hash ) ) ),
+			'warnings'     => $warnings,
+			'stylePath'    => $paths['stylePath'],
+			'manifestPath' => $paths['manifestPath'],
+		);
+	}
+
+	/**
+	 * Build context from current map and layer posts.
+	 *
+	 * @param int $map_id Map post ID.
+	 * @return array|WP_Error
+	 */
+	private function build_context( $map_id ) {
+		$post = get_post( $map_id );
+		if ( ! $post instanceof WP_Post || 'map' !== $post->post_type ) {
+			return new WP_Error( 'jeo_mapbox_composer_map_not_found', __( 'Map not found.', 'jeowp' ) );
+		}
+
+		$settings = get_post_meta( $map_id, 'layers', true );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+
+		$token = trim( (string) \jeo_settings()->get_option( 'mapbox_key' ) );
+		if ( '' === $token ) {
+			return new WP_Error( 'jeo_mapbox_composer_missing_token', __( 'A Mapbox access token is required to compose Mapbox styles.', 'jeowp' ) );
+		}
+
+		$refs = $this->build_refs_from_settings( $settings, $token, true );
+
+		$center     = null;
+		$center_lon = get_post_meta( $map_id, 'center_lon', true );
+		$center_lat = get_post_meta( $map_id, 'center_lat', true );
+		if ( '' !== $center_lon && '' !== $center_lat && is_numeric( $center_lon ) && is_numeric( $center_lat ) ) {
+			$center = array( (float) $center_lon, (float) $center_lat );
+		}
+
+		$zoom = get_post_meta( $map_id, 'initial_zoom', true );
+		$zoom = '' !== $zoom && is_numeric( $zoom ) ? (float) $zoom : null;
+
+		return array(
+			'kind'        => 'map',
+			'id'          => $map_id,
+			'slug'        => $post->post_name ? $post->post_name : (string) $map_id,
+			'title'       => get_the_title( $post ),
+			'url'         => get_permalink( $post ),
+			'center'      => $center,
+			'zoom'        => $zoom,
+			'modifiedGmt' => $post->post_modified_gmt,
+			'refs'        => $refs,
+			'mapSettings' => $this->normalize_array( $settings ),
+		);
+	}
+
+	/**
+	 * Build context from an editor/public payload.
+	 *
+	 * @param array $payload Request payload.
+	 * @return array|WP_Error
+	 */
+	private function build_virtual_context( array $payload ) {
+		$scope = $this->normalize_virtual_scope( $payload['scope'] ?? self::VIRTUAL_SCOPE_PREVIEW );
+		$kind  = sanitize_key( $payload['kind'] ?? ( self::VIRTUAL_SCOPE_ONETIME === $scope ? 'onetime-map' : 'preview' ) );
+
+		if ( self::VIRTUAL_SCOPE_ONETIME === $scope && 'onetime-map' !== $kind ) {
+			return new WP_Error( 'jeo_mapbox_composer_invalid_scope', __( 'Public payload composition is only available for one-time maps.', 'jeowp' ) );
+		}
+
+		$encoded_payload = wp_json_encode( $payload );
+		$max_size        = (int) apply_filters( 'jeo_mapbox_composed_payload_max_bytes', 64 * 1024, $scope );
+		if ( strlen( (string) $encoded_payload ) > $max_size ) {
+			return new WP_Error( 'jeo_mapbox_composer_payload_too_large', __( 'The map preview payload is too large.', 'jeowp' ) );
+		}
+
+		$settings   = isset( $payload['layers'] ) && is_array( $payload['layers'] )
+			? $this->sanitize_layer_settings_payload( $payload['layers'] )
+			: array();
+		$max_layers = (int) apply_filters(
+			'jeo_mapbox_composed_payload_max_layers',
+			self::VIRTUAL_SCOPE_ONETIME === $scope ? 40 : 100,
+			$scope
+		);
+		if ( count( $settings ) > $max_layers ) {
+			return new WP_Error( 'jeo_mapbox_composer_too_many_layers', __( 'The map preview has too many layers to compose.', 'jeowp' ) );
+		}
+
+		$token = trim( (string) \jeo_settings()->get_option( 'mapbox_key' ) );
+		if ( '' === $token ) {
+			return new WP_Error( 'jeo_mapbox_composer_missing_token', __( 'A Mapbox access token is required to compose Mapbox styles.', 'jeowp' ) );
+		}
+
+		$include_private = self::VIRTUAL_SCOPE_PREVIEW === $scope;
+		$refs            = $this->build_refs_from_settings( $settings, $token, $include_private );
+		if ( empty( $refs ) ) {
+			return new WP_Error( 'jeo_mapbox_composer_empty_payload', __( 'The map preview does not include any renderable layers.', 'jeowp' ) );
+		}
+
+		$post_id = absint( $payload['postId'] ?? 0 );
+		$post    = $post_id ? get_post( $post_id ) : null;
+
+		$center     = null;
+		$center_lon = $payload['center_lon'] ?? null;
+		$center_lat = $payload['center_lat'] ?? null;
+		if ( '' !== $center_lon && '' !== $center_lat && is_numeric( $center_lon ) && is_numeric( $center_lat ) ) {
+			$center = array( (float) $center_lon, (float) $center_lat );
+		}
+
+		$zoom = $payload['initial_zoom'] ?? null;
+		$zoom = '' !== $zoom && is_numeric( $zoom ) ? (float) $zoom : null;
+
+		$virtual_id = $post_id ? (string) $post_id : substr( sha1( wp_json_encode( $settings ) ), 0, 8 );
+		$title      = isset( $payload['title'] ) ? sanitize_text_field( $payload['title'] ) : '';
+		if ( '' === $title && $post instanceof WP_Post ) {
+			$title = get_the_title( $post );
+		}
+		if ( '' === $title ) {
+			$title = __( 'Map preview', 'jeowp' );
+		}
+
+		$url = '';
+		if ( isset( $payload['url'] ) ) {
+			$url = esc_url_raw( $payload['url'] );
+		} elseif ( $post instanceof WP_Post ) {
+			$url = get_permalink( $post );
+		}
+
+		return array(
+			'kind'        => $kind,
+			'scope'       => $scope,
+			'id'          => $virtual_id,
+			'slug'        => $post instanceof WP_Post && $post->post_name ? $post->post_name : $this->slug_id( $kind . '-' . $virtual_id ),
+			'title'       => $title,
+			'url'         => $url,
+			'center'      => $center,
+			'zoom'        => $zoom,
+			'modifiedGmt' => $post instanceof WP_Post ? $post->post_modified_gmt : '',
+			'refs'        => $refs,
+			'mapSettings' => $settings,
+		);
+	}
+
+	/**
+	 * Build layer references from saved or payload layer settings.
+	 *
+	 * @param array  $settings Layer instance settings.
+	 * @param string $token Default Mapbox token.
+	 * @param bool   $include_private Whether draft/private layers can be used.
+	 * @return array
+	 */
+	private function build_refs_from_settings( array $settings, $token, $include_private ) {
+		$refs = array();
+
+		foreach ( $settings as $index => $setting ) {
+			$setting  = $this->normalize_array( $setting );
+			$layer_id = absint( $setting['id'] ?? 0 );
+			if ( ! $layer_id ) {
+				continue;
+			}
+
+			$layer_post = get_post( $layer_id );
+			if ( ! $layer_post instanceof WP_Post || 'map-layer' !== $layer_post->post_type ) {
+				continue;
+			}
+
+			if ( 'publish' !== get_post_status( $layer_post ) && ( ! $include_private || ! current_user_can( 'edit_post', $layer_id ) ) ) {
+				continue;
+			}
+
+			$type    = (string) get_post_meta( $layer_id, 'type', true );
+			$options = $this->normalize_array( get_post_meta( $layer_id, 'layer_type_options', true ) );
+			if ( '' === $type ) {
+				continue;
+			}
+
+			$style_id = 'mapbox' === $type ? $this->normalize_style_id( $options['style_id'] ?? '' ) : null;
+			if ( 'mapbox' === $type && ! $style_id ) {
+				continue;
+			}
+
+			$refs[] = array(
+				'index'                => (int) $index,
+				'layerId'              => $layer_id,
+				'title'                => get_the_title( $layer_post ),
+				'slug'                 => $layer_post->post_name ? $layer_post->post_name : (string) $layer_id,
+				'type'                 => $type,
+				'options'              => $options,
+				'token'                => ! empty( $options['access_token'] ) ? (string) $options['access_token'] : $token,
+				'styleId'              => $style_id,
+				'loadAsStyle'          => $this->to_bool( $setting['load_as_style'] ?? false ),
+				'use'                  => $setting['use'] ?? null,
+				'default'              => $this->to_bool( $setting['default'] ?? false ),
+				'styleLayerSettings'   => isset( $setting['style_layers'] ) && is_array( $setting['style_layers'] ) ? $this->normalize_array( $setting['style_layers'] ) : array(),
+				'modifiedGmt'          => $layer_post->post_modified_gmt,
+				'layerTypeOptionsHash' => sha1( wp_json_encode( $options ) ),
+			);
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * Keep only layer instance fields that are safe to influence composition.
+	 *
+	 * @param array $settings Raw layer settings.
+	 * @return array
+	 */
+	private function sanitize_layer_settings_payload( array $settings ) {
+		$sanitized = array();
+
+		foreach ( $settings as $setting ) {
+			$setting  = $this->normalize_array( $setting );
+			$layer_id = absint( $setting['id'] ?? 0 );
+			if ( ! $layer_id ) {
+				continue;
+			}
+
+			$item = array(
+				'id'            => $layer_id,
+				'use'           => isset( $setting['use'] ) ? sanitize_key( $setting['use'] ) : null,
+				'default'       => $this->to_bool( $setting['default'] ?? false ),
+				'load_as_style' => $this->to_bool( $setting['load_as_style'] ?? false ),
+				'show_legend'   => ! array_key_exists( 'show_legend', $setting ) || $this->to_bool( $setting['show_legend'] ),
+				'style_layers'  => array(),
+			);
+
+			if ( isset( $setting['style_layers'] ) && is_array( $setting['style_layers'] ) ) {
+				foreach ( $setting['style_layers'] as $style_layer ) {
+					$style_layer = $this->normalize_array( $style_layer );
+					if ( empty( $style_layer['id'] ) ) {
+						continue;
+					}
+					$item['style_layers'][] = array(
+						'id'   => sanitize_text_field( $style_layer['id'] ),
+						'show' => ! array_key_exists( 'show', $style_layer ) || ! $this->is_false( $style_layer['show'] ),
+					);
+				}
+			}
+
+			$sanitized[] = $item;
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Calculate the cache hash.
+	 *
+	 * @param array $context Composer context.
+	 * @return string
+	 */
+	private function calculate_hash( array $context ) {
+		return substr(
+			sha1(
+				wp_json_encode(
+					array(
+						'version'     => self::CACHE_VERSION,
+						'mapId'       => $context['id'],
+						'modifiedGmt' => $context['modifiedGmt'],
+						'mapSettings' => $context['mapSettings'],
+						'refs'        => array_map(
+							function ( $ref ) {
+								return array(
+									'layerId'              => $ref['layerId'],
+									'modifiedGmt'          => $ref['modifiedGmt'],
+									'type'                 => $ref['type'],
+									'styleId'              => $ref['styleId'],
+									'layerTypeOptionsHash' => $ref['layerTypeOptionsHash'],
+								);
+							},
+							$context['refs']
+						),
+					)
+				)
+			),
+			0,
+			16
+		);
+	}
+
+	/**
+	 * Calculate the cache hash for virtual payloads.
+	 *
+	 * @param array $context Composer context.
+	 * @return string
+	 */
+	private function calculate_virtual_hash( array $context ) {
+		return substr(
+			sha1(
+				wp_json_encode(
+					array(
+						'version'     => self::CACHE_VERSION,
+						'scope'       => $context['scope'],
+						'kind'        => $context['kind'],
+						'id'          => $context['id'],
+						'modifiedGmt' => $context['modifiedGmt'],
+						'center'      => $context['center'],
+						'zoom'        => $context['zoom'],
+						'mapSettings' => $context['mapSettings'],
+						'refs'        => array_map(
+							function ( $ref ) {
+								return array(
+									'layerId'              => $ref['layerId'],
+									'modifiedGmt'          => $ref['modifiedGmt'],
+									'type'                 => $ref['type'],
+									'styleId'              => $ref['styleId'],
+									'layerTypeOptionsHash' => $ref['layerTypeOptionsHash'],
+								);
+							},
+							$context['refs']
+						),
+					)
+				)
+			),
+			0,
+			16
+		);
+	}
+
+	/**
+	 * Get artifact filesystem paths and URLs.
+	 *
+	 * @param int    $map_id Map post ID.
+	 * @param string $hash Cache hash.
+	 * @return array|WP_Error
+	 */
+	private function get_artifact_paths( $map_id, $hash ) {
+		$upload_dir = wp_upload_dir( null, false );
+		if ( ! empty( $upload_dir['error'] ) ) {
+			return new WP_Error( 'jeo_mapbox_composer_upload_dir', $upload_dir['error'] );
+		}
+
+		$relative = sprintf( '%s/%d/%s', self::CACHE_DIR, $map_id, sanitize_key( $hash ) );
+		$dir      = trailingslashit( $upload_dir['basedir'] ) . $relative;
+		$baseurl  = trailingslashit( $upload_dir['baseurl'] ) . $relative;
+
+		return array(
+			'dir'          => $dir,
+			'baseurl'      => $baseurl,
+			'stylePath'    => trailingslashit( $dir ) . 'style.json',
+			'manifestPath' => trailingslashit( $dir ) . 'manifest.json',
+			'reportPath'   => trailingslashit( $dir ) . 'report.json',
+			'spriteRoot'   => trailingslashit( $baseurl ) . 'sprite',
+		);
+	}
+
+	/**
+	 * Get artifact filesystem paths and URLs for virtual payloads.
+	 *
+	 * @param string $scope Virtual cache scope.
+	 * @param string $hash Cache hash.
+	 * @return array|WP_Error
+	 */
+	private function get_virtual_artifact_paths( $scope, $hash ) {
+		$scope = $this->normalize_virtual_scope( $scope );
+		$hash  = sanitize_key( $hash );
+
+		if ( ! preg_match( '/^[a-f0-9]{16}$/', $hash ) ) {
+			return new WP_Error( 'jeo_mapbox_composer_invalid_hash', __( 'Invalid composed style hash.', 'jeowp' ) );
+		}
+
+		$upload_dir = wp_upload_dir( null, false );
+		if ( ! empty( $upload_dir['error'] ) ) {
+			return new WP_Error( 'jeo_mapbox_composer_upload_dir', $upload_dir['error'] );
+		}
+
+		$relative = sprintf( '%s/%s/%s', self::CACHE_DIR, $scope, $hash );
+		$dir      = trailingslashit( $upload_dir['basedir'] ) . $relative;
+		$baseurl  = trailingslashit( $upload_dir['baseurl'] ) . $relative;
+
+		return array(
+			'dir'          => $dir,
+			'baseurl'      => $baseurl,
+			'stylePath'    => trailingslashit( $dir ) . 'style.json',
+			'manifestPath' => trailingslashit( $dir ) . 'manifest.json',
+			'reportPath'   => trailingslashit( $dir ) . 'report.json',
+			'spriteRoot'   => trailingslashit( $baseurl ) . 'sprite',
+		);
+	}
+
+	/**
+	 * Compose the style and manifest.
+	 *
+	 * @param array $context Composer context.
+	 * @param array $paths Artifact paths.
+	 * @return array|WP_Error
+	 */
+	private function compose_context( array $context, array $paths ) {
+		$bundles       = array();
+		$failed_styles = array();
+		$warnings      = array();
+		$direct_types  = array( 'mapbox-tileset-raster', 'mapbox-tileset-vector', 'mvt', 'tilelayer' );
+
+		foreach ( $context['refs'] as $ref ) {
+			if ( 'mapbox' !== $ref['type'] ) {
+				continue;
+			}
+
+			$style = $this->fetch_mapbox_style( $ref['styleId'], $ref['token'] );
+			if ( is_wp_error( $style ) ) {
+				$failed_styles[] = array(
+					'layerId' => $ref['layerId'],
+					'styleId' => $ref['styleId'],
+					'error'   => $style->get_error_message(),
+				);
+				continue;
+			}
+
+			$image_props              = $this->get_image_props( $style );
+			$prefix                   = $this->make_prefix( $context, $ref );
+			$bundles[ $ref['index'] ] = array(
+				'ref'         => $ref,
+				'style'       => $style,
+				'prefix'      => $prefix,
+				'imagePrefix' => $prefix . 'img_',
+				'imageProps'  => $image_props,
+				'needsSprite' => $image_props > 0,
+				'spriteUrl'   => $this->first_sprite( $style ),
+				'glyphsUrl'   => $style['glyphs'] ?? null,
+				'warnings'    => array(),
+			);
+		}
+
+		if ( ! empty( $failed_styles ) ) {
+			foreach ( $failed_styles as $failed_style ) {
+				$warnings[] = array(
+					'layerId' => $failed_style['layerId'],
+					'styleId' => $failed_style['styleId'],
+					'warning' => sprintf(
+						'Skipped Mapbox style because it could not be fetched: %s',
+						$this->sanitize_tokens_in_value( $failed_style['error'] )
+					),
+				);
+			}
+
+			$has_direct_layers = array_reduce(
+				$context['refs'],
+				function ( $has_direct, $ref ) use ( $direct_types ) {
+					return $has_direct || in_array( $ref['type'], $direct_types, true );
+				},
+				false
+			);
+
+			if ( empty( $bundles ) && ! $has_direct_layers ) {
+				return new WP_Error(
+					'jeo_mapbox_composer_style_fetch_failed',
+					__( 'One or more Mapbox styles could not be fetched.', 'jeowp' ),
+					$failed_styles
+				);
+			}
+		}
+
+		$sprite_summary = $this->build_composite_sprite( $bundles, $paths );
+		if ( is_wp_error( $sprite_summary ) ) {
+			$warnings[]     = array(
+				'warning' => $sprite_summary->get_error_message(),
+			);
+			$sprite_summary = array(
+				'generated'      => false,
+				'normalImages'   => 0,
+				'retinaImages'   => 0,
+				'spritesMerged'  => 0,
+				'fallbackImages' => 0,
+				'fallbackMisses' => array(),
+				'failures'       => array(),
+			);
+		}
+
+		$glyphs = $this->select_glyphs( $bundles );
+		$style  = array(
+			'version'  => 8,
+			'name'     => sprintf( 'JEO - %s', $context['title'] ),
+			'metadata' => array(
+				'jeo:composed'     => true,
+				'jeo:cacheVersion' => self::CACHE_VERSION,
+				'jeo:sourcePost'   => array(
+					'kind'  => $context['kind'],
+					'id'    => $context['id'],
+					'title' => $context['title'],
+					'url'   => $context['url'],
+				),
+				'jeo:generatedAt'  => gmdate( 'c' ),
+			),
+			'sources'  => array(),
+			'layers'   => array(),
+		);
+
+		if ( ! empty( $context['center'] ) ) {
+			$style['center'] = $context['center'];
+		}
+		if ( null !== $context['zoom'] ) {
+			$style['zoom'] = $context['zoom'];
+		}
+		if ( $glyphs ) {
+			$style['glyphs'] = $glyphs;
+		}
+		if ( ! empty( $sprite_summary['generated'] ) ) {
+			$style['sprite'] = $paths['spriteRoot'];
+		}
+
+		$manifest = array(
+			'kind'        => $context['kind'],
+			'id'          => $context['id'],
+			'slug'        => $context['slug'],
+			'title'       => $context['title'],
+			'originalUrl' => $context['url'],
+			'layers'      => array(),
+		);
+
+		foreach ( $context['refs'] as $ref ) {
+			$bundle = $bundles[ $ref['index'] ] ?? null;
+			if ( ! $bundle ) {
+				if ( in_array( $ref['type'], $direct_types, true ) ) {
+					$direct = $this->build_direct_layer( $context, $ref );
+					if ( $direct ) {
+						$style['sources'][ $direct['sourceId'] ] = $direct['source'];
+						$style['layers'][]                       = $direct['layer'];
+						$manifest['layers'][]                    = $direct['manifest'];
+					}
+				}
+				continue;
+			}
+
+			$source_map = array();
+			foreach ( $bundle['style']['sources'] ?? array() as $old_source_id => $source_definition ) {
+				$new_source_id                      = $bundle['prefix'] . 'src_' . $this->slug_id( $old_source_id );
+				$source_map[ $old_source_id ]       = $new_source_id;
+				$style['sources'][ $new_source_id ] = $this->prepare_source_for_composed_style( $source_definition );
+			}
+
+			foreach ( array( 'projection', 'light', 'terrain', 'fog' ) as $root_property ) {
+				$this->merge_root_property( $style, $root_property, $bundle, $source_map, $warnings );
+			}
+
+			$layer_id_map = array();
+			foreach ( $bundle['style']['layers'] ?? array() as $layer ) {
+				if ( ! is_array( $layer ) || empty( $layer['id'] ) ) {
+					continue;
+				}
+				if ( ! $this->is_style_layer_enabled( $bundle['ref'], $layer['id'] ) ) {
+					continue;
+				}
+				$layer_id_map[ $layer['id'] ] = $bundle['prefix'] . $this->slug_id( $layer['id'] );
+			}
+
+			$manifest_layers = array();
+			$initial_visible = true === $bundle['ref']['default'];
+			foreach ( $bundle['style']['layers'] ?? array() as $layer ) {
+				if ( ! is_array( $layer ) || empty( $layer['id'] ) || ! isset( $layer_id_map[ $layer['id'] ] ) ) {
+					continue;
+				}
+
+				$old_layer_id    = $layer['id'];
+				$new_layer       = $this->sanitize_tokens_in_value( $layer );
+				$new_layer['id'] = $layer_id_map[ $old_layer_id ];
+
+				if ( isset( $new_layer['source'] ) && isset( $source_map[ $new_layer['source'] ] ) ) {
+					$new_layer['source'] = $source_map[ $new_layer['source'] ];
+				}
+
+				if ( isset( $new_layer['ref'] ) ) {
+					if ( isset( $layer_id_map[ $new_layer['ref'] ] ) ) {
+						$new_layer['ref'] = $layer_id_map[ $new_layer['ref'] ];
+					} else {
+						$warnings[] = array(
+							'styleId' => $bundle['ref']['styleId'],
+							'warning' => sprintf( 'Skipped layer %1$s because its ref %2$s was not copied.', $old_layer_id, $new_layer['ref'] ),
+						);
+						continue;
+					}
+				}
+
+				$visible_when_on = ! isset( $layer['layout']['visibility'] ) || 'none' !== $layer['layout']['visibility'];
+				if ( ! $initial_visible ) {
+					$new_layer = $this->set_layer_visibility( $new_layer, false );
+				}
+				if ( ! empty( $bundle['needsSprite'] ) && ! empty( $sprite_summary['generated'] ) ) {
+					$new_layer = $this->rewrite_layer_images( $new_layer, $bundle['imagePrefix'], $bundle['warnings'] );
+				}
+
+				$unsupported_expressions = array();
+				$new_layer               = $this->normalize_unsupported_expressions( $new_layer, $unsupported_expressions );
+				if ( ! empty( $unsupported_expressions ) ) {
+					$warnings[] = array(
+						'styleId' => $bundle['ref']['styleId'],
+						'layerId' => $bundle['ref']['layerId'],
+						'warning' => sprintf(
+							'Layer %1$s used renderer-specific expression operators that were replaced for composed style compatibility: %2$s.',
+							$old_layer_id,
+							implode( ', ', array_keys( $unsupported_expressions ) )
+						),
+					);
+				}
+
+				if ( ! isset( $new_layer['metadata'] ) || ! is_array( $new_layer['metadata'] ) ) {
+					$new_layer['metadata'] = array();
+				}
+				$new_layer['metadata']['jeo:source'] = array(
+					'layerPostId'     => $bundle['ref']['layerId'],
+					'layerTitle'      => $bundle['ref']['title'],
+					'styleId'         => $bundle['ref']['styleId'],
+					'originalLayerId' => $old_layer_id,
+				);
+
+				$style['layers'][] = $new_layer;
+				$manifest_layers[] = array(
+					'originalId'         => $old_layer_id,
+					'compositeId'        => $new_layer['id'],
+					'type'               => $new_layer['type'] ?? null,
+					'visibleWhenLayerOn' => $visible_when_on,
+				);
+			}
+
+			$manifest['layers'][] = array(
+				'layerPostId'     => $bundle['ref']['layerId'],
+				'title'           => $bundle['ref']['title'],
+				'slug'            => $bundle['ref']['slug'],
+				'layerType'       => $bundle['ref']['type'],
+				'styleId'         => $bundle['ref']['styleId'],
+				'loadAsStyle'     => $bundle['ref']['loadAsStyle'],
+				'use'             => $bundle['ref']['use'],
+				'default'         => $bundle['ref']['default'],
+				'initialVisible'  => $initial_visible,
+				'directLayer'     => false,
+				'prefix'          => $bundle['prefix'],
+				'imagePrefix'     => ! empty( $bundle['needsSprite'] ) ? $bundle['imagePrefix'] : null,
+				'interactions'    => $bundle['ref']['loadAsStyle'] ? $this->transform_interactions( $bundle['ref'], $layer_id_map, $warnings ) : array(),
+				'compositeLayers' => $manifest_layers,
+			);
+
+			foreach ( $bundle['warnings'] as $warning ) {
+				$warnings[] = array(
+					'styleId' => $bundle['ref']['styleId'],
+					'warning' => $warning,
+				);
+			}
+		}
+
+		$report = array(
+			'kind'             => $context['kind'],
+			'id'               => $context['id'],
+			'slug'             => $context['slug'],
+			'title'            => $context['title'],
+			'sourceRefs'       => count( $context['refs'] ),
+			'fetchedStyles'    => count( $bundles ),
+			'compositeSources' => count( $style['sources'] ),
+			'compositeLayers'  => count( $style['layers'] ),
+			'manifestLayers'   => array_sum(
+				array_map(
+					function ( $layer ) {
+						return count( $layer['compositeLayers'] ?? array() );
+					},
+					$manifest['layers']
+				)
+			),
+			'spriteSummary'    => $sprite_summary,
+			'warnings'         => $warnings,
+		);
+
+		return array(
+			'style'    => $style,
+			'manifest' => $manifest,
+			'report'   => $report,
+		);
+	}
+
+	/**
+	 * Fetch a Mapbox style.
+	 *
+	 * @param string $style_id Style ID.
+	 * @param string $token Access token.
+	 * @return array|WP_Error
+	 */
+	private function fetch_mapbox_style( $style_id, $token ) {
+		$url = add_query_arg(
+			'access_token',
+			$token,
+			sprintf( 'https://api.mapbox.com/styles/v1/%s', ltrim( $style_id, '/' ) )
+		);
+
+		$data = $this->remote_json( $url );
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		return $this->normalize_array( $data );
+	}
+
+	/**
+	 * Build a direct non-style layer.
+	 *
+	 * @param array $context Composer context.
+	 * @param array $ref Layer reference.
+	 * @return array|null
+	 */
+	private function build_direct_layer( array $context, array $ref ) {
+		$options   = $ref['options'];
+		$prefix    = $this->make_prefix( $context, $ref );
+		$source_id = $prefix . 'src_' . $this->slug_id( $ref['slug'] );
+		$layer_id  = $prefix . $this->slug_id( $ref['slug'] );
+		$visible   = true === $ref['default'];
+
+		if ( in_array( $ref['type'], array( 'mapbox-tileset-raster', 'mapbox-tileset-vector' ), true ) ) {
+			$tileset_url = $this->normalize_tileset_url( $options['tileset_id'] ?? '' );
+			if ( ! $tileset_url ) {
+				return null;
+			}
+			$source = array(
+				'type' => $options['style_source_type'] ?? ( 'mapbox-tileset-vector' === $ref['type'] ? 'vector' : 'raster' ),
+				'url'  => $tileset_url,
+			);
+			$source = $this->prepare_source_for_composed_style( $source );
+			$layer  = array(
+				'id'     => $layer_id,
+				'type'   => $options['type'] ?? ( 'mapbox-tileset-vector' === $ref['type'] ? 'fill' : 'raster' ),
+				'source' => $source_id,
+				'layout' => array(
+					'visibility' => $visible ? 'visible' : 'none',
+				),
+			);
+			if ( 'mapbox-tileset-vector' === $ref['type'] && ! empty( $options['source_layer'] ) ) {
+				$layer['source-layer'] = $options['source_layer'];
+			}
+		} elseif ( 'mvt' === $ref['type'] ) {
+			if ( empty( $options['url'] ) ) {
+				return null;
+			}
+			$source = array(
+				'type'  => 'vector',
+				'tiles' => array( $this->sanitize_tokens_in_value( $options['url'] ) ),
+			);
+			$layer  = array(
+				'id'     => $layer_id,
+				'type'   => $options['type'] ?? 'fill',
+				'source' => $source_id,
+				'layout' => array(
+					'visibility' => $visible ? 'visible' : 'none',
+				),
+			);
+			if ( ! empty( $options['source_layer'] ) ) {
+				$layer['source-layer'] = $options['source_layer'];
+			}
+		} elseif ( 'tilelayer' === $ref['type'] ) {
+			if ( empty( $options['url'] ) ) {
+				return null;
+			}
+			$source = array(
+				'type'     => 'raster',
+				'tiles'    => array( $this->sanitize_tokens_in_value( $options['url'] ) ),
+				'tileSize' => 256,
+				'scheme'   => $options['scheme'] ?? 'xyz',
+			);
+			$source = $this->prepare_source_for_composed_style( $source );
+			$layer  = array(
+				'id'     => $layer_id,
+				'type'   => 'raster',
+				'source' => $source_id,
+				'layout' => array(
+					'visibility' => $visible ? 'visible' : 'none',
+				),
+			);
+		} else {
+			return null;
+		}
+
+		$layer['metadata']['jeo:source'] = array(
+			'layerPostId' => $ref['layerId'],
+			'layerTitle'  => $ref['title'],
+			'layerType'   => $ref['type'],
+		);
+
+		return array(
+			'sourceId' => $source_id,
+			'source'   => $source,
+			'layer'    => $layer,
+			'manifest' => array(
+				'layerPostId'     => $ref['layerId'],
+				'title'           => $ref['title'],
+				'slug'            => $ref['slug'],
+				'layerType'       => $ref['type'],
+				'styleId'         => null,
+				'loadAsStyle'     => $ref['loadAsStyle'],
+				'use'             => $ref['use'],
+				'default'         => $ref['default'],
+				'initialVisible'  => $visible,
+				'directLayer'     => true,
+				'prefix'          => $prefix,
+				'imagePrefix'     => null,
+				'interactions'    => array(),
+				'compositeLayers' => array(
+					array(
+						'originalId'         => (string) $ref['layerId'],
+						'compositeId'        => $layer_id,
+						'type'               => $layer['type'],
+						'visibleWhenLayerOn' => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Merge sprites used by remote styles.
+	 *
+	 * @param array $bundles Style bundles.
+	 * @param array $paths Artifact paths.
+	 * @return array|WP_Error
+	 */
+	private function build_composite_sprite( array $bundles, array $paths ) {
+		$needed = array_filter(
+			$bundles,
+			function ( $bundle ) {
+				return ! empty( $bundle['needsSprite'] ) && ! empty( $bundle['spriteUrl'] );
+			}
+		);
+
+		$summary = array(
+			'generated'      => false,
+			'normalImages'   => 0,
+			'retinaImages'   => 0,
+			'spritesMerged'  => 0,
+			'fallbackImages' => 0,
+			'fallbackMisses' => array(),
+			'failures'       => array(),
+		);
+
+		if ( empty( $needed ) ) {
+			return $summary;
+		}
+
+		if ( ! function_exists( 'imagecreatefromstring' ) ) {
+			return new WP_Error( 'jeo_mapbox_composer_gd_missing', __( 'The PHP GD extension is required to merge Mapbox sprites.', 'jeowp' ) );
+		}
+
+		foreach ( array( 1, 2 ) as $ratio ) {
+			$entries        = array();
+			$entry_keys     = array();
+			$merged_roots   = array();
+			$fallback_cache = null;
+
+			foreach ( $needed as $bundle ) {
+				$fetched = $this->fetch_sprite( $bundle['spriteUrl'], $bundle['ref']['token'], $ratio );
+				if ( is_wp_error( $fetched ) ) {
+					$summary['failures'][] = array(
+						'style' => $bundle['ref']['styleId'],
+						'ratio' => $ratio,
+						'error' => $fetched->get_error_message(),
+					);
+					if ( 2 === $ratio ) {
+						continue;
+					}
+					return $fetched;
+				}
+
+				$merged_roots[ $bundle['spriteUrl'] ] = true;
+				foreach ( $fetched['json'] as $name => $meta ) {
+					$crop = $this->crop_sprite_image( $fetched['image'], $meta );
+					if ( ! $crop ) {
+						continue;
+					}
+					$key                = $bundle['imagePrefix'] . $name;
+					$entries[]          = array(
+						'key'   => $key,
+						'meta'  => $meta,
+						'image' => $crop,
+					);
+					$entry_keys[ $key ] = true;
+				}
+
+				$missing = array_diff( $this->collect_style_image_names( $bundle['style'] ), array_keys( $fetched['json'] ) );
+				if ( ! empty( $missing ) && null === $fallback_cache ) {
+					$fallback_cache = $this->fetch_sprite( self::FALLBACK_SPRITE, $bundle['ref']['token'], $ratio );
+				}
+
+				if ( ! empty( $missing ) && is_array( $fallback_cache ) ) {
+					foreach ( $missing as $name ) {
+						$key = $bundle['imagePrefix'] . $name;
+						if ( isset( $entry_keys[ $key ] ) || empty( $fallback_cache['json'][ $name ] ) ) {
+							if ( 1 === $ratio && empty( $fallback_cache['json'][ $name ] ) ) {
+								$summary['fallbackMisses'][] = array(
+									'style' => $bundle['ref']['styleId'],
+									'image' => $name,
+								);
+							}
+							continue;
+						}
+						$crop = $this->crop_sprite_image( $fallback_cache['image'], $fallback_cache['json'][ $name ] );
+						if ( ! $crop ) {
+							continue;
+						}
+						$entries[]          = array(
+							'key'   => $key,
+							'meta'  => $fallback_cache['json'][ $name ],
+							'image' => $crop,
+						);
+						$entry_keys[ $key ] = true;
+						if ( 1 === $ratio ) {
+							++$summary['fallbackImages'];
+						}
+					}
+				}
+			}
+
+			$packed = $this->pack_images( $entries );
+			if ( is_wp_error( $packed ) ) {
+				return $packed;
+			}
+
+			$suffix = 2 === $ratio ? '@2x' : '';
+			$this->write_json_file( trailingslashit( $paths['dir'] ) . "sprite{$suffix}.json", $packed['json'] );
+			imagepng( $packed['image'], trailingslashit( $paths['dir'] ) . "sprite{$suffix}.png" );
+			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated -- Explicitly frees GD memory after writing generated sprite sheets.
+			imagedestroy( $packed['image'] );
+
+			if ( 1 === $ratio ) {
+				$summary['normalImages'] = count( $packed['json'] );
+			} else {
+				$summary['retinaImages'] = count( $packed['json'] );
+			}
+			$summary['spritesMerged'] = max( $summary['spritesMerged'], count( $merged_roots ) );
+		}
+
+		$summary['generated'] = true;
+		return $summary;
+	}
+
+	/**
+	 * Fetch sprite JSON and PNG.
+	 *
+	 * @param string $sprite Sprite root.
+	 * @param string $token Access token.
+	 * @param int    $ratio Pixel ratio.
+	 * @return array|WP_Error
+	 */
+	private function fetch_sprite( $sprite, $token, $ratio ) {
+		$suffix = 2 === (int) $ratio ? '@2x' : '';
+		$json   = $this->remote_json( $this->sprite_asset_url( $sprite, $token, $suffix, 'json' ) );
+		if ( is_wp_error( $json ) ) {
+			return $json;
+		}
+
+		$image_bytes = $this->remote_bytes( $this->sprite_asset_url( $sprite, $token, $suffix, 'png' ) );
+		if ( is_wp_error( $image_bytes ) ) {
+			return $image_bytes;
+		}
+
+		$image = imagecreatefromstring( $image_bytes );
+		if ( ! $image ) {
+			return new WP_Error( 'jeo_mapbox_composer_sprite_image', __( 'Could not decode a Mapbox sprite image.', 'jeowp' ) );
+		}
+
+		imagealphablending( $image, false );
+		imagesavealpha( $image, true );
+
+		return array(
+			'json'  => $this->normalize_array( $json ),
+			'image' => $image,
+		);
+	}
+
+	/**
+	 * Crop one sprite entry.
+	 *
+	 * @param resource|\GdImage $image Sprite image.
+	 * @param array             $meta Sprite metadata.
+	 * @return resource|\GdImage|null
+	 */
+	private function crop_sprite_image( $image, $meta ) {
+		$width  = absint( $meta['width'] ?? 0 );
+		$height = absint( $meta['height'] ?? 0 );
+		$x      = absint( $meta['x'] ?? 0 );
+		$y      = absint( $meta['y'] ?? 0 );
+		if ( ! $width || ! $height ) {
+			return null;
+		}
+
+		$crop = imagecreatetruecolor( $width, $height );
+		if ( ! $crop ) {
+			return null;
+		}
+
+		imagealphablending( $crop, false );
+		imagesavealpha( $crop, true );
+		$transparent = imagecolorallocatealpha( $crop, 0, 0, 0, 127 );
+		imagefilledrectangle( $crop, 0, 0, $width, $height, $transparent );
+
+		if ( ! imagecopy( $crop, $image, 0, 0, $x, $y, $width, $height ) ) {
+			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated -- Explicitly frees GD memory after a failed sprite crop.
+			imagedestroy( $crop );
+			return null;
+		}
+
+		return $crop;
+	}
+
+	/**
+	 * Pack sprite images into a single canvas.
+	 *
+	 * @param array $entries Sprite entries.
+	 * @return array|WP_Error
+	 */
+	private function pack_images( array $entries ) {
+		$max_width  = 2048;
+		$padding    = 2;
+		$x          = 0;
+		$y          = 0;
+		$row_height = 0;
+		$placements = array();
+
+		foreach ( $entries as $entry ) {
+			$width  = imagesx( $entry['image'] );
+			$height = imagesy( $entry['image'] );
+			if ( $x && $x + $width > $max_width ) {
+				$x          = 0;
+				$y         += $row_height + $padding;
+				$row_height = 0;
+			}
+			$placements[] = array_merge(
+				$entry,
+				array(
+					'x' => $x,
+					'y' => $y,
+				)
+			);
+			$x           += $width + $padding;
+			$row_height   = max( $row_height, $height );
+		}
+
+		$canvas_width  = 1;
+		$canvas_height = 1;
+		foreach ( $placements as $placement ) {
+			$canvas_width  = max( $canvas_width, $placement['x'] + imagesx( $placement['image'] ) );
+			$canvas_height = max( $canvas_height, $placement['y'] + imagesy( $placement['image'] ) );
+		}
+
+		$canvas = imagecreatetruecolor( $canvas_width, $canvas_height );
+		imagealphablending( $canvas, false );
+		imagesavealpha( $canvas, true );
+		$transparent = imagecolorallocatealpha( $canvas, 0, 0, 0, 127 );
+		imagefilledrectangle( $canvas, 0, 0, $canvas_width, $canvas_height, $transparent );
+
+		$packed = array();
+		foreach ( $placements as $placement ) {
+			imagecopy( $canvas, $placement['image'], $placement['x'], $placement['y'], 0, 0, imagesx( $placement['image'] ), imagesy( $placement['image'] ) );
+			$meta                        = $placement['meta'];
+			$meta['x']                   = $placement['x'];
+			$meta['y']                   = $placement['y'];
+			$meta['width']               = imagesx( $placement['image'] );
+			$meta['height']              = imagesy( $placement['image'] );
+			$packed[ $placement['key'] ] = $meta;
+			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated -- Explicitly frees GD memory after each packed sprite fragment.
+			imagedestroy( $placement['image'] );
+		}
+
+		return array(
+			'json'  => $packed,
+			'image' => $canvas,
+		);
+	}
+
+	/**
+	 * Transform interactions to generated layer IDs.
+	 *
+	 * @param array $ref Layer ref.
+	 * @param array $layer_id_map Layer ID map.
+	 * @param array $warnings Warnings.
+	 * @return array
+	 */
+	private function transform_interactions( array $ref, array $layer_id_map, array &$warnings ) {
+		$interactions = isset( $ref['options']['interactions'] ) && is_array( $ref['options']['interactions'] )
+			? $ref['options']['interactions']
+			: array();
+		$transformed  = array();
+
+		foreach ( $interactions as $interaction ) {
+			$interaction = $this->normalize_array( $interaction );
+			$original_id = (string) ( $interaction['id'] ?? '' );
+			if ( '' === $original_id || empty( $layer_id_map[ $original_id ] ) ) {
+				$warnings[] = array(
+					'styleId' => $ref['styleId'],
+					'layerId' => $ref['layerId'],
+					'warning' => sprintf( 'Interaction target layer %s was not copied into the composed style.', $original_id ? $original_id : '<empty>' ),
+				);
+				continue;
+			}
+
+			$fields = array();
+			foreach ( $interaction['fields'] ?? array() as $field ) {
+				$field = $this->normalize_array( $field );
+				if ( empty( $field['field'] ) ) {
+					continue;
+				}
+				$fields[] = array(
+					'field' => $field['field'],
+					'label' => $field['label'] ?? $field['field'],
+				);
+			}
+
+			$transformed[] = array(
+				'originalId'  => $original_id,
+				'compositeId' => $layer_id_map[ $original_id ],
+				'on'          => isset( $interaction['on'] ) && in_array( $interaction['on'], array( 'click', 'mouseover' ), true ) ? $interaction['on'] : 'click',
+				'title'       => $interaction['title'] ?? null,
+				'fields'      => $fields,
+			);
+		}
+
+		return $transformed;
+	}
+
+	/**
+	 * Select a glyph template.
+	 *
+	 * @param array $bundles Style bundles.
+	 * @return string|null
+	 */
+	private function select_glyphs( array $bundles ) {
+		foreach ( $bundles as $bundle ) {
+			foreach ( $bundle['style']['layers'] ?? array() as $layer ) {
+				if ( isset( $layer['layout']['text-font'], $bundle['glyphsUrl'] ) ) {
+					return $bundle['glyphsUrl'];
+				}
+			}
+		}
+
+		foreach ( $bundles as $bundle ) {
+			if ( ! empty( $bundle['glyphsUrl'] ) ) {
+				return $bundle['glyphsUrl'];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Merge a root style property.
+	 *
+	 * @param array  $composite Composite style.
+	 * @param string $property Root property.
+	 * @param array  $bundle Style bundle.
+	 * @param array  $source_map Source ID map.
+	 * @param array  $warnings Warnings.
+	 * @return void
+	 */
+	private function merge_root_property( array &$composite, $property, array $bundle, array $source_map, array &$warnings ) {
+		if ( ! isset( $bundle['style'][ $property ] ) ) {
+			return;
+		}
+		if ( isset( $composite[ $property ] ) ) {
+			$warnings[] = array(
+				'property' => $property,
+				'styleId'  => $bundle['ref']['styleId'],
+				'layerId'  => $bundle['ref']['layerId'],
+				'warning'  => sprintf( 'Root property conflict for %s.', $property ),
+			);
+			return;
+		}
+
+		$value = $this->sanitize_tokens_in_value( $bundle['style'][ $property ] );
+		if ( isset( $value['source'], $source_map[ $value['source'] ] ) ) {
+			$value['source'] = $source_map[ $value['source'] ];
+		}
+		$composite[ $property ] = $value;
+	}
+
+	/**
+	 * Return whether a style layer is enabled by JEO settings.
+	 *
+	 * @param array  $ref Layer ref.
+	 * @param string $layer_id Original style layer ID.
+	 * @return bool
+	 */
+	private function is_style_layer_enabled( array $ref, $layer_id ) {
+		foreach ( $ref['styleLayerSettings'] as $setting ) {
+			$setting = $this->normalize_array( $setting );
+			if ( isset( $setting['id'] ) && $setting['id'] === $layer_id && array_key_exists( 'show', $setting ) && $this->is_false( $setting['show'] ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Set layer visibility.
+	 *
+	 * @param array $layer Style layer.
+	 * @param bool  $visible Visibility.
+	 * @return array
+	 */
+	private function set_layer_visibility( array $layer, $visible ) {
+		if ( ! isset( $layer['layout'] ) || ! is_array( $layer['layout'] ) ) {
+			$layer['layout'] = array();
+		}
+		$layer['layout']['visibility'] = $visible ? 'visible' : 'none';
+		return $layer;
+	}
+
+	/**
+	 * Count image properties in a style.
+	 *
+	 * @param array $style Style JSON.
+	 * @return int
+	 */
+	private function get_image_props( array $style ) {
+		$count = 0;
+		foreach ( $style['layers'] ?? array() as $layer ) {
+			foreach ( array( 'layout', 'paint' ) as $section_name ) {
+				$section = $layer[ $section_name ] ?? array();
+				if ( ! is_array( $section ) ) {
+					continue;
+				}
+				if ( 'layout' === $section_name && array_key_exists( 'icon-image', $section ) ) {
+					++$count;
+				}
+				foreach ( array_keys( $section ) as $key ) {
+					if ( $this->ends_with( $key, '-pattern' ) ) {
+						++$count;
+					}
+				}
+			}
+		}
+		return $count;
+	}
+
+	/**
+	 * Collect literal image names from a style.
+	 *
+	 * @param array $style Style JSON.
+	 * @return array
+	 */
+	private function collect_style_image_names( array $style ) {
+		$names = array();
+		foreach ( $style['layers'] ?? array() as $layer ) {
+			foreach ( array( 'layout', 'paint' ) as $section_name ) {
+				$section = $layer[ $section_name ] ?? array();
+				if ( ! is_array( $section ) ) {
+					continue;
+				}
+				if ( 'layout' === $section_name && array_key_exists( 'icon-image', $section ) ) {
+					$names = array_merge( $names, $this->collect_literal_image_names( $section['icon-image'] ) );
+				}
+				foreach ( $section as $key => $value ) {
+					if ( $this->ends_with( $key, '-pattern' ) ) {
+						$names = array_merge( $names, $this->collect_literal_image_names( $value ) );
+					}
+				}
+			}
+		}
+		return array_values( array_unique( array_filter( $names ) ) );
+	}
+
+	/**
+	 * Collect literal image names from expressions.
+	 *
+	 * @param mixed $value Expression value.
+	 * @return array
+	 */
+	private function collect_literal_image_names( $value ) {
+		if ( is_string( $value ) ) {
+			return '' === $value ? array() : array( $value );
+		}
+		if ( ! is_array( $value ) || empty( $value ) ) {
+			return array();
+		}
+
+		$op          = is_string( $value[0] ?? null ) ? $value[0] : null;
+		$value_count = count( $value );
+		$names       = array();
+		if ( 'step' === $op ) {
+			if ( isset( $value[2] ) ) {
+				$names = array_merge( $names, $this->collect_literal_image_names( $value[2] ) );
+			}
+			for ( $i = 4; $i < $value_count; $i += 2 ) {
+				$names = array_merge( $names, $this->collect_literal_image_names( $value[ $i ] ) );
+			}
+			return $names;
+		}
+		if ( in_array( $op, array( 'interpolate', 'interpolate-hcl', 'interpolate-lab' ), true ) ) {
+			for ( $i = 4; $i < $value_count; $i += 2 ) {
+				$names = array_merge( $names, $this->collect_literal_image_names( $value[ $i ] ) );
+			}
+			return $names;
+		}
+		if ( 'case' === $op ) {
+			for ( $i = 2; $i < $value_count - 1; $i += 2 ) {
+				$names = array_merge( $names, $this->collect_literal_image_names( $value[ $i ] ) );
+			}
+			$names = array_merge( $names, $this->collect_literal_image_names( end( $value ) ) );
+			return $names;
+		}
+		if ( 'match' === $op ) {
+			for ( $i = 3; $i < $value_count - 1; $i += 2 ) {
+				$names = array_merge( $names, $this->collect_literal_image_names( $value[ $i ] ) );
+			}
+			$names = array_merge( $names, $this->collect_literal_image_names( end( $value ) ) );
+			return $names;
+		}
+		if ( 'coalesce' === $op ) {
+			for ( $i = 1; $i < $value_count; ++$i ) {
+				$names = array_merge( $names, $this->collect_literal_image_names( $value[ $i ] ) );
+			}
+			return $names;
+		}
+		if ( 'image' === $op && isset( $value[1] ) ) {
+			return $this->collect_literal_image_names( $value[1] );
+		}
+
+		return array();
+	}
+
+	/**
+	 * Rewrite image references with a prefix.
+	 *
+	 * @param array  $layer Style layer.
+	 * @param string $image_prefix Image prefix.
+	 * @param array  $warnings Warnings.
+	 * @return array
+	 */
+	private function rewrite_layer_images( array $layer, $image_prefix, array &$warnings ) {
+		if ( isset( $layer['layout']['icon-image'] ) ) {
+			$layer['layout']['icon-image'] = $this->rewrite_image_expression( $layer['layout']['icon-image'], $image_prefix, $warnings );
+		}
+
+		foreach ( array( 'layout', 'paint' ) as $section_name ) {
+			if ( empty( $layer[ $section_name ] ) || ! is_array( $layer[ $section_name ] ) ) {
+				continue;
+			}
+			foreach ( $layer[ $section_name ] as $key => $value ) {
+				if ( $this->ends_with( $key, '-pattern' ) ) {
+					$layer[ $section_name ][ $key ] = $this->rewrite_image_expression( $value, $image_prefix, $warnings );
+				}
+			}
+		}
+		return $layer;
+	}
+
+	/**
+	 * Rewrite one image expression.
+	 *
+	 * @param mixed  $value Image expression.
+	 * @param string $image_prefix Image prefix.
+	 * @param array  $warnings Warnings.
+	 * @return mixed
+	 */
+	private function rewrite_image_expression( $value, $image_prefix, array &$warnings ) {
+		if ( is_string( $value ) ) {
+			return '' === $value ? $value : $image_prefix . $value;
+		}
+		if ( ! is_array( $value ) || empty( $value ) ) {
+			return $value;
+		}
+
+			$op              = is_string( $value[0] ?? null ) ? $value[0] : null;
+			$rewritten       = $value;
+			$rewritten_count = count( $rewritten );
+		if ( 'step' === $op ) {
+			if ( isset( $rewritten[2] ) ) {
+				$rewritten[2] = $this->rewrite_image_expression( $rewritten[2], $image_prefix, $warnings );
+			}
+			for ( $i = 4; $i < $rewritten_count; $i += 2 ) {
+				$rewritten[ $i ] = $this->rewrite_image_expression( $rewritten[ $i ], $image_prefix, $warnings );
+			}
+			return $rewritten;
+		}
+		if ( in_array( $op, array( 'interpolate', 'interpolate-hcl', 'interpolate-lab' ), true ) ) {
+			for ( $i = 4; $i < $rewritten_count; $i += 2 ) {
+				$rewritten[ $i ] = $this->rewrite_image_expression( $rewritten[ $i ], $image_prefix, $warnings );
+			}
+			return $rewritten;
+		}
+		if ( 'case' === $op ) {
+			for ( $i = 2; $i < $rewritten_count - 1; $i += 2 ) {
+				$rewritten[ $i ] = $this->rewrite_image_expression( $rewritten[ $i ], $image_prefix, $warnings );
+			}
+			$last = $rewritten_count - 1;
+			if ( $last >= 0 ) {
+				$rewritten[ $last ] = $this->rewrite_image_expression( $rewritten[ $last ], $image_prefix, $warnings );
+			}
+			return $rewritten;
+		}
+		if ( 'match' === $op ) {
+			for ( $i = 3; $i < $rewritten_count - 1; $i += 2 ) {
+				$rewritten[ $i ] = $this->rewrite_image_expression( $rewritten[ $i ], $image_prefix, $warnings );
+			}
+			$last = $rewritten_count - 1;
+			if ( $last >= 0 ) {
+				$rewritten[ $last ] = $this->rewrite_image_expression( $rewritten[ $last ], $image_prefix, $warnings );
+			}
+			return $rewritten;
+		}
+		if ( 'coalesce' === $op ) {
+			for ( $i = 1; $i < $rewritten_count; ++$i ) {
+				$rewritten[ $i ] = $this->rewrite_image_expression( $rewritten[ $i ], $image_prefix, $warnings );
+			}
+			return $rewritten;
+		}
+		if ( 'image' === $op && isset( $rewritten[1] ) ) {
+			$rewritten[1] = $this->rewrite_image_expression( $rewritten[1], $image_prefix, $warnings );
+			return $rewritten;
+		}
+		if ( in_array( $op, array( 'get', 'var', 'to-string', 'concat', 'upcase', 'downcase' ), true ) ) {
+			$string_value = 'to-string' === $op ? $value : array( 'to-string', $value );
+			return array( 'case', array( '==', $string_value, '' ), '', array( 'concat', $image_prefix, $string_value ) );
+		}
+
+		$warnings[] = sprintf( 'Wrapped unsupported image expression: %s.', $op ? $op : 'unknown' );
+		return array( 'case', array( '==', array( 'to-string', $value ), '' ), '', array( 'concat', $image_prefix, array( 'to-string', $value ) ) );
+	}
+
+	/**
+	 * Replace Mapbox renderer-specific expressions unsupported by MapLibre.
+	 *
+	 * These expressions are used by recent Mapbox styles mostly to cull labels
+	 * when the map is pitched. JEO maps are rendered flat by default, so replacing
+	 * them with the flat-map value keeps the style valid without changing the
+	 * normal view.
+	 *
+	 * @param mixed $value Style fragment.
+	 * @param array $replacements Operators replaced, passed by reference.
+	 * @return mixed
+	 */
+	private function normalize_unsupported_expressions( $value, array &$replacements ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$operator = isset( $value[0] ) && is_string( $value[0] ) ? $value[0] : null;
+		if ( 1 === count( $value ) && in_array( $operator, array( 'pitch', 'distance-from-center' ), true ) ) {
+			$replacements[ $operator ] = true;
+			return 0;
+		}
+
+		foreach ( $value as $key => $item ) {
+			$value[ $key ] = $this->normalize_unsupported_expressions( $item, $replacements );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Normalize a Mapbox style ID.
+	 *
+	 * @param string $value Raw style ID.
+	 * @return string|null
+	 */
+	private function normalize_style_id( $value ) {
+		$value = trim( (string) $value );
+		if ( '' === $value ) {
+			return null;
+		}
+		$value = preg_replace( '#^mapbox://styles/#', '', $value );
+		$value = preg_replace( '#^https://api\.mapbox\.com/styles/v1/#', '', $value );
+		$value = strtok( $value, '?' );
+		$value = trim( $value, '/' );
+		return '' === $value ? null : $value;
+	}
+
+	/**
+	 * Normalize a Mapbox tileset URL.
+	 *
+	 * @param string $tileset_id Tileset ID.
+	 * @return string|null
+	 */
+	private function normalize_tileset_url( $tileset_id ) {
+		$tileset_id = trim( (string) $tileset_id );
+		if ( '' === $tileset_id ) {
+			return null;
+		}
+		return $this->starts_with( $tileset_id, 'mapbox://' ) ? $tileset_id : 'mapbox://' . $tileset_id;
+	}
+
+	/**
+	 * Prepare a style source for composed output.
+	 *
+	 * Sources keep their original Mapbox/source URLs. The composer only applies
+	 * token placeholders and minimal source normalization needed by the renderer.
+	 *
+	 * @param array $source Source definition.
+	 * @return array
+	 */
+	private function prepare_source_for_composed_style( $source ) {
+		$source = $this->normalize_array( $source );
+		$type   = $source['type'] ?? null;
+
+		if ( 'raster' === $type && ! empty( $source['tiles'] ) && is_array( $source['tiles'] ) && empty( $source['tileSize'] ) ) {
+			$source['tileSize'] = 256;
+		}
+
+		if ( 'vector' === $type && isset( $source['tileSize'] ) && 512 !== absint( $source['tileSize'] ) ) {
+			$source['tileSize'] = 512;
+		}
+
+		return $this->sanitize_tokens_in_value( $source );
+	}
+
+	/**
+	 * Make a layer prefix.
+	 *
+	 * @param array $context Composer context.
+	 * @param array $ref Layer ref.
+	 * @return string
+	 */
+	private function make_prefix( array $context, array $ref ) {
+		return sprintf( 'j%s_l%d_%d_', $this->slug_id( $context['id'] ), $ref['layerId'], $ref['index'] );
+	}
+
+	/**
+	 * Convert arbitrary IDs to style-safe IDs.
+	 *
+	 * @param string $value Raw ID.
+	 * @param string $fallback Fallback.
+	 * @return string
+	 */
+	private function slug_id( $value, $fallback = 'id' ) {
+		$value = preg_replace( '/[^A-Za-z0-9_.-]+/', '_', (string) $value );
+		$value = trim( preg_replace( '/_+/', '_', $value ), '_' );
+		return '' === $value ? $fallback : $value;
+	}
+
+	/**
+	 * Return the first sprite URL in a style.
+	 *
+	 * @param array $style Style JSON.
+	 * @return string|null
+	 */
+	private function first_sprite( array $style ) {
+		if ( isset( $style['sprite'] ) && is_string( $style['sprite'] ) ) {
+			return $style['sprite'];
+		}
+		if ( isset( $style['sprite'][0] ) && is_string( $style['sprite'][0] ) ) {
+			return $style['sprite'][0];
+		}
+		return null;
+	}
+
+	/**
+	 * Build a sprite asset URL.
+	 *
+	 * @param string $sprite Sprite root.
+	 * @param string $token Access token.
+	 * @param string $suffix Pixel ratio suffix.
+	 * @param string $extension Extension.
+	 * @return string
+	 */
+	private function sprite_asset_url( $sprite, $token, $suffix, $extension ) {
+		if ( $this->starts_with( $sprite, 'mapbox://sprites/' ) ) {
+			$path = trim( substr( $sprite, strlen( 'mapbox://sprites/' ) ), '/' );
+			$root = sprintf( 'https://api.mapbox.com/styles/v1/%s/sprite', $path );
+		} else {
+			$root = preg_replace( '/(@2x)?\.(json|png)(\?.*)?$/', '', $sprite );
+		}
+
+		return add_query_arg( 'access_token', $token, sprintf( '%s%s.%s', $root, $suffix, $extension ) );
+	}
+
+	/**
+	 * Replace raw access tokens with a runtime placeholder.
+	 *
+	 * @param mixed $value Value.
+	 * @return mixed
+	 */
+	private function sanitize_tokens_in_value( $value ) {
+		if ( is_string( $value ) ) {
+			return preg_replace( '/([?&]access_token=)[^&"\']+/', '$1' . self::TOKEN_PLACEHOLDER, $value );
+		}
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $item ) {
+				$value[ $key ] = $this->sanitize_tokens_in_value( $item );
+			}
+		}
+		return $value;
+	}
+
+	/**
+	 * Preserve Mapbox Style object containers that can be empty.
+	 *
+	 * @param array $style Style JSON.
+	 * @return array
+	 */
+	private function prepare_style_for_json( array $style ) {
+		if ( isset( $style['sources'] ) && is_array( $style['sources'] ) ) {
+			foreach ( $style['sources'] as $source_id => $source ) {
+				if ( is_array( $source ) && empty( $source ) ) {
+					$style['sources'][ $source_id ] = new \stdClass();
+				}
+			}
+		}
+
+		if ( isset( $style['layers'] ) && is_array( $style['layers'] ) ) {
+			foreach ( $style['layers'] as $index => $layer ) {
+				if ( ! is_array( $layer ) ) {
+					continue;
+				}
+
+				foreach ( array( 'layout', 'paint', 'metadata' ) as $property ) {
+					if ( isset( $layer[ $property ] ) && is_array( $layer[ $property ] ) && empty( $layer[ $property ] ) ) {
+						$style['layers'][ $index ][ $property ] = new \stdClass();
+					}
+				}
+			}
+		}
+
+		foreach ( array( 'metadata', 'projection', 'light', 'terrain', 'fog' ) as $property ) {
+			if ( isset( $style[ $property ] ) && is_array( $style[ $property ] ) && empty( $style[ $property ] ) ) {
+				$style[ $property ] = new \stdClass();
+			}
+		}
+
+		return $style;
+	}
+
+	/**
+	 * Fetch remote JSON.
+	 *
+	 * @param string $url URL.
+	 * @return mixed|WP_Error
+	 */
+	private function remote_json( $url ) {
+		$bytes = $this->remote_bytes( $url );
+		if ( is_wp_error( $bytes ) ) {
+			return $bytes;
+		}
+		$data = json_decode( $bytes, true );
+		if ( JSON_ERROR_NONE !== json_last_error() ) {
+			return new WP_Error( 'jeo_mapbox_composer_json', json_last_error_msg() );
+		}
+		return $data;
+	}
+
+	/**
+	 * Fetch remote bytes.
+	 *
+	 * @param string $url URL.
+	 * @return string|WP_Error
+	 */
+	private function remote_bytes( $url ) {
+		$response = wp_remote_get(
+			$url,
+			array(
+				'timeout'    => 45,
+				'user-agent' => 'jeo-mapbox-style-composer/' . self::CACHE_VERSION,
+			)
+		);
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( $code < 200 || $code >= 300 ) {
+			return new WP_Error(
+				'jeo_mapbox_composer_http',
+				sprintf( 'Remote request failed with HTTP %1$d for %2$s.', $code, $this->sanitize_tokens_in_value( esc_url_raw( $url ) ) )
+			);
+		}
+		return wp_remote_retrieve_body( $response );
+	}
+
+		/**
+		 * Read a JSON file.
+		 *
+		 * @param string $path Path.
+		 * @param bool   $associative Whether to return associative arrays.
+		 * @return mixed|WP_Error
+		 */
+	private function read_json_file( $path, $associative = true ) {
+		if ( ! file_exists( $path ) ) {
+			return new WP_Error( 'jeo_mapbox_composer_missing_file', __( 'Composed style artifact was not found.', 'jeowp' ) );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads plugin-generated cache files.
+		$data = json_decode( file_get_contents( $path ), $associative );
+		if ( JSON_ERROR_NONE !== json_last_error() ) {
+			return new WP_Error( 'jeo_mapbox_composer_json_file', json_last_error_msg() );
+		}
+		return $data;
+	}
+
+	/**
+	 * Write a JSON file.
+	 *
+	 * @param string $path Path.
+	 * @param mixed  $data Data.
+	 * @return void
+	 */
+	private function write_json_file( $path, $data ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writes plugin-generated cache files.
+		file_put_contents(
+			$path,
+			wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
+		);
+	}
+
+	/**
+	 * Normalize a virtual cache scope.
+	 *
+	 * @param string $scope Scope.
+	 * @return string
+	 */
+	private function normalize_virtual_scope( $scope ) {
+		$scope = sanitize_key( $scope );
+		return self::VIRTUAL_SCOPE_ONETIME === $scope ? self::VIRTUAL_SCOPE_ONETIME : self::VIRTUAL_SCOPE_PREVIEW;
+	}
+
+	/**
+	 * Remove old virtual cache directories opportunistically.
+	 *
+	 * @param string $scope Virtual cache scope.
+	 * @return void
+	 */
+	private function maybe_cleanup_virtual_cache( $scope ) {
+		$scope      = $this->normalize_virtual_scope( $scope );
+		$lock_key   = 'jeo_mapbox_composed_' . $scope . '_cleanup_lock';
+		$lock_value = get_transient( $lock_key );
+		if ( $lock_value ) {
+			return;
+		}
+
+		set_transient( $lock_key, 1, HOUR_IN_SECONDS );
+
+		$upload_dir = wp_upload_dir( null, false );
+		if ( ! empty( $upload_dir['error'] ) ) {
+			return;
+		}
+
+		$root = trailingslashit( $upload_dir['basedir'] ) . self::CACHE_DIR . '/' . $scope;
+		if ( ! is_dir( $root ) ) {
+			return;
+		}
+
+		$ttl         = (int) apply_filters(
+			'jeo_mapbox_composed_virtual_cache_ttl',
+			self::VIRTUAL_SCOPE_ONETIME === $scope ? 30 * DAY_IN_SECONDS : DAY_IN_SECONDS,
+			$scope
+		);
+		$now         = time();
+		$deleted     = 0;
+		$directories = glob( trailingslashit( $root ) . '*' );
+
+		if ( ! is_array( $directories ) ) {
+			return;
+		}
+
+		foreach ( $directories as $dir ) {
+			if ( $deleted >= 50 || ! is_dir( $dir ) ) {
+				continue;
+			}
+			if ( $now - filemtime( $dir ) < $ttl ) {
+				continue;
+			}
+			$this->delete_directory( $dir );
+			++$deleted;
+		}
+	}
+
+	/**
+	 * Delete a generated cache directory recursively.
+	 *
+	 * @param string $dir Directory.
+	 * @return void
+	 */
+	private function delete_directory( $dir ) {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+
+		foreach ( glob( trailingslashit( $dir ) . '*' ) as $path ) {
+			if ( is_dir( $path ) ) {
+				$this->delete_directory( $path );
+			} else {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes plugin-generated cache files.
+				unlink( $path );
+			}
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Removes plugin-generated cache directories.
+		rmdir( $dir );
+	}
+
+	/**
+	 * Normalize objects into arrays recursively.
+	 *
+	 * @param mixed $value Value.
+	 * @return mixed
+	 */
+	private function normalize_array( $value ) {
+		if ( is_object( $value ) ) {
+			$value = get_object_vars( $value );
+		}
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $item ) {
+				$value[ $key ] = $this->normalize_array( $item );
+			}
+		}
+		return $value;
+	}
+
+	/**
+	 * Convert values to booleans.
+	 *
+	 * @param mixed $value Value.
+	 * @return bool
+	 */
+	private function to_bool( $value ) {
+		return true === $value || 1 === $value || '1' === $value || 'true' === $value;
+	}
+
+	/**
+	 * Return whether a value represents false.
+	 *
+	 * @param mixed $value Value.
+	 * @return bool
+	 */
+	private function is_false( $value ) {
+		return false === $value || 0 === $value || '0' === $value || 'false' === $value || '' === $value;
+	}
+
+	/**
+	 * Check a string prefix without requiring PHP 8.
+	 *
+	 * @param string $haystack Haystack.
+	 * @param string $needle Needle.
+	 * @return bool
+	 */
+	private function starts_with( $haystack, $needle ) {
+		return 0 === strpos( (string) $haystack, (string) $needle );
+	}
+
+	/**
+	 * Check a string suffix without requiring PHP 8.
+	 *
+	 * @param string $haystack Haystack.
+	 * @param string $needle Needle.
+	 * @return bool
+	 */
+	private function ends_with( $haystack, $needle ) {
+		$haystack = (string) $haystack;
+		$needle   = (string) $needle;
+		if ( '' === $needle ) {
+			return true;
+		}
+		return substr( $haystack, -strlen( $needle ) ) === $needle;
+	}
+}

--- a/src/includes/maps/class-map-style-composer.php
+++ b/src/includes/maps/class-map-style-composer.php
@@ -2489,5 +2489,4 @@ class Map_Style_Composer {
 	private function is_false( $value ) {
 		return false === $value || 0 === $value || '0' === $value || 'false' === $value || '' === $value;
 	}
-
 }

--- a/src/includes/maps/class-map-style-composer.php
+++ b/src/includes/maps/class-map-style-composer.php
@@ -25,9 +25,9 @@ class Map_Style_Composer {
 	use Singleton;
 
 	const CACHE_DIR               = 'jeo-mapbox-composed-styles';
-	const CACHE_VERSION           = 11;
+	const CACHE_VERSION           = 12;
 	const TOKEN_PLACEHOLDER       = '__JEO_MAPBOX_ACCESS_TOKEN__';
-	const DEFAULT_FALLBACK_SPRITE = 'mapbox://sprites/mapbox/streets-v11';
+	const DEFAULT_FALLBACK_SPRITE = 'mapbox://sprites/mapbox/standard';
 	const VIRTUAL_SCOPE_PREVIEW   = 'preview';
 	const VIRTUAL_SCOPE_ONETIME   = 'onetime';
 

--- a/src/includes/maps/class-map-style-composer.php
+++ b/src/includes/maps/class-map-style-composer.php
@@ -1785,7 +1785,7 @@ class Map_Style_Composer {
 					++$count;
 				}
 				foreach ( array_keys( $section ) as $key ) {
-					if ( $this->ends_with( $key, '-pattern' ) ) {
+					if ( str_ends_with( $key, '-pattern' ) ) {
 						++$count;
 					}
 				}
@@ -1812,7 +1812,7 @@ class Map_Style_Composer {
 					$names = array_merge( $names, $this->collect_literal_image_names( $section['icon-image'] ) );
 				}
 				foreach ( $section as $key => $value ) {
-					if ( $this->ends_with( $key, '-pattern' ) ) {
+					if ( str_ends_with( $key, '-pattern' ) ) {
 						$names = array_merge( $names, $this->collect_literal_image_names( $value ) );
 					}
 				}
@@ -1898,7 +1898,7 @@ class Map_Style_Composer {
 				continue;
 			}
 			foreach ( $layer[ $section_name ] as $key => $value ) {
-				if ( $this->ends_with( $key, '-pattern' ) ) {
+				if ( str_ends_with( $key, '-pattern' ) ) {
 					$layer[ $section_name ][ $key ] = $this->rewrite_image_expression( $value, $image_prefix, $warnings );
 				}
 			}
@@ -2038,7 +2038,7 @@ class Map_Style_Composer {
 		if ( '' === $tileset_id ) {
 			return null;
 		}
-		return $this->starts_with( $tileset_id, 'mapbox://' ) ? $tileset_id : 'mapbox://' . $tileset_id;
+		return str_starts_with( $tileset_id, 'mapbox://' ) ? $tileset_id : 'mapbox://' . $tileset_id;
 	}
 
 	/**
@@ -2115,7 +2115,7 @@ class Map_Style_Composer {
 	 * @return string
 	 */
 	private function sprite_asset_url( $sprite, $token, $suffix, $extension ) {
-		if ( $this->starts_with( $sprite, 'mapbox://sprites/' ) ) {
+		if ( str_starts_with( $sprite, 'mapbox://sprites/' ) ) {
 			$path = trim( substr( $sprite, strlen( 'mapbox://sprites/' ) ), '/' );
 			$root = sprintf( 'https://api.mapbox.com/styles/v1/%s/sprite', $path );
 		} else {
@@ -2385,30 +2385,4 @@ class Map_Style_Composer {
 		return false === $value || 0 === $value || '0' === $value || 'false' === $value || '' === $value;
 	}
 
-	/**
-	 * Check a string prefix without requiring PHP 8.
-	 *
-	 * @param string $haystack Haystack.
-	 * @param string $needle Needle.
-	 * @return bool
-	 */
-	private function starts_with( $haystack, $needle ) {
-		return 0 === strpos( (string) $haystack, (string) $needle );
-	}
-
-	/**
-	 * Check a string suffix without requiring PHP 8.
-	 *
-	 * @param string $haystack Haystack.
-	 * @param string $needle Needle.
-	 * @return bool
-	 */
-	private function ends_with( $haystack, $needle ) {
-		$haystack = (string) $haystack;
-		$needle   = (string) $needle;
-		if ( '' === $needle ) {
-			return true;
-		}
-		return substr( $haystack, -strlen( $needle ) ) === $needle;
-	}
 }

--- a/src/js/src/discovery/blocks/map-layers.js
+++ b/src/js/src/discovery/blocks/map-layers.js
@@ -15,7 +15,6 @@ import Search from './search';
 
 const MAPS_PER_PAGE = 20;
 const MAP_COLLECTION_FIELDS = 'id,title,excerpt,meta';
-const DEFAULT_GLYPHS = 'mapbox://fonts/mapbox/{fontstack}/{range}.pbf';
 const STATIC_IMAGE_EXPRESSION_OPS = new Set( [
 	'step',
 	'case',
@@ -765,8 +764,12 @@ class MapLayers extends Component {
 			return;
 		}
 
+		const defaultGlyphs = window.jeoMapVars?.composedStyleDefaultGlyphs || '';
+
 		if ( map.style?.stylesheet ) {
-			map.style.stylesheet.glyphs = glyphs || DEFAULT_GLYPHS;
+			if ( glyphs || defaultGlyphs ) {
+				map.style.stylesheet.glyphs = glyphs || defaultGlyphs;
+			}
 		}
 	}
 

--- a/src/js/src/discovery/blocks/map-layers.js
+++ b/src/js/src/discovery/blocks/map-layers.js
@@ -4,14 +4,35 @@ import { __ } from '@wordpress/i18n';
 import { List, arrayMove } from 'react-movable';
 import { addQueryArgs } from '@wordpress/url';
 
-import { mapboxToken } from '../../lib/mapgl-loader';
-import { chunkRecordIds, mergeRecordsByIdOrder } from '../../shared/rest-records';
+import {
+	chunkRecordIds,
+	mergeRecordsByIdOrder,
+} from '../../shared/rest-records';
+import { addComposedInteractions } from '../../shared/composed-style-layers';
 import LoadingSpinner from './loading-spinner';
 import MapItem from './map-item';
 import Search from './search';
 
 const MAPS_PER_PAGE = 20;
 const MAP_COLLECTION_FIELDS = 'id,title,excerpt,meta';
+const DEFAULT_GLYPHS = 'mapbox://fonts/mapbox/{fontstack}/{range}.pbf';
+const STATIC_IMAGE_EXPRESSION_OPS = new Set( [
+	'step',
+	'case',
+	'match',
+	'coalesce',
+	'image',
+	'interpolate',
+	'interpolate-hcl',
+	'interpolate-lab',
+] );
+const STORY_INTERACTION_LAYER_IDS = [
+	'unclustered-points',
+	'hover-unclustered-points',
+	'cluster-layer',
+	'cluster-count',
+	'hover-cluster-layer',
+];
 
 const normalizeMaps = ( maps = [] ) =>
 	( Array.isArray( maps ) ? maps : [] )
@@ -24,11 +45,12 @@ const normalizeMaps = ( maps = [] ) =>
 					? singleMap.meta.layers
 					: [],
 			},
-			queriedLayers: Array.isArray( singleMap.queriedLayers ) ?
-				singleMap.queriedLayers :
-				Array.isArray( singleMap?.meta?.layers ) && singleMap.meta.layers.length
-					? null
-					: [],
+			queriedLayers: Array.isArray( singleMap.queriedLayers )
+				? singleMap.queriedLayers
+				: Array.isArray( singleMap?.meta?.layers ) &&
+				  singleMap.meta.layers.length
+				? null
+				: [],
 		} ) );
 
 const mergeMapsById = ( currentMaps = [], nextMaps = [] ) => {
@@ -56,6 +78,12 @@ class MapLayers extends Component {
 			currentSearch: '',
 		};
 		this.pendingLayerRequests = new Map();
+		this.composedMapRequests = new Map();
+		this.composedLayerState = new Map();
+		this.spriteAtlasRequests = new Map();
+		this.spriteAtlases = new Map();
+		this.styleImageMissingHandlerRegistered = false;
+		this.applyLayersSequence = 0;
 
 		this.toggleLayer = this.toggleLayer.bind( this );
 		this.applyLayersChanges = this.applyLayersChanges.bind( this );
@@ -66,22 +94,83 @@ class MapLayers extends Component {
 		this.fetchMapsByIds = this.fetchMapsByIds.bind( this );
 		this.canLoadMoreMaps = this.canLoadMoreMaps.bind( this );
 		this.loadMoreMaps = this.loadMoreMaps.bind( this );
+		this.fetchComposedMap = this.fetchComposedMap.bind( this );
+		this.addComposedMapboxLayer = this.addComposedMapboxLayer.bind( this );
+		this.registerStyleImageMissingHandler =
+			this.registerStyleImageMissingHandler.bind( this );
 
 		if ( ! this.props.mapsLoaded ) {
 			if ( this.props.isEmbed ) {
-				const requestedLayerIds = this.getLayerIdsFromUrl().map(
+				const requestedLayers = this.getLayerIdsFromUrl();
+				const requestedLayerIds = requestedLayers.map(
 					( data ) => data[ 0 ]
 				);
-				this.fetchLayers( requestedLayerIds ).then( ( layers ) => {
-					const { selectedLayers, layersQueue } =
-						this.buildSelectionState( layers.reverse() );
+				const requestedMapIds = [
+					...new Set(
+						requestedLayers
+							.map( ( data ) => data[ 1 ] )
+							.filter( ( mapId ) =>
+								Number.isFinite( Number.parseInt( mapId, 10 ) )
+							)
+					),
+				];
 
-					this.props.updateState( {
-						selectedLayers,
-						layersQueue,
+				if ( requestedMapIds.length ) {
+					this.fetchMapsByIds( requestedMapIds ).then(
+						async ( maps ) => {
+							const layersByMap = new Map();
+
+							for ( const mapId of requestedMapIds ) {
+								layersByMap.set(
+									mapId,
+									await this.loadMapLayers(
+										maps.find(
+											( singleMap ) =>
+												singleMap.id === mapId
+										) || null,
+										maps
+									)
+								);
+							}
+
+							const sortedLayerBatch = requestedLayers
+								.map( ( item ) =>
+									layersByMap
+										.get( item[ 1 ] )
+										?.find(
+											( layer ) => layer.id === item[ 0 ]
+										)
+								)
+								.filter( Boolean );
+							const { selectedLayers, layersQueue } =
+								this.buildSelectionState(
+									sortedLayerBatch.reverse()
+								);
+
+							this.props.updateState( {
+								maps,
+								mapsLoaded: true,
+								selectedLayers,
+								layersQueue,
+							} );
+							this.applyLayersChanges(
+								layersQueue,
+								selectedLayers
+							);
+						}
+					);
+				} else {
+					this.fetchLayers( requestedLayerIds ).then( ( layers ) => {
+						const { selectedLayers, layersQueue } =
+							this.buildSelectionState( layers.reverse() );
+
+						this.props.updateState( {
+							selectedLayers,
+							layersQueue,
+						} );
+						this.applyLayersChanges( layersQueue, selectedLayers );
 					} );
-					this.applyLayersChanges( layersQueue, selectedLayers );
-				} );
+				}
 			} else {
 				const urlParams = new URLSearchParams( window.location.search );
 				const isShare = urlParams.get( 'share' );
@@ -97,20 +186,32 @@ class MapLayers extends Component {
 									.map( ( item ) => item.map )
 									.filter(
 										( mapId ) =>
-											! maps.some( ( singleMap ) => singleMap.id === mapId )
+											! maps.some(
+												( singleMap ) =>
+													singleMap.id === mapId
+											)
 									)
 							),
 						];
-						const allMaps = missingMapIds.length ?
-							mergeMapsById( maps, await this.fetchMapsByIds( missingMapIds ) ) :
-							maps;
+						const allMaps = missingMapIds.length
+							? mergeMapsById(
+									maps,
+									await this.fetchMapsByIds( missingMapIds )
+							  )
+							: maps;
 						const layersByMap = new Map();
 
-						for ( const mapId of [ ...new Set( requestedLayerIds.map( ( item ) => item.map ) ) ] ) {
+						for ( const mapId of [
+							...new Set(
+								requestedLayerIds.map( ( item ) => item.map )
+							),
+						] ) {
 							layersByMap.set(
 								mapId,
 								await this.loadMapLayers(
-									allMaps.find( ( singleMap ) => singleMap.id === mapId ) || null,
+									allMaps.find(
+										( singleMap ) => singleMap.id === mapId
+									) || null,
 									allMaps
 								)
 							);
@@ -124,7 +225,9 @@ class MapLayers extends Component {
 							)
 							.filter( Boolean );
 						const { selectedLayers, layersQueue } =
-							this.buildSelectionState( sortedLayerBatch.reverse() );
+							this.buildSelectionState(
+								sortedLayerBatch.reverse()
+							);
 
 						this.props.updateState( {
 							selectedLayers,
@@ -159,7 +262,10 @@ class MapLayers extends Component {
 		);
 
 		if ( window.jeowpLanguageParams?.currentLang ) {
-			mapsUrl.searchParams.append( 'lang', window.jeowpLanguageParams.currentLang );
+			mapsUrl.searchParams.append(
+				'lang',
+				window.jeowpLanguageParams.currentLang
+			);
 		}
 
 		return fetch( mapsUrl )
@@ -172,9 +278,9 @@ class MapLayers extends Component {
 			} ) )
 			.then( ( { maps, totalPages } ) => {
 				const nextMaps = normalizeMaps( maps );
-				const mergedMaps = cumulative ?
-					mergeMapsById( this.props.maps, nextMaps ) :
-					nextMaps;
+				const mergedMaps = cumulative
+					? mergeMapsById( this.props.maps, nextMaps )
+					: nextMaps;
 
 				this.props.updateState( {
 					maps: mergedMaps,
@@ -193,7 +299,10 @@ class MapLayers extends Component {
 			.catch( ( error ) => {
 				this.setState( {
 					isLoadingMaps: false,
-					mapsError: __( 'Unable to load map layers right now.', 'jeowp' ),
+					mapsError: __(
+						'Unable to load map layers right now.',
+						'jeowp'
+					),
 				} );
 
 				throw error;
@@ -208,14 +317,17 @@ class MapLayers extends Component {
 				orderby: 'include',
 				per_page: chunk.length,
 				_fields: MAP_COLLECTION_FIELDS,
-				...( 'jeowpLanguageParams' in window && window.jeowpLanguageParams?.currentLang
+				...( 'jeowpLanguageParams' in window &&
+				window.jeowpLanguageParams?.currentLang
 					? { lang: window.jeowpLanguageParams.currentLang }
 					: {} ),
 			} );
 
 			return fetch( path )
 				.then( ( response ) => response.json() )
-				.then( ( response ) => Array.isArray( response ) ? response : [] );
+				.then( ( response ) =>
+					Array.isArray( response ) ? response : []
+				);
 		} );
 
 		return Promise.all( requests ).then( ( maps ) =>
@@ -229,14 +341,17 @@ class MapLayers extends Component {
 			const path = addQueryArgs( jeoMapVars.layersUrl, {
 				include: chunk,
 				context: 'view',
-				...( 'jeowpLanguageParams' in window && window.jeowpLanguageParams?.currentLang
+				...( 'jeowpLanguageParams' in window &&
+				window.jeowpLanguageParams?.currentLang
 					? { lang: window.jeowpLanguageParams.currentLang }
 					: {} ),
 			} );
 
 			return fetch( path )
 				.then( ( response ) => response.json() )
-				.then( ( response ) => Array.isArray( response ) ? response : [] );
+				.then( ( response ) =>
+					Array.isArray( response ) ? response : []
+				);
 		} );
 
 		return Promise.all( requests ).then( ( layers ) =>
@@ -249,7 +364,10 @@ class MapLayers extends Component {
 			return Promise.resolve( [] );
 		}
 
-		if ( ! Array.isArray( map?.meta?.layers ) || map.meta.layers.length === 0 ) {
+		if (
+			! Array.isArray( map?.meta?.layers ) ||
+			map.meta.layers.length === 0
+		) {
 			return Promise.resolve( [] );
 		}
 
@@ -268,9 +386,14 @@ class MapLayers extends Component {
 			},
 		} ) );
 
-		const request = this.fetchLayers( map.meta.layers.map( ( layer ) => layer.id ) )
+		const request = this.fetchLayers(
+			map.meta.layers.map( ( layer ) => layer.id )
+		)
 			.then( ( layers ) => {
-				const queriedLayers = layers.map( ( layer ) => ( { ...layer, map } ) );
+				const queriedLayers = layers.map( ( layer ) => ( {
+					...layer,
+					map,
+				} ) );
 				const nextMaps = maps.map( ( currentMap ) =>
 					currentMap.id === map.id
 						? { ...currentMap, queriedLayers }
@@ -283,7 +406,9 @@ class MapLayers extends Component {
 			.finally( () => {
 				this.pendingLayerRequests.delete( map.id );
 				this.setState( ( currentState ) => {
-					const loadingMapLayerIds = { ...currentState.loadingMapLayerIds };
+					const loadingMapLayerIds = {
+						...currentState.loadingMapLayerIds,
+					};
 					delete loadingMapLayerIds[ map.id ];
 					return { loadingMapLayerIds };
 				} );
@@ -303,9 +428,594 @@ class MapLayers extends Component {
 		}
 
 		try {
-			return JSON.parse( layerIds );
+			return JSON.parse( layerIds )
+				.map( ( item ) => {
+					if ( ! Array.isArray( item ) ) {
+						return null;
+					}
+
+					const layerId = Number.parseInt( item[ 0 ], 10 );
+					const mapId = Number.parseInt( item[ 1 ], 10 );
+
+					if ( ! Number.isFinite( layerId ) ) {
+						return null;
+					}
+
+					return Number.isFinite( mapId )
+						? [ layerId, mapId ]
+						: [ layerId ];
+				} )
+				.filter( Boolean );
 		} catch ( error ) {
 			return [];
+		}
+	}
+
+	fetchJson( url ) {
+		return fetch( url, {
+			headers: jeoMapVars?.nonce
+				? {
+						'X-WP-Nonce': jeoMapVars.nonce,
+				  }
+				: {},
+		} ).then( ( response ) => {
+			if ( ! response.ok ) {
+				throw new Error(
+					`${ response.status } ${ response.statusText }`
+				);
+			}
+
+			return response.json();
+		} );
+	}
+
+	fetchComposedMap( mapId ) {
+		if ( ! mapId || ! window.jeoMapVars?.composedStyleUrlBase ) {
+			return Promise.reject(
+				new Error(
+					__( 'Mapbox style composition is unavailable.', 'jeowp' )
+				)
+			);
+		}
+
+		if ( this.composedMapRequests.has( mapId ) ) {
+			return this.composedMapRequests.get( mapId );
+		}
+
+		const request = this.fetchJson(
+			`${ jeoMapVars.composedStyleUrlBase }${ mapId }`
+		)
+			.then( async ( metadata ) => {
+				if (
+					! metadata?.enabled ||
+					! metadata.style ||
+					! metadata.manifest
+				) {
+					throw new Error(
+						metadata?.error ||
+							__(
+								'Mapbox style composition is unavailable for this map.',
+								'jeowp'
+							)
+					);
+				}
+
+				const [ style, manifest ] = await Promise.all( [
+					this.fetchJson( metadata.style ),
+					this.fetchJson( metadata.manifest ),
+				] );
+
+				return { metadata, style, manifest };
+			} )
+			.catch( ( error ) => {
+				this.composedMapRequests.delete( mapId );
+				throw error;
+			} );
+
+		this.composedMapRequests.set( mapId, request );
+		return request;
+	}
+
+	cloneJson( value ) {
+		if ( value === undefined || value === null ) {
+			return value;
+		}
+
+		return JSON.parse( JSON.stringify( value ) );
+	}
+
+	collectLiteralImageNames( value ) {
+		if ( typeof value === 'string' ) {
+			return value ? new Set( [ value ] ) : new Set();
+		}
+
+		if ( ! Array.isArray( value ) || ! value.length ) {
+			return new Set();
+		}
+
+		const op = typeof value[ 0 ] === 'string' ? value[ 0 ] : null;
+		const names = new Set();
+		let indexes = [];
+
+		if ( op === 'step' ) {
+			indexes = [ 2 ];
+			for ( let index = 4; index < value.length; index += 2 ) {
+				indexes.push( index );
+			}
+		} else if (
+			[ 'interpolate', 'interpolate-hcl', 'interpolate-lab' ].includes(
+				op
+			)
+		) {
+			for ( let index = 4; index < value.length; index += 2 ) {
+				indexes.push( index );
+			}
+		} else if ( op === 'case' ) {
+			for ( let index = 2; index < value.length - 1; index += 2 ) {
+				indexes.push( index );
+			}
+			indexes.push( value.length - 1 );
+		} else if ( op === 'match' ) {
+			for ( let index = 3; index < value.length - 1; index += 2 ) {
+				indexes.push( index );
+			}
+			indexes.push( value.length - 1 );
+		} else if ( op === 'coalesce' ) {
+			for ( let index = 1; index < value.length; index += 1 ) {
+				indexes.push( index );
+			}
+		} else if ( op === 'image' ) {
+			indexes = [ 1 ];
+		} else if ( STATIC_IMAGE_EXPRESSION_OPS.has( op ) ) {
+			for ( let index = 1; index < value.length; index += 1 ) {
+				indexes.push( index );
+			}
+		}
+
+		indexes.forEach( ( index ) => {
+			this.collectLiteralImageNames( value[ index ] ).forEach(
+				( imageId ) => {
+					names.add( imageId );
+				}
+			);
+		} );
+
+		return names;
+	}
+
+	collectLayerImageNames( layer ) {
+		const names = new Set();
+		const layout = layer?.layout || {};
+		const paint = layer?.paint || {};
+
+		if ( layout[ 'icon-image' ] !== undefined ) {
+			this.collectLiteralImageNames( layout[ 'icon-image' ] ).forEach(
+				( imageId ) => {
+					names.add( imageId );
+				}
+			);
+		}
+
+		[ layout, paint ].forEach( ( section ) => {
+			Object.entries( section ).forEach( ( [ key, value ] ) => {
+				if ( key.endsWith( '-pattern' ) ) {
+					this.collectLiteralImageNames( value ).forEach(
+						( imageId ) => {
+							names.add( imageId );
+						}
+					);
+				}
+			} );
+		} );
+
+		return names;
+	}
+
+	loadImageElement( url ) {
+		return new Promise( ( resolve, reject ) => {
+			const image = new Image();
+			image.crossOrigin = 'anonymous';
+			image.onload = () => resolve( image );
+			image.onerror = reject;
+			image.src = url;
+		} );
+	}
+
+	loadSpriteAtlas( spriteRoot ) {
+		if ( ! spriteRoot ) {
+			return Promise.resolve( null );
+		}
+
+		if ( this.spriteAtlasRequests.has( spriteRoot ) ) {
+			return this.spriteAtlasRequests.get( spriteRoot );
+		}
+
+		const ratio = window.devicePixelRatio >= 1.5 ? 2 : 1;
+		const load = async ( requestedRatio ) => {
+			const suffix = requestedRatio === 2 ? '@2x' : '';
+			const [ metadata, image ] = await Promise.all( [
+				this.fetchJson( `${ spriteRoot }${ suffix }.json` ),
+				this.loadImageElement( `${ spriteRoot }${ suffix }.png` ),
+			] );
+
+			return {
+				metadata,
+				image,
+				ratio: requestedRatio,
+				added: new Set(),
+			};
+		};
+
+		const request = load( ratio )
+			.catch( () => ( ratio === 2 ? load( 1 ) : null ) )
+			.then( ( atlas ) => {
+				if ( atlas ) {
+					this.spriteAtlases.set( spriteRoot, atlas );
+				}
+
+				return atlas;
+			} )
+			.catch( ( error ) => {
+				this.spriteAtlasRequests.delete( spriteRoot );
+				throw error;
+			} );
+
+		this.spriteAtlasRequests.set( spriteRoot, request );
+		return request;
+	}
+
+	addImageFromAtlas( atlas, imageId ) {
+		const map = this.props.map;
+		const item = atlas?.metadata?.[ imageId ];
+
+		if ( ! item || ! map || map.hasImage( imageId ) ) {
+			return false;
+		}
+
+		const width = Number.parseInt( item.width, 10 );
+		const height = Number.parseInt( item.height, 10 );
+		const x = Number.parseInt( item.x, 10 );
+		const y = Number.parseInt( item.y, 10 );
+
+		if ( ! width || ! height ) {
+			return false;
+		}
+
+		const canvas = document.createElement( 'canvas' );
+		canvas.width = width;
+		canvas.height = height;
+		const context = canvas.getContext( '2d' );
+		context.drawImage(
+			atlas.image,
+			x,
+			y,
+			width,
+			height,
+			0,
+			0,
+			width,
+			height
+		);
+		const imageData = context.getImageData( 0, 0, width, height );
+		const options = {
+			pixelRatio: item.pixelRatio || atlas.ratio || 1,
+			sdf: Boolean( item.sdf ),
+		};
+
+		if ( Array.isArray( item.content ) ) {
+			options.content = item.content;
+		}
+		if ( Array.isArray( item.stretchX ) ) {
+			options.stretchX = item.stretchX;
+		}
+		if ( Array.isArray( item.stretchY ) ) {
+			options.stretchY = item.stretchY;
+		}
+
+		map.addImage( imageId, imageData, options );
+		atlas.added.add( imageId );
+		return true;
+	}
+
+	registerStyleImageMissingHandler() {
+		const map = this.props.map;
+
+		if ( ! map || this.styleImageMissingHandlerRegistered ) {
+			return;
+		}
+
+		this.styleImageMissingHandlerRegistered = true;
+		map.on( 'styleimagemissing', ( event ) => {
+			const imageId = event?.id;
+			if ( typeof imageId !== 'string' || map.hasImage( imageId ) ) {
+				return;
+			}
+
+			for ( const atlas of this.spriteAtlases.values() ) {
+				if ( this.addImageFromAtlas( atlas, imageId ) ) {
+					map.triggerRepaint?.();
+					return;
+				}
+			}
+		} );
+	}
+
+	async preloadStyleImages( spriteRoot, imageIds ) {
+		if ( ! spriteRoot || ! imageIds.size ) {
+			return;
+		}
+
+		const atlas = await this.loadSpriteAtlas( spriteRoot );
+		if ( ! atlas ) {
+			return;
+		}
+
+		imageIds.forEach( ( imageId ) => {
+			this.addImageFromAtlas( atlas, imageId );
+		} );
+	}
+
+	ensureMapGlyphs( glyphs ) {
+		const map = this.props.map;
+		if ( ! map ) {
+			return;
+		}
+
+		if ( map.getStyle?.()?.glyphs ) {
+			return;
+		}
+
+		if ( map.style?.stylesheet ) {
+			map.style.stylesheet.glyphs = glyphs || DEFAULT_GLYPHS;
+		}
+	}
+
+	getComposedLayerDefinition( style, layerId ) {
+		return ( style?.layers || [] ).find( ( item ) => item?.id === layerId );
+	}
+
+	getComposedLayerSourceIds( style, compositeLayers ) {
+		const sourceIds = new Set();
+
+		compositeLayers.forEach( ( compositeLayer ) => {
+			const layerDefinition = this.getComposedLayerDefinition(
+				style,
+				compositeLayer.compositeId
+			);
+
+			if ( layerDefinition?.source ) {
+				sourceIds.add( layerDefinition.source );
+			}
+		} );
+
+		return sourceIds;
+	}
+
+	addComposedSources( style, sourceIds ) {
+		const map = this.props.map;
+		const sources = style?.sources || {};
+
+		sourceIds.forEach( ( sourceId ) => {
+			if ( map.getSource( sourceId ) || ! sources[ sourceId ] ) {
+				return;
+			}
+
+			map.addSource( sourceId, this.cloneJson( sources[ sourceId ] ) );
+		} );
+	}
+
+	getBeforeLayerId() {
+		return this.props.map.getLayer( 'unclustered-points' )
+			? 'unclustered-points'
+			: undefined;
+	}
+
+	moveLayerGroup( layerIds ) {
+		const map = this.props.map;
+		const beforeId = this.getBeforeLayerId();
+
+		layerIds.forEach( ( layerId ) => {
+			if ( ! map.getLayer( layerId ) ) {
+				return;
+			}
+
+			if ( beforeId ) {
+				map.moveLayer( layerId, beforeId );
+			} else {
+				map.moveLayer( layerId );
+			}
+		} );
+	}
+
+	cleanupUnusedSources( sourceIds ) {
+		const map = this.props.map;
+		const style = map.getStyle?.();
+		const usedSources = new Set(
+			( style?.layers || [] )
+				.map( ( layer ) => layer.source )
+				.filter( Boolean )
+		);
+
+		sourceIds.forEach( ( sourceId ) => {
+			if ( ! usedSources.has( sourceId ) && map.getSource( sourceId ) ) {
+				map.removeSource( sourceId );
+			}
+		} );
+	}
+
+	getStoryInteractionLayerIds() {
+		const map = this.props.map;
+
+		if ( ! map?.getLayer ) {
+			return [];
+		}
+
+		return STORY_INTERACTION_LAYER_IDS.filter( ( layerId ) =>
+			map.getLayer( layerId )
+		);
+	}
+
+	hasStoryFeatureAtPoint( point ) {
+		const map = this.props.map;
+		const storyLayerIds = this.getStoryInteractionLayerIds();
+
+		if ( ! point || ! storyLayerIds.length || ! map?.queryRenderedFeatures ) {
+			return false;
+		}
+
+		try {
+			return (
+				map.queryRenderedFeatures( point, {
+					layers: storyLayerIds,
+				} ).length > 0
+			);
+		} catch ( error ) {
+			return false;
+		}
+	}
+
+	addComposedLayerInteractions( manifestLayer, compositeLayerIds ) {
+		return addComposedInteractions(
+			this.props.map,
+			[ manifestLayer ],
+			{
+				shouldIgnoreEvent: ( event ) =>
+					this.hasStoryFeatureAtPoint( event?.point ),
+				visibleLayerIds: compositeLayerIds,
+			}
+		);
+	}
+
+	removeComposedMapboxLayer( layer ) {
+		const state = this.composedLayerState.get( String( layer.id ) );
+		const map = this.props.map;
+
+		if ( ! state ) {
+			return;
+		}
+
+		( state.interactionCleanups || [] ).forEach( ( cleanup ) => {
+			cleanup();
+		} );
+
+		[ ...state.compositeLayerIds ].reverse().forEach( ( layerId ) => {
+			if ( map.getLayer( layerId ) ) {
+				map.removeLayer( layerId );
+			}
+		} );
+
+		this.cleanupUnusedSources( state.sourceIds );
+		this.composedLayerState.delete( String( layer.id ) );
+	}
+
+	async addComposedMapboxLayer( layer ) {
+		const map = this.props.map;
+		const mapId = layer?.map?.id;
+		const layerId = String( layer.id );
+
+		if ( this.composedLayerState.has( layerId ) ) {
+			this.moveLayerGroup(
+				this.composedLayerState.get( layerId ).compositeLayerIds
+			);
+			return;
+		}
+
+		if ( ! mapId ) {
+			console.warn(
+				'Skipping Mapbox layer in Discovery because its source map is unknown.',
+				layer
+			);
+			return;
+		}
+
+		this.props.registerLayerCustomToken?.( layer );
+		this.registerStyleImageMissingHandler();
+
+		try {
+			const { style, manifest } = await this.fetchComposedMap( mapId );
+			const manifestLayer = ( manifest?.layers || [] ).find(
+				( item ) =>
+					Number.parseInt( item.layerPostId, 10 ) ===
+					Number.parseInt( layer.id, 10 )
+			);
+
+			if ( ! manifestLayer || manifestLayer.directLayer ) {
+				console.warn(
+					'Skipping Mapbox layer in Discovery because the composed manifest does not contain it.',
+					layer
+				);
+				return;
+			}
+
+			const compositeLayers = (
+				manifestLayer.compositeLayers || []
+			).filter(
+				( compositeLayer ) =>
+					compositeLayer.visibleWhenLayerOn !== false
+			);
+			const sourceIds = this.getComposedLayerSourceIds(
+				style,
+				compositeLayers
+			);
+			const imageIds = new Set();
+			const layerDefinitions = [];
+
+			compositeLayers.forEach( ( compositeLayer ) => {
+				const layerDefinition = this.getComposedLayerDefinition(
+					style,
+					compositeLayer.compositeId
+				);
+
+				if ( ! layerDefinition ) {
+					return;
+				}
+
+				const nextLayer = this.cloneJson( layerDefinition );
+				nextLayer.layout = {
+					...( nextLayer.layout || {} ),
+					visibility: 'visible',
+				};
+
+				this.collectLayerImageNames( nextLayer ).forEach(
+					( imageId ) => {
+						imageIds.add( imageId );
+					}
+				);
+				layerDefinitions.push( nextLayer );
+			} );
+
+			this.ensureMapGlyphs( style.glyphs );
+			this.addComposedSources( style, sourceIds );
+			await this.preloadStyleImages( style.sprite, imageIds );
+
+			const beforeId = this.getBeforeLayerId();
+			const compositeLayerIds = [];
+
+			layerDefinitions.forEach( ( layerDefinition ) => {
+				if ( ! map.getLayer( layerDefinition.id ) ) {
+					map.addLayer( layerDefinition, beforeId );
+					}
+					compositeLayerIds.push( layerDefinition.id );
+				} );
+
+				const interactionCleanups = this.addComposedLayerInteractions(
+					manifestLayer,
+					compositeLayerIds
+				);
+
+				this.composedLayerState.set( layerId, {
+					mapId,
+					compositeLayerIds,
+					sourceIds,
+					interactionCleanups,
+				} );
+				this.moveLayerGroup( compositeLayerIds );
+			} catch ( error ) {
+			console.warn(
+				'Unable to load composed Mapbox layer in Discovery.',
+				error,
+				layer
+			);
 		}
 	}
 
@@ -353,7 +1063,8 @@ class MapLayers extends Component {
 	}
 
 	toggleLayersBatch( layers ) {
-		const { selectedLayers, layersQueue } = this.buildSelectionState( layers );
+		const { selectedLayers, layersQueue } =
+			this.buildSelectionState( layers );
 
 		this.props.updateState( {
 			selectedLayers,
@@ -361,11 +1072,13 @@ class MapLayers extends Component {
 		} );
 	}
 
-	applyLayersChanges(
+	async applyLayersChanges(
 		batch = this.props.layersQueue,
 		selectedLayers = this.props.selectedLayers,
 		appliedLayers = this.props.appliedLayers
 	) {
+		const sequence = ++this.applyLayersSequence;
+
 		if ( batch?.preventDefault ) {
 			batch.preventDefault();
 			batch = this.props.layersQueue;
@@ -378,12 +1091,17 @@ class MapLayers extends Component {
 		}
 
 		const map = this.props.map;
-		let nextAppliedLayers = appliedLayers;
+		const batchIds = batch.map( ( layerId ) => String( layerId ) );
 
-		nextAppliedLayers.forEach( ( layer ) => {
+		appliedLayers.forEach( ( layer ) => {
 			const layerId = String( layer.id );
 			// If layer is not requested
-			if ( ! batch.includes( layer.id ) ) {
+			if ( ! batchIds.includes( layerId ) ) {
+				if ( layer.meta.type === 'mapbox' ) {
+					this.removeComposedMapboxLayer( layer );
+					return;
+				}
+
 				if ( map.getLayer( layerId ) ) {
 					map.removeLayer( layerId );
 				}
@@ -391,12 +1109,15 @@ class MapLayers extends Component {
 		} );
 
 		const reverseBatch = [ ...batch ].reverse();
-		reverseBatch.forEach( ( layerID ) => {
+		for ( const layerID of reverseBatch ) {
 			const layerId = String( layerID );
 			const layer = selectedLayers[ layerId ];
+			if ( ! layer ) {
+				continue;
+			}
 			const attributes = layer.meta;
 
-				if ( layer.meta.type === 'tilelayer' ) {
+			if ( layer.meta.type === 'tilelayer' ) {
 				if ( ! map.getSource( layerId ) ) {
 					map.addSource( layerId, {
 						type: 'raster',
@@ -420,31 +1141,9 @@ class MapLayers extends Component {
 					map.moveLayer( layerId, 'unclustered-points' );
 				}
 			} else if ( layer.meta.type === 'mapbox' ) {
-				if ( map.getLayer( layerId ) === undefined ) {
-					if ( ! map.getSource( layerId ) ) {
-						const accessToken = attributes.layer_type_options.access_token || mapboxToken;
-
-						const styleId = attributes.layer_type_options.style_id?.replace( 'mapbox://styles/', '' );
-
-						map.addSource( layerId, {
-							type: 'raster',
-							tiles: [
-								`https://api.mapbox.com/styles/v1/${ styleId }/tiles/512/{z}/{x}/{y}@2x?access_token=${ accessToken }`,
-							],
-						} );
-					}
-
-					const newLayer = {
-						id: layerId,
-						source: layerId,
-						type: 'raster',
-					};
-
-					map.addLayer( newLayer );
-				}
-
-				if ( map.getLayer( 'unclustered-points' ) ) {
-					map.moveLayer( layerId, 'unclustered-points' );
+				await this.addComposedMapboxLayer( layer );
+				if ( sequence !== this.applyLayersSequence ) {
+					return;
 				}
 			} else if ( layer.meta.type === 'mvt' ) {
 				if ( map.getLayer( layerId ) === undefined ) {
@@ -459,7 +1158,8 @@ class MapLayers extends Component {
 						id: layerId,
 						type: attributes.layer_type_options.type,
 						source: layerId,
-						'source-layer': attributes.layer_type_options.source_layer,
+						'source-layer':
+							attributes.layer_type_options.source_layer,
 					};
 
 					map.addLayer( newLayer );
@@ -469,11 +1169,15 @@ class MapLayers extends Component {
 					map.moveLayer( layerId, 'unclustered-points' );
 				}
 			} else if ( layer.meta.type === 'mapbox-tileset-vector' ) {
+				this.props.registerLayerCustomToken?.( layer );
 				if ( map.getLayer( layerId ) === undefined ) {
 					if ( ! map.getSource( layerId ) ) {
 						map.addSource( layerId, {
-							type: attributes.layer_type_options.style_source_type,
-							url: 'mapbox://' + attributes.layer_type_options.tileset_id,
+							type: attributes.layer_type_options
+								.style_source_type,
+							url:
+								'mapbox://' +
+								attributes.layer_type_options.tileset_id,
 						} );
 					}
 
@@ -481,7 +1185,8 @@ class MapLayers extends Component {
 						id: layerId,
 						type: attributes.layer_type_options.type,
 						source: layerId,
-						'source-layer': attributes.layer_type_options.source_layer,
+						'source-layer':
+							attributes.layer_type_options.source_layer,
 					};
 
 					map.addLayer( newLayer );
@@ -491,11 +1196,15 @@ class MapLayers extends Component {
 					map.moveLayer( layerId, 'unclustered-points' );
 				}
 			} else if ( layer.meta.type === 'mapbox-tileset-raster' ) {
+				this.props.registerLayerCustomToken?.( layer );
 				if ( map.getLayer( layerId ) === undefined ) {
 					if ( ! map.getSource( layerId ) ) {
 						map.addSource( layerId, {
-							type: attributes.layer_type_options.style_source_type,
-							url: 'mapbox://' + attributes.layer_type_options.tileset_id,
+							type: attributes.layer_type_options
+								.style_source_type,
+							url:
+								'mapbox://' +
+								attributes.layer_type_options.tileset_id,
 						} );
 					}
 
@@ -512,11 +1221,15 @@ class MapLayers extends Component {
 					map.moveLayer( layerId, 'unclustered-points' );
 				}
 			}
-		} );
+		}
 
-		nextAppliedLayers = batch.map( ( layerId ) => {
-			return selectedLayers[ layerId ];
-		} );
+		if ( sequence !== this.applyLayersSequence ) {
+			return;
+		}
+
+		const nextAppliedLayers = batch
+			.map( ( layerId ) => selectedLayers[ String( layerId ) ] )
+			.filter( Boolean );
 
 		this.props.updateState( {
 			appliedLayers: nextAppliedLayers,
@@ -554,17 +1267,19 @@ class MapLayers extends Component {
 
 		const mapItens = this.props.maps.map( ( map, index ) => {
 			return (
-					<MapItem
-						map={ map }
-						key={ index }
-						toggleLayer={ this.toggleLayer }
-						selectedLayers={ this.props.selectedLayers }
-						toggleLayersBatch={ this.toggleLayersBatch }
-						loadMapLayers={ this.loadMapLayers }
-						loadingMapLayers={ Boolean( this.state.loadingMapLayerIds[ map.id ] ) }
-					/>
-				);
-			} );
+				<MapItem
+					map={ map }
+					key={ index }
+					toggleLayer={ this.toggleLayer }
+					selectedLayers={ this.props.selectedLayers }
+					toggleLayersBatch={ this.toggleLayersBatch }
+					loadMapLayers={ this.loadMapLayers }
+					loadingMapLayers={ Boolean(
+						this.state.loadingMapLayerIds[ map.id ]
+					) }
+				/>
+			);
+		} );
 
 		const selectedLayersRender = (
 			<List
@@ -594,7 +1309,9 @@ class MapLayers extends Component {
 					return (
 						<div
 							{ ...props }
-							className={ 'layer-item' + ( isDragged ? ' dragged' : '' ) }
+							className={
+								'layer-item' + ( isDragged ? ' dragged' : '' )
+							}
 						>
 							<svg
 								aria-hidden="true"
@@ -609,7 +1326,9 @@ class MapLayers extends Component {
 							</svg>
 							<div className="layer-item--content">
 								<div className="layer-item--map">
-									{ decodeEntities( layer.map.title.rendered ) }
+									{ decodeEntities(
+										layer.map.title.rendered
+									) }
 								</div>
 								<div className="layer-item--layer">
 									{ decodeEntities( layer.title.rendered ) }
@@ -700,7 +1419,9 @@ class MapLayers extends Component {
 						</div>
 
 						<div className="status-message">
-							{ isApplied ? __( 'Changes applied', 'jeowp' ) : __( 'Not applied', 'jeowp' ) }
+							{ isApplied
+								? __( 'Changes applied', 'jeowp' )
+								: __( 'Not applied', 'jeowp' ) }
 						</div>
 					</div>
 

--- a/src/js/src/discovery/blocks/sidebar.js
+++ b/src/js/src/discovery/blocks/sidebar.js
@@ -14,7 +14,8 @@ class Sidebar extends Component {
 		this.lastStoriesScrollTop = 0;
 		this.lastMapLayersScrollTop = 0;
 		this.pendingStoriesPage = null;
-		this.ensureStoriesFillScroll = this.ensureStoriesFillScroll.bind( this );
+		this.ensureStoriesFillScroll =
+			this.ensureStoriesFillScroll.bind( this );
 		this.ensureMapsFillScroll = this.ensureMapsFillScroll.bind( this );
 		this.handleScroll = this.handleScroll.bind( this );
 		this.queueNextStoriesPage = this.queueNextStoriesPage.bind( this );
@@ -68,6 +69,7 @@ class Sidebar extends Component {
 			applyLayersChanges: this.props.applyLayersChanges,
 			layersQueue: this.props.layersQueue,
 			appliedLayers: this.props.appliedLayers,
+			registerLayerCustomToken: this.props.registerLayerCustomToken,
 
 			isEmbed: this.props.isEmbed,
 		};
@@ -83,15 +85,29 @@ class Sidebar extends Component {
 			);
 		} else {
 			if ( tab.name === 'stories' ) {
-				tabRenderer = 	(<>
-									<Stories { ...storiesProps }  />
-									<MapLayers { ...mapLayersProps } ref={ this.mapLayersRef } style={ { display: "none" } } />
-								</>);
+				tabRenderer = (
+					<>
+						<Stories { ...storiesProps } />
+						<MapLayers
+							{ ...mapLayersProps }
+							ref={ this.mapLayersRef }
+							style={ { display: 'none' } }
+						/>
+					</>
+				);
 			} else {
-				tabRenderer = 	(<>
-									<Stories { ...storiesProps }  style={ { display: "none" } }  />
-									<MapLayers { ...mapLayersProps } ref={ this.mapLayersRef } />
-								</>);
+				tabRenderer = (
+					<>
+						<Stories
+							{ ...storiesProps }
+							style={ { display: 'none' } }
+						/>
+						<MapLayers
+							{ ...mapLayersProps }
+							ref={ this.mapLayersRef }
+						/>
+					</>
+				);
 			}
 		}
 
@@ -99,7 +115,9 @@ class Sidebar extends Component {
 	}
 
 	getStoriesScrollPanel() {
-		return this.sidebarRef.current?.querySelector?.( '.togable-panel' ) ?? null;
+		return (
+			this.sidebarRef.current?.querySelector?.( '.togable-panel' ) ?? null
+		);
 	}
 
 	getCanLoadMoreStories() {
@@ -110,7 +128,10 @@ class Sidebar extends Component {
 			return false;
 		}
 
-		const totalPages = Number.parseInt( this.props.pageInfo.totalPages, 10 );
+		const totalPages = Number.parseInt(
+			this.props.pageInfo.totalPages,
+			10
+		);
 		const currentPage =
 			Number.parseInt( this.props.pageInfo.currentPage, 10 ) || 1;
 
@@ -189,13 +210,15 @@ class Sidebar extends Component {
 
 			this.storiesRef.current?.markListScrolling?.();
 
-			const isScrollingDown = currentScrollTop > this.lastStoriesScrollTop;
+			const isScrollingDown =
+				currentScrollTop > this.lastStoriesScrollTop;
 			this.lastStoriesScrollTop = currentScrollTop;
 
 			if (
 				isScrollingDown &&
 				this.getCanLoadMoreStories() &&
-				( element.scrollHeight - element.scrollTop - 100 ) <= element.clientHeight &&
+				element.scrollHeight - element.scrollTop - 100 <=
+					element.clientHeight &&
 				this.storiesRef.current
 			) {
 				this.queueNextStoriesPage();
@@ -209,13 +232,15 @@ class Sidebar extends Component {
 				return;
 			}
 
-			const isScrollingDown = currentScrollTop > this.lastMapLayersScrollTop;
+			const isScrollingDown =
+				currentScrollTop > this.lastMapLayersScrollTop;
 			this.lastMapLayersScrollTop = currentScrollTop;
 
 			if (
 				isScrollingDown &&
 				this.getCanLoadMoreMaps() &&
-				( element.scrollHeight - element.scrollTop - 100 ) <= element.clientHeight
+				element.scrollHeight - element.scrollTop - 100 <=
+					element.clientHeight
 			) {
 				this.queueNextMapsPage();
 			}
@@ -247,7 +272,7 @@ class Sidebar extends Component {
 							) }
 						/>
 
-						<span>{ __('Stories', 'jeowp') }</span>
+						<span>{ __( 'Stories', 'jeowp' ) }</span>
 					</div>
 				),
 				className: 'stories-tab',
@@ -275,7 +300,7 @@ class Sidebar extends Component {
 							) }
 						/>
 
-						<span>{ __('Map layers', 'jeowp') }</span>
+						<span>{ __( 'Map layers', 'jeowp' ) }</span>
 					</div>
 				),
 				className: 'stories-tab',
@@ -286,9 +311,13 @@ class Sidebar extends Component {
 			<div
 				ref={ this.sidebarRef }
 				onScrollCapture={ this.handleScroll }
-				className={ this.props.isEmbed ? 'is-embed' : 'default-sidebar' }
+				className={
+					this.props.isEmbed ? 'is-embed' : 'default-sidebar'
+				}
 			>
-				<div className="discovery-title">{ __( 'Explore', 'jeowp' ) }</div>
+				<div className="discovery-title">
+					{ __( 'Explore', 'jeowp' ) }
+				</div>
 				<TabPanel
 					className="togable-panel"
 					activeClass="active-tab"
@@ -309,7 +338,9 @@ class Sidebar extends Component {
 							: __( 'Expand discovery panel', 'jeowp' )
 					}
 					onClick={ () => {
-						this.props.updateState( { showSidebar: ! this.props.showSidebar } );
+						this.props.updateState( {
+							showSidebar: ! this.props.showSidebar,
+						} );
 						window.setTimeout( () => {
 							this.props.map.resize();
 						}, 200 );

--- a/src/js/src/discovery/blocks/stories.js
+++ b/src/js/src/discovery/blocks/stories.js
@@ -96,7 +96,8 @@ function getHoveredClusterFeature( map, event ) {
 		return null;
 	}
 
-	const features = map.queryRenderedFeatures( event.point, {
+	const point = { x: event.point.x, y: event.point.y };
+	const features = map.queryRenderedFeatures( point, {
 		layers: clusterLayers,
 	} );
 

--- a/src/js/src/discovery/index.js
+++ b/src/js/src/discovery/index.js
@@ -268,11 +268,12 @@ class Discovery extends Component {
 			return defaultStyle;
 		}
 
+		const defaultGlyphs = window.jeoMapVars?.composedStyleDefaultGlyphs || '';
+		const glyphs = defaultStyle.glyphs || defaultGlyphs;
+
 		return {
 			...defaultStyle,
-			glyphs:
-				defaultStyle.glyphs ||
-				'mapbox://fonts/mapbox/{fontstack}/{range}.pbf',
+			...( glyphs ? { glyphs } : {} ),
 		};
 	}
 

--- a/src/js/src/discovery/index.js
+++ b/src/js/src/discovery/index.js
@@ -1,9 +1,10 @@
 import { Component, createRoot } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 import Sidebar from './blocks/sidebar';
 import { formatDateRangeValue } from './blocks/date-range-filter';
-import { createMap, mapgl } from '../lib/mapgl-loader';
+import { createMap, defaultStyle, mapgl, MAP_RUNTIME } from '../lib/mapgl-loader';
 import { computeInlineStart } from '../shared/direction';
 import './style/discovery.scss';
 
@@ -101,11 +102,14 @@ class Discovery extends Component {
 
 		// map can't be a state, trust me.
 		this.map = null;
-		this.attributionResizeObserver = null;
-		this.discoveryBlock = null;
+			this.attributionResizeObserver = null;
+			this.discoveryBlock = null;
+			this.customTokens = {};
+			this.moreInfoTemplate =
+				window.jeoMapVars?.templates?.moreInfo || null;
 
-		// general state
-		this.state = {
+			// general state
+			this.state = {
 			// component
 			embedUrl: '',
 			firstLoad: true,
@@ -117,11 +121,15 @@ class Discovery extends Component {
 			// toggles
 			showLegends: false,
 			showShareOptions: false,
-			showEmbedTooltip: false,
-			showSidebar: true,
+				showEmbedTooltip: false,
+				showSidebar: true,
+				showMoreInfo: false,
+				moreInfoLoading: false,
+				moreInfoError: null,
+				infoMapsById: {},
 
-			// maps
-			maps: [],
+				// maps
+				maps: [],
 			mapsLoaded: false,
 
 			// markers
@@ -150,7 +158,14 @@ class Discovery extends Component {
 		// methods bindings
 		this.updateState = this.updateState.bind( this );
 		this.syncViewportHeight = this.syncViewportHeight.bind( this );
-	}
+			this.registerLayerCustomToken =
+				this.registerLayerCustomToken.bind( this );
+			this.transformRequestUrl = this.transformRequestUrl.bind( this );
+			this.openMoreInfo = this.openMoreInfo.bind( this );
+			this.closeMoreInfo = this.closeMoreInfo.bind( this );
+			this.handleMoreInfoTitleKeyDown =
+				this.handleMoreInfoTitleKeyDown.bind( this );
+		}
 
 	componentDidMount() {
 		this.syncViewportHeight();
@@ -164,7 +179,10 @@ class Discovery extends Component {
 			zoom: mapDefaults.zoom,
 		};
 
-		if ( this.getParamFromUrl( 'discovery' ) || this.getParamFromUrl( 'share' ) ) {
+		if (
+			this.getParamFromUrl( 'discovery' ) ||
+			this.getParamFromUrl( 'share' )
+		) {
 			const urlCenter = this.getParamFromUrl( 'center' );
 			if ( urlCenter ) {
 				additionalMapOptions.center = urlCenter;
@@ -176,10 +194,12 @@ class Discovery extends Component {
 			}
 		}
 
-		const map = createMap({
+		const map = createMap( {
 			container: this.mapContainer,
+			style: this.getInitialMapStyle(),
+			transformRequest: this.transformRequestUrl,
 			...additionalMapOptions,
-		});
+		} );
 
 		this.map = map;
 		const inlineStart = computeInlineStart();
@@ -187,10 +207,13 @@ class Discovery extends Component {
 		this.map.on( 'load', () => {
 			this.map.addControl(
 				new mapgl.NavigationControl( { showCompass: false } ),
-				`top-${inlineStart}`
+				`top-${ inlineStart }`
 			);
 
-			this.map.addControl( new mapgl.FullscreenControl(), `top-${inlineStart}` );
+			this.map.addControl(
+				new mapgl.FullscreenControl(),
+				`top-${ inlineStart }`
+			);
 			this.syncAttributionSpacing();
 			this.syncViewportHeight();
 			this.setState( { ...this.state, mapLoaded: true } );
@@ -203,6 +226,23 @@ class Discovery extends Component {
 		} );
 	}
 
+	componentDidUpdate( prevProps, prevState ) {
+		const previousMapIds = this.getAppliedMoreInfoMapIds(
+			prevState.appliedLayers
+		);
+		const nextMapIds = this.getAppliedMoreInfoMapIds();
+
+		if ( previousMapIds.join( ',' ) === nextMapIds.join( ',' ) ) {
+			return;
+		}
+
+		if ( ! nextMapIds.length && this.state.showMoreInfo ) {
+			this.setState( { showMoreInfo: false } );
+		}
+
+		this.fetchMoreInfoMaps( nextMapIds );
+	}
+
 	componentWillUnmount() {
 		if ( this.attributionResizeObserver ) {
 			this.attributionResizeObserver.disconnect();
@@ -210,7 +250,10 @@ class Discovery extends Component {
 		}
 
 		window.removeEventListener( 'resize', this.syncViewportHeight );
-		window.removeEventListener( 'orientationchange', this.syncViewportHeight );
+		window.removeEventListener(
+			'orientationchange',
+			this.syncViewportHeight
+		);
 		window.removeEventListener( 'load', this.syncViewportHeight );
 	}
 
@@ -218,6 +261,71 @@ class Discovery extends Component {
 		const urlParams = new URLSearchParams( window.location.search );
 		const value = parseUrlStateParam( urlParams, paramKey );
 		return value ?? false;
+	}
+
+	getInitialMapStyle() {
+		if ( ! defaultStyle || typeof defaultStyle !== 'object' ) {
+			return defaultStyle;
+		}
+
+		return {
+			...defaultStyle,
+			glyphs:
+				defaultStyle.glyphs ||
+				'mapbox://fonts/mapbox/{fontstack}/{range}.pbf',
+		};
+	}
+
+	registerLayerCustomToken( layer ) {
+		const options = layer?.meta?.layer_type_options || {};
+		const accessToken = options.access_token;
+
+		if ( ! accessToken ) {
+			return;
+		}
+
+		const styleId = options.style_id?.replace( 'mapbox://styles/', '' );
+		const tilesetId = options.tileset_id?.replace( 'mapbox://', '' );
+		const owner =
+			styleId?.split( '/' )[ 0 ] || tilesetId?.split( '.' )[ 0 ];
+
+		if ( owner ) {
+			this.customTokens[ owner ] = accessToken;
+		}
+	}
+
+	transformRequestUrl( url, resourceType ) {
+		const tokenPlaceholder = '__JEO_MAPBOX_ACCESS_TOKEN__';
+		if ( url.includes( tokenPlaceholder ) ) {
+			url = url
+				.split( tokenPlaceholder )
+				.join( encodeURIComponent( jeo_settings.mapbox_key || '' ) );
+		}
+
+		for ( const owner of Object.keys( this.customTokens ) ) {
+			if (
+				! url.includes( `${ owner }/` ) &&
+				! url.includes( `${ owner }.` )
+			) {
+				continue;
+			}
+
+			try {
+				const parsedUrl = new URL( url );
+				const parsedParams = new URLSearchParams( parsedUrl.search );
+				const accessToken = this.customTokens[ owner ];
+
+				if ( parsedParams.get( 'access_token' ) !== accessToken ) {
+					parsedParams.set( 'access_token', accessToken );
+					parsedUrl.search = '?' + parsedParams.toString();
+					return { url: parsedUrl.toString() };
+				}
+			} catch ( error ) {
+				return { url };
+			}
+		}
+
+		return { url };
 	}
 
 	buildUrlParamsString(
@@ -250,7 +358,11 @@ class Discovery extends Component {
 	}
 
 	syncViewportHeight() {
-		if ( this.props.embed || ! this.discoveryBlock || typeof window === 'undefined' ) {
+		if (
+			this.props.embed ||
+			! this.discoveryBlock ||
+			typeof window === 'undefined'
+		) {
 			return;
 		}
 
@@ -275,8 +387,9 @@ class Discovery extends Component {
 		}
 	}
 
-	syncAttributionSpacing() {
-		const discoveryMapElement = this.mapContainer?.closest( '.discovery-map' );
+		syncAttributionSpacing() {
+			const discoveryMapElement =
+				this.mapContainer?.closest( '.discovery-map' );
 		if ( ! discoveryMapElement ) {
 			return;
 		}
@@ -306,15 +419,216 @@ class Discovery extends Component {
 			'.mapboxgl-ctrl-attrib, .maplibregl-ctrl-attrib'
 		);
 		if ( attributionControl && typeof ResizeObserver !== 'undefined' ) {
-			this.attributionResizeObserver = new ResizeObserver( updateSpacing );
+			this.attributionResizeObserver = new ResizeObserver(
+				updateSpacing
+			);
 			this.attributionResizeObserver.observe( attributionControl );
 		}
 
-		window.requestAnimationFrame( updateSpacing );
-	}
+			window.requestAnimationFrame( updateSpacing );
+		}
 
-	render() {
-		const props = {
+		hasMeaningfulHtml( html = '' ) {
+			if ( ! html ) {
+				return false;
+			}
+
+			if ( typeof document !== 'undefined' ) {
+				const wrapper = document.createElement( 'div' );
+				wrapper.innerHTML = html;
+
+				const textContent = ( wrapper.textContent || '' )
+					.replace( /\u00a0/g, ' ' )
+					.trim();
+
+				if ( textContent.length ) {
+					return true;
+				}
+
+				return Boolean(
+					wrapper.querySelector(
+						'img,video,audio,iframe,table,ul,ol,svg'
+					)
+				);
+			}
+
+			return String( html )
+				.replace( /<[^>]+>/g, '' )
+				.replace( /&nbsp;|&#160;/gi, ' ' )
+				.trim().length > 0;
+		}
+
+		hasMoreInfoContent( map ) {
+			return this.hasMeaningfulHtml( map?.content?.rendered );
+		}
+
+		getAppliedMoreInfoMapIds( appliedLayers = this.state.appliedLayers ) {
+			const mapIds = [];
+
+			appliedLayers.forEach( ( layer ) => {
+				const mapId = Number.parseInt( layer?.map?.id, 10 );
+				if ( Number.isFinite( mapId ) && ! mapIds.includes( mapId ) ) {
+					mapIds.push( mapId );
+				}
+			} );
+
+			return mapIds;
+		}
+
+		getMoreInfoMapById( mapId ) {
+			return (
+				this.state.infoMapsById[ mapId ] ||
+				this.state.appliedLayers.find(
+					( layer ) =>
+						Number.parseInt( layer?.map?.id, 10 ) === mapId
+				)?.map ||
+				null
+			);
+		}
+
+		fetchMoreInfoMaps( mapIds = this.getAppliedMoreInfoMapIds() ) {
+			const missingMapIds = mapIds.filter( ( mapId ) => {
+				const map = this.state.infoMapsById[ mapId ];
+				return map?.content?.rendered === undefined;
+			} );
+
+			if ( ! missingMapIds.length ) {
+				return Promise.resolve();
+			}
+
+			const path = addQueryArgs( jeoMapVars.jsonUrl + 'map/', {
+				include: missingMapIds,
+				orderby: 'include',
+				per_page: missingMapIds.length,
+				_fields: 'id,title,content,link',
+				...( 'jeowpLanguageParams' in window &&
+				window.jeowpLanguageParams?.currentLang
+					? { lang: window.jeowpLanguageParams.currentLang }
+					: {} ),
+			} );
+
+			this.setState( {
+				moreInfoLoading: true,
+				moreInfoError: null,
+			} );
+
+			return fetch( path, {
+				headers: jeoMapVars?.nonce
+					? {
+							'X-WP-Nonce': jeoMapVars.nonce,
+					  }
+					: {},
+			} )
+				.then( ( response ) => {
+					if ( ! response.ok ) {
+						throw new Error(
+							`${ response.status } ${ response.statusText }`
+						);
+					}
+
+					return response.json();
+				} )
+				.then( ( response ) => {
+					const maps = Array.isArray( response ) ? response : [];
+					const nextInfoMapsById = {};
+
+					maps.forEach( ( map ) => {
+						nextInfoMapsById[ map.id ] = map;
+					} );
+
+					this.setState( ( currentState ) => ( {
+						infoMapsById: {
+							...currentState.infoMapsById,
+							...nextInfoMapsById,
+						},
+						moreInfoLoading: false,
+					} ) );
+				} )
+				.catch( ( error ) => {
+					console.warn(
+						'Unable to load map information in Discovery.',
+						error
+					);
+					this.setState( {
+						moreInfoLoading: false,
+						moreInfoError: __(
+							'Unable to load map information right now.',
+							'jeowp'
+						),
+					} );
+				} );
+		}
+
+		getMoreInfoFallbackTitle( map ) {
+			if ( typeof map?.title?.rendered === 'string' ) {
+				return map.title.rendered;
+			}
+
+			if ( typeof map?.title === 'string' ) {
+				return map.title;
+			}
+
+			return __( 'Map information', 'jeowp' );
+		}
+
+		renderMoreInfoMapContent( map ) {
+			const title = map?.title?.rendered || '';
+			const content = map?.content?.rendered || '';
+
+			if ( this.moreInfoTemplate ) {
+				return this.moreInfoTemplate
+					.replace( /<%[~=]\s*map\.title\.rendered\s*%>/g, title )
+					.replace(
+						/<%[~=]\s*map\.content\.rendered\s*%>/g,
+						content
+					);
+			}
+
+			return `<h2>${ title }</h2>${ content }`;
+		}
+
+		renderMoreInfoContent( maps ) {
+			const sections = maps
+				.filter( ( map ) => this.hasMoreInfoContent( map ) )
+				.map( ( map ) => this.renderMoreInfoMapContent( map ) );
+
+			if ( this.state.moreInfoError ) {
+				sections.push( `<p>${ this.state.moreInfoError }</p>` );
+			}
+
+			return sections.join( '' );
+		}
+
+		openMoreInfo( e ) {
+			e?.preventDefault?.();
+			e?.stopPropagation?.();
+
+			const mapIds = this.getAppliedMoreInfoMapIds();
+
+			this.setState( {
+				showMoreInfo: true,
+				moreInfoError: null,
+			} );
+			this.fetchMoreInfoMaps( mapIds );
+		}
+
+		closeMoreInfo( e ) {
+			e?.preventDefault?.();
+			e?.stopPropagation?.();
+
+			this.setState( {
+				showMoreInfo: false,
+			} );
+		}
+
+		handleMoreInfoTitleKeyDown( e ) {
+			if ( e.key === 'Enter' || e.key === ' ' ) {
+				this.openMoreInfo( e );
+			}
+		}
+
+		render() {
+			const props = {
 			map: this.map,
 			stories: this.state.stories,
 			storiesLoaded: this.state.storiesLoaded,
@@ -338,6 +652,7 @@ class Discovery extends Component {
 			applyLayersChanges: this.applyLayersChanges,
 
 			updateState: this.updateState,
+			registerLayerCustomToken: this.registerLayerCustomToken,
 			pageInfo: {
 				currentPage: this.state.currentPage,
 				totalPages: this.state.totalPages,
@@ -361,21 +676,36 @@ class Discovery extends Component {
 				} );
 			} );
 
-		let renderedLegends = legends.map( ( legendObj ) => legendObj.render() );
-		renderedLegends = renderedLegends.map( ( legendRender, index ) => {
-			return (
+		let renderedLegends = legends.map( ( legendObj ) =>
+			legendObj.render()
+		);
+			renderedLegends = renderedLegends.map( ( legendRender, index ) => {
+				return (
 				<>
 					{ legends[ index ].attributes.legend_title && (
 						<div className="legend-single-title">
 							{ legends[ index ].attributes.legend_title }
 						</div>
 					) }
-					<span dangerouslySetInnerHTML={ { __html: legendRender.outerHTML } } />
-				</>
-			);
-		} );
+					<span
+						dangerouslySetInnerHTML={ {
+							__html: legendRender.outerHTML,
+						} }
+					/>
+					</>
+				);
+			} );
+			const moreInfoMapIds = this.getAppliedMoreInfoMapIds();
+			const moreInfoMaps = moreInfoMapIds
+				.map( ( mapId ) => this.getMoreInfoMapById( mapId ) )
+				.filter( ( map ) => this.hasMoreInfoContent( map ) );
+			const hasMoreInfo = moreInfoMaps.length > 0;
+			const moreInfoHtml = hasMoreInfo
+				? this.renderMoreInfoContent( moreInfoMaps )
+				: '';
+			const hasLegendPanel = renderedLegends.length || hasMoreInfo;
 
-		const buildURLParams = {
+			const buildURLParams = {
 			'selected-layers': this.state.appliedLayers.map( ( layer ) => {
 				if ( layer.map ) {
 					return [ layer.id, layer.map.id ];
@@ -402,7 +732,7 @@ class Discovery extends Component {
 		const generatedEmbedUrl = this.buildUrlParamsString( buildURLParams );
 		const notEncodedUrlEmbed = this.buildUrlParamsString(
 			buildURLParams,
-			false,
+			false
 		);
 
 		const notEncodedUrl = this.buildUrlParamsString(
@@ -437,7 +767,10 @@ class Discovery extends Component {
 				{ this.state.mapLoaded ? <Sidebar { ...props } /> : '' }
 
 				<div className="discovery-map">
-					<div className="discovery-map__container" ref={ ( el ) => ( this.mapContainer = el ) }>
+					<div
+						className="discovery-map__container"
+						ref={ ( el ) => ( this.mapContainer = el ) }
+					>
 						{ /* Map container should be empty */ }
 					</div>
 					{ ! this.props.embed && (
@@ -494,7 +827,11 @@ class Discovery extends Component {
 									<svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="weixin" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M385.2 167.6c6.4 0 12.6.3 18.8 1.1C387.4 90.3 303.3 32 207.7 32 100.5 32 13 104.8 13 197.4c0 53.4 29.3 97.5 77.9 131.6l-19.3 58.6 68-34.1c24.4 4.8 43.8 9.7 68.2 9.7 6.2 0 12.1-.3 18.3-.8-4-12.9-6.2-26.6-6.2-40.8-.1-84.9 72.9-154 165.3-154zm-104.5-52.9c14.5 0 24.2 9.7 24.2 24.4 0 14.5-9.7 24.2-24.2 24.2-14.8 0-29.3-9.7-29.3-24.2.1-14.7 14.6-24.4 29.3-24.4zm-136.4 48.6c-14.5 0-29.3-9.7-29.3-24.2 0-14.8 14.8-24.4 29.3-24.4 14.8 0 24.4 9.7 24.4 24.4 0 14.6-9.6 24.2-24.4 24.2zM563 319.4c0-77.9-77.9-141.3-165.4-141.3-92.7 0-165.4 63.4-165.4 141.3S305 460.7 397.6 460.7c19.3 0 38.9-5.1 58.6-9.9l53.4 29.3-14.8-48.6C534 402.1 563 363.2 563 319.4zm-219.1-24.5c-9.7 0-19.3-9.7-19.3-19.6 0-9.7 9.7-19.3 19.3-19.3 14.8 0 24.4 9.7 24.4 19.3 0 10-9.7 19.6-24.4 19.6zm107.1 0c-9.7 0-19.3-9.7-19.3-19.6 0-9.7 9.7-19.3 19.3-19.3 14.5 0 24.4 9.7 24.4 19.3.1 10-9.9 19.6-24.4 19.6z"></path></svg>
 								</a> */ }
 
-								<a href={ notEncodedUrl } target="_blank" rel="noreferrer">
+								<a
+									href={ notEncodedUrl }
+									target="_blank"
+									rel="noreferrer"
+								>
 									<svg
 										aria-hidden="true"
 										focusable="false"
@@ -512,7 +849,9 @@ class Discovery extends Component {
 								</a>
 
 								<a
-									href={ `mailto:?subject=${ encodeURIComponent( __( 'Explore', 'jeowp' ) ) }&body=${ encodedMailBody }` }
+									href={ `mailto:?subject=${ encodeURIComponent(
+										__( 'Explore', 'jeowp' )
+									) }&body=${ encodedMailBody }` }
 									target="_blank"
 									rel="noreferrer"
 								>
@@ -536,11 +875,16 @@ class Discovery extends Component {
 									onClick={ () =>
 										this.setState( {
 											...this.state,
-											showEmbedTooltip: ! this.state.showEmbedTooltip,
+											showEmbedTooltip:
+												! this.state.showEmbedTooltip,
 										} )
 									}
 								>
-									{ _x( 'Embed', 'discovery share action', 'jeowp' ) }
+									{ _x(
+										'Embed',
+										'discovery share action',
+										'jeowp'
+									) }
 								</button>
 
 								{ this.state.showEmbedTooltip && (
@@ -557,7 +901,8 @@ class Discovery extends Component {
 								onClick={ () =>
 									this.setState( {
 										...this.state,
-										showShareOptions: ! this.state.showShareOptions,
+										showShareOptions:
+											! this.state.showShareOptions,
 									} )
 								}
 							>
@@ -581,54 +926,118 @@ class Discovery extends Component {
 					) }
 				</div>
 
-				{ renderedLegends.length ? (
-					<div
-						className={
-							'legend-container' + ( this.state.showLegends ? ' active' : '' )
-						}
-					>
-						<div className="legends-title">
-							<div className="text-icon">
-								<i className="legend-icon"></i>
-								<span className="text">{ __( 'Legend', 'jeowp' ) }</span>
-							</div>
-							<i
-								onClick={ () =>
-									this.setState( {
-										...this.state,
-										showLegends: ! this.state.showLegends,
-									} )
-								}
-								className={
-									'arrow-icon' + ( this.state.showLegends ? ' active' : '' )
-								}
-							>
-								<svg
-									aria-hidden="true"
-									focusable="false"
-									data-prefix="fas"
-									data-icon="chevron-down"
-									role="img"
-									xmlns="http://www.w3.org/2000/svg"
-									viewBox="0 0 448 512"
+					{ hasLegendPanel ? (
+						<div
+							className={
+								'legend-container' +
+								( this.state.showLegends ? ' active' : '' ) +
+								( ! renderedLegends.length && hasMoreInfo
+									? ' has-more-info-only'
+									: '' )
+							}
+						>
+							{ renderedLegends.length ? (
+								<>
+									<div className="legends-title">
+										<div className="text-icon">
+											<i className="legend-icon"></i>
+											<span className="text">
+												{ __( 'Legend', 'jeowp' ) }
+											</span>
+										</div>
+										<i
+											onClick={ () =>
+												this.setState( {
+													...this.state,
+													showLegends:
+														! this.state.showLegends,
+												} )
+											}
+											className={
+												'arrow-icon' +
+												( this.state.showLegends
+													? ' active'
+													: '' )
+											}
+										>
+											<svg
+												aria-hidden="true"
+												focusable="false"
+												data-prefix="fas"
+												data-icon="chevron-down"
+												role="img"
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 448 512"
+											>
+												<path
+													fill="currentColor"
+													d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+												></path>
+											</svg>
+										</i>
+									</div>
+									<div className="hideable-content">
+										<div className="legends-wrapper">
+											{ renderedLegends }
+										</div>
+										{ hasMoreInfo ? (
+											<a
+												href="#more-info"
+												className="more-info-button"
+												onClick={ this.openMoreInfo }
+											>
+												{ __( 'Info', 'jeowp' ) }
+											</a>
+										) : (
+											''
+										) }
+									</div>
+								</>
+							) : (
+								<div
+									className="legends-title more-info-title"
+									role="button"
+									tabIndex="0"
+									onClick={ this.openMoreInfo }
+									onKeyDown={ this.handleMoreInfoTitleKeyDown }
 								>
-									<path
-										fill="currentColor"
-										d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-									></path>
-								</svg>
-							</i>
+									<div className="text-icon">
+										<i className="info-icon"></i>
+										<span className="text">
+											{ __( 'Info', 'jeowp' ) }
+										</span>
+									</div>
+								</div>
+							) }
 						</div>
-						<div className="hideable-content">
-							<div className="legends-wrapper">{ renderedLegends }</div>
+					) : (
+						''
+					) }
+					{ hasMoreInfo && this.state.showMoreInfo ? (
+						<div className="more-info-overlayer">
+							<div className="more-info-close">
+								<button
+									className={ `${ MAP_RUNTIME }-popup-close-button` }
+									type="button"
+									aria-label={ __( 'Close popup', 'jeowp' ) }
+									onClick={ this.closeMoreInfo }
+								>
+									<span>&times;</span>
+								</button>
+							</div>
+							<div
+								className="more-info-content"
+								dangerouslySetInnerHTML={ {
+									__html: moreInfoHtml,
+								} }
+							/>
 						</div>
-					</div>
-				) : (
-					''
-				) }
-			</div>
-		);
-	}
+					) : (
+						''
+					) }
+				</div>
+			);
+		}
 }
 
 if ( document.querySelector( '.discovery-embed' ) ) {

--- a/src/js/src/discovery/index.js
+++ b/src/js/src/discovery/index.js
@@ -102,14 +102,14 @@ class Discovery extends Component {
 
 		// map can't be a state, trust me.
 		this.map = null;
-			this.attributionResizeObserver = null;
-			this.discoveryBlock = null;
-			this.customTokens = {};
-			this.moreInfoTemplate =
-				window.jeoMapVars?.templates?.moreInfo || null;
+		this.attributionResizeObserver = null;
+		this.discoveryBlock = null;
+		this.customTokens = {};
+		this.moreInfoTemplate =
+			window.jeoMapVars?.templates?.moreInfo || null;
 
-			// general state
-			this.state = {
+		// general state
+		this.state = {
 			// component
 			embedUrl: '',
 			firstLoad: true,
@@ -158,14 +158,14 @@ class Discovery extends Component {
 		// methods bindings
 		this.updateState = this.updateState.bind( this );
 		this.syncViewportHeight = this.syncViewportHeight.bind( this );
-			this.registerLayerCustomToken =
-				this.registerLayerCustomToken.bind( this );
-			this.transformRequestUrl = this.transformRequestUrl.bind( this );
-			this.openMoreInfo = this.openMoreInfo.bind( this );
-			this.closeMoreInfo = this.closeMoreInfo.bind( this );
-			this.handleMoreInfoTitleKeyDown =
-				this.handleMoreInfoTitleKeyDown.bind( this );
-		}
+		this.registerLayerCustomToken =
+			this.registerLayerCustomToken.bind( this );
+		this.transformRequestUrl = this.transformRequestUrl.bind( this );
+		this.openMoreInfo = this.openMoreInfo.bind( this );
+		this.closeMoreInfo = this.closeMoreInfo.bind( this );
+		this.handleMoreInfoTitleKeyDown =
+			this.handleMoreInfoTitleKeyDown.bind( this );
+	}
 
 	componentDidMount() {
 		this.syncViewportHeight();

--- a/src/js/src/discovery/index.js
+++ b/src/js/src/discovery/index.js
@@ -121,15 +121,15 @@ class Discovery extends Component {
 			// toggles
 			showLegends: false,
 			showShareOptions: false,
-				showEmbedTooltip: false,
-				showSidebar: true,
-				showMoreInfo: false,
-				moreInfoLoading: false,
-				moreInfoError: null,
-				infoMapsById: {},
+			showEmbedTooltip: false,
+			showSidebar: true,
+			showMoreInfo: false,
+			moreInfoLoading: false,
+			moreInfoError: null,
+			infoMapsById: {},
 
-				// maps
-				maps: [],
+			// maps
+			maps: [],
 			mapsLoaded: false,
 
 			// markers

--- a/src/js/src/discovery/style/discovery.scss
+++ b/src/js/src/discovery/style/discovery.scss
@@ -1403,9 +1403,113 @@ $font: var(--jeo-font, inherit);
 		color: var(--jeo-primary-color);
 	}
 
-	.is-embed {
-		display: none;
-	}
+		.is-embed {
+			display: none;
+		}
+
+		div.more-info-overlayer {
+			box-sizing: border-box;
+			background-color: white;
+			position: absolute;
+			top: 10px;
+			inset-inline-start: 10px;
+			z-index: 10;
+			width: calc(100% - 250px);
+			height: calc(100% - 70px);
+			max-width: calc(100% - 20px);
+			max-height: calc(100% - 70px);
+			margin-top: 50px;
+			overflow-y: auto;
+			padding: 0 20px 20px;
+		}
+
+		&.active:not(.embed) {
+			div.more-info-overlayer {
+				inset-inline-start: calc(30% + 10px);
+				width: calc(70% - 250px);
+				max-width: calc(70% - 20px);
+			}
+		}
+
+		.more-info-overlayer {
+			font-family: $font;
+
+			.more-info-close {
+				position: absolute;
+				top: 10px;
+				inset-inline-end: 10px;
+				z-index: 11;
+				cursor: pointer;
+			}
+
+			:is(.mapboxgl-popup-close-button, .maplibregl-popup-close-button) {
+				border-radius: 0;
+				cursor: pointer;
+				width: 22px;
+				height: 22px;
+				display: block;
+				padding: 0;
+				font-size: 18px;
+				background: var(--jeo_close-bkg-color);
+				color: var(--jeo_close-color);
+
+				&:hover {
+					text-decoration: none;
+					background-color: var(--jeo_more-bkg-color-darker-15);
+				}
+
+				span {
+					font-size: 24px;
+					font-weight: 100;
+					line-height: 18px;
+				}
+			}
+
+			.more-info-content {
+				font-family: $font;
+				padding-top: 20px;
+
+				h2 {
+					font-family: $font;
+				}
+
+				p {
+					font-family: $font;
+				}
+			}
+
+			.map-content-layers-list {
+				font-size: 16px;
+				line-height: 25px;
+				font-family: $font;
+
+				a.download-source {
+					font-family: $font;
+					background: #fff;
+					border: 1px solid rgba(0, 0, 0, 0.4);
+					color: #404040;
+					margin-top: 8px;
+					padding: 4px 10px;
+					text-decoration: none;
+					border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+					text-align: center;
+					cursor: pointer;
+					display: inline-block;
+					font-size: 16px;
+					font-weight: bold;
+					transition: all 0.2s ease-in-out;
+
+					&:hover {
+						background: rgba(0, 0, 0, 0.05);
+						transition: all 0.2s ease-in-out;
+					}
+				}
+
+				h3 {
+					font-family: $font;
+				}
+			}
+		}
 
 		div.legend-container {
 			background: #fff;
@@ -1427,27 +1531,69 @@ $font: var(--jeo-font, inherit);
 
 			@extend .scroll-bar-style;
 
+			.legend-single-title {
+				margin-bottom: 15px;
+				font-size: 16px;
+				color: #333;
+				font-weight: bold;
+				display: block;
+				font-family: $font;
+			}
+
 			h4 {
 				margin: 15px 0;
 				font-size: 2.2rem;
 			}
 		}
 
-		.legends-title {
-			background: #191e23;
-			padding: 9px 20px;
-			color: white;
+			.legends-title {
+				background: #191e23;
+				padding: 9px 20px;
+				color: white;
 			font-size: 16px;
 			font-weight: 600;
 			display: flex;
 			justify-content: space-between;
-			align-items: center;
-		}
+				align-items: center;
+			}
 
-		i.arrow-icon {
-			width: 14px;
-			color: white;
-			cursor: pointer;
+			.more-info-title {
+				cursor: pointer;
+			}
+
+			.text-icon {
+				display: flex;
+				align-items: center;
+			}
+
+			.text-icon {
+				.legend-icon {
+					width: 14px;
+					height: 16px;
+					background-size: cover;
+					background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='list' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' class='svg-inline--fa fa-list fa-w-16 fa-3x'%3E%3Cpath fill='%23333' d='M80 368H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16v-64a16 16 0 0 0-16-16zm0-320H16A16 16 0 0 0 0 64v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16V64a16 16 0 0 0-16-16zm0 160H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16v-64a16 16 0 0 0-16-16zm416 176H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-320H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16zm0 160H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16z' class=''%3E%3C/path%3E%3C/svg%3E");
+					background-position: center;
+					cursor: pointer;
+					margin-inline-end: 12px;
+					filter: brightness(0) invert(1);
+				}
+
+				.info-icon {
+					width: 16px;
+					height: 16px;
+					background-size: cover;
+					background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23333' d='M11 10h2v7h-2zm0-3h2v2h-2z'/%3E%3Cpath fill='%23333' d='M12 2a10 10 0 100 20 10 10 0 000-20zm0 18a8 8 0 110-16 8 8 0 010 16z'/%3E%3C/svg%3E");
+					background-position: center;
+					cursor: pointer;
+					margin-inline-end: 12px;
+					filter: brightness(0) invert(1);
+				}
+			}
+
+			i.arrow-icon {
+				width: 14px;
+				color: white;
+				cursor: pointer;
 		}
 
 		i.arrow-icon.active {
@@ -1455,22 +1601,26 @@ $font: var(--jeo-font, inherit);
 		}
 
 		a.more-info-button {
-			background: white;
-			color: #555d66;
+			background: var(--jeo_more-bkg-color);
+			color: var(--jeo_more-color);
 			margin: 20px auto 20px auto;
-			border: 2px solid #555d66;
-			padding: 5px 10px;
+			padding: 3px;
+			border-radius: 5px;
 			text-decoration: none;
 			text-align: center;
 			cursor: pointer;
 			width: calc( 100% - 40px );
 			display: block;
-			font-size: 16px;
 			font-weight: bold;
+			font-family: $font;
+			font-size: 8px;
+			line-height: 20px;
 			transition: all 0.1s ease-in-out;
+			text-transform: uppercase;
 
 			&:hover {
-				color: #555d66;
+				background-color: var(--jeo_more-bkg-color-darker-15);
+				color: var(--jeo_more-color);
 				transition: all 0.1s ease-in-out;
 			}
 		}
@@ -1500,9 +1650,125 @@ $font: var(--jeo-font, inherit);
 			margin-bottom: 27px;
 		}
 	}
-}
 
-.layer-item {
+	:is(.mapboxgl-popup, .maplibregl-popup):not(:last-child) {
+		display: none;
+	}
+
+	:is(.mapboxgl-popup .mapboxgl-popup-content, .maplibregl-popup .maplibregl-popup-content) {
+		background-color: white;
+		border-radius: 5px;
+		box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+
+			h2 {
+				font-family: $font;
+			}
+		}
+
+		:is(.mapboxgl-popup, .maplibregl-popup):not(.jeo-popup__mouseover) {
+			:is(.mapboxgl-popup-content, .maplibregl-popup-content) {
+				h3 {
+					margin-top: 1.2rem;
+				}
+			}
+	}
+
+		:is(.mapboxgl-popup-content, .maplibregl-popup-content) {
+			h3,
+			p {
+			color: #111 !important;
+			font-size: 16px;
+			}
+
+			h3 {
+				font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
+				font-weight: 700;
+				line-height: 1.3;
+				margin: 0 0 0.45rem;
+		}
+
+		p {
+			font-family: $font;
+			line-height: 1.4;
+			margin: 0;
+		}
+
+		p + p {
+			margin-top: 0.35rem;
+		}
+
+			strong {
+				font-weight: 700;
+			}
+		}
+
+		:is(.mapboxgl-popup-close-button, .maplibregl-popup-close-button) {
+			position: absolute;
+			inset-inline-end: 6px;
+			top: 6px;
+			border-radius: 0;
+			cursor: pointer;
+			width: 22px;
+			height: 22px;
+			display: block;
+			padding: 0;
+			font-size: 18px;
+			background: var(--jeo_close-bkg-color);
+			color: var(--jeo_close-color);
+
+			&:hover {
+				text-decoration: none;
+				background-color: var(--jeo_more-bkg-color-darker-15);
+			}
+
+			span {
+				font-size: 24px;
+				font-weight: 100;
+				line-height: 18px;
+			}
+		}
+
+		:is(.mapboxgl-popup.mapboxgl-popup-anchor-bottom, .maplibregl-popup.maplibregl-popup-anchor-bottom) {
+			&:not(.jeo-popup__mouseover) {
+			margin-top: -28px;
+		}
+	}
+
+		:is(.mapboxgl-popup.mapboxgl-popup-anchor-top, .maplibregl-popup.maplibregl-popup-anchor-top) {
+			&:not(.jeo-popup__mouseover) {
+				margin-top: 28px;
+			}
+		}
+
+		.jeo-popup__mouseover {
+			font-size: 16px;
+			transform: none !important;
+			inset-inline-start: 5px;
+			inset-inline-end: auto;
+			top: 110px !important;
+			max-width: min(300px, calc(100vw - 24px));
+			padding: 5px;
+			pointer-events: none;
+
+			* {
+				font-size: 16px;
+			}
+
+			:is(.mapboxgl-popup-tip, .maplibregl-popup-tip) {
+				display: none !important;
+			}
+		}
+
+		.mapboxgl-popup.jeo-popup__mouseover {
+			top: 122px !important;
+		}
+
+		&:not(.embed) .jeo-popup__mouseover {
+			inset-inline-start: 52px;
+		}
+	}
+
+	.layer-item {
 	font-family: $font;
 	font-size: 14px;
 	z-index: 1;

--- a/src/js/src/jeo-map/class-jeo-map.js
+++ b/src/js/src/jeo-map/class-jeo-map.js
@@ -75,6 +75,7 @@ export default class JeoMap {
 		this.composedManifest = null;
 		this.usingComposedStyle = false;
 		this.composedStyleError = null;
+		this.composedInteractionCleanups = [];
 		this.initialized = false;
 		this.popup = null;
 		this.attributionResizeObserver = null;
@@ -226,7 +227,7 @@ export default class JeoMap {
 						// When style is done loading (don't try to add layers before style is ready)
 						this.mapLoaded.then( () => {
 							if ( usingComposedStyle ) {
-								addComposedInteractions( map, this.composedManifest );
+								this.addComposedInteractions( map );
 							} else {
 								this.addComposedStyleWarningMessage();
 								layers.forEach( ( layer ) => {
@@ -454,6 +455,29 @@ export default class JeoMap {
 		if ( this.composedStyleError ) {
 			console.warn( this.composedStyleError );
 		}
+	}
+
+	addComposedInteractions( map ) {
+		this.cleanupComposedInteractions();
+		this.composedInteractionCleanups = addComposedInteractions(
+			map,
+			this.composedManifest
+		);
+
+		if ( typeof map?.once === 'function' ) {
+			map.once( 'remove', () => this.cleanupComposedInteractions() );
+		}
+	}
+
+	cleanupComposedInteractions() {
+		this.composedInteractionCleanups.forEach( ( cleanup ) => {
+			try {
+				cleanup();
+			} catch ( error ) {
+				// Map layers may already be gone when the map runtime tears down.
+			}
+		} );
+		this.composedInteractionCleanups = [];
 	}
 
 	addMapWithoutLayersMessage() {

--- a/src/js/src/jeo-map/class-jeo-map.js
+++ b/src/js/src/jeo-map/class-jeo-map.js
@@ -2,6 +2,13 @@ import Spiderfy from '@nazka/map-gl-js-spiderfy';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
 import { createMap, getClusterLeaves, loadImage, mapgl, MAP_RUNTIME } from '../lib/mapgl-loader';
+import { loadComposedStyleData } from '../shared/composed-style-data';
+import {
+	addComposedInteractions,
+	getComposedLayerVisibility,
+	hasComposedStyle,
+	setComposedLayerVisibility,
+} from '../shared/composed-style-layers';
 import { computeInlineEnd, computeInlineStart } from '../shared/direction';
 import { onFirstIntersection } from '../shared/intersect';
 import { appendRestQueryParams } from '../shared/rest-query';
@@ -64,6 +71,10 @@ export default class JeoMap {
 		this.markers = [];
 		this.layers = [];
 		this.legends = [];
+		this.composedStyleMetadata = null;
+		this.composedManifest = null;
+		this.usingComposedStyle = false;
+		this.composedStyleError = null;
 		this.initialized = false;
 		this.popup = null;
 		this.attributionResizeObserver = null;
@@ -205,70 +216,27 @@ export default class JeoMap {
 						this.getArg( 'layers' ).length > 0 &&
 						amountLayers > 0
 					) {
-						const mapLayersSettings = this.getArg( 'layers' );
+						const usingComposedStyle = this.hasComposedStyle();
 
-						let firstStyleLayerId;
-						let styleLayerIndex;
-
-						layers.forEach( ( layer, index ) => {
-							const currentLayerSettings = mapLayersSettings.find(
-								( item ) => item.id === layer.attributes.layer_post_id
-							);
-
+						layers.forEach( ( layer ) => {
 							// Register custom accessTokens, if found, to request transformer
 							this.checkCustomToken( layer.attributes );
-
-							if ( currentLayerSettings.load_as_style ) {
-								layer.addStyle( map );
-								styleLayerIndex = index;
-							}
 						} );
 
 						// When style is done loading (don't try to add layers before style is ready)
-						this.mapLoaded.then(() => {
-							// Remove not selected layers and toggle visibility
-							mapLayersSettings.forEach( ( layer ) => {
-								if ( layer.load_as_style ) {
-									const styleLayers = layer.style_layers;
-
-									styleLayers.forEach( ( styleLayer ) => {
-										if ( ! styleLayer.show ) {
-											if ( map.getLayer( styleLayer.id ) ) {
-												map.removeLayer( styleLayer.id );
-											}
-										}
-
-										// In the future individual style layers will have their own toggles/swaps
-										if ( ! layer.default ) {
-											if ( map.getLayer( styleLayer.id ) ) {
-												map.setLayoutProperty(
-													styleLayer.id,
-													'visibility',
-													'none'
-												);
-											}
-										}
-									} );
-								}
-							} );
-
-							// Select reference pointers
-							firstStyleLayerId = map.style._order[ 0 ];
-
-							this.styleLoaded.then( () => {
-								layers.forEach( ( layer, index ) => {
-									if ( index === styleLayerIndex ) {
-										layer.addInteractions( map );
-									} else {
-										// If the current layer is below the style, add using first syle layer reference
-										if ( index < styleLayerIndex ) {
-											layer.addLayer( map, [ firstStyleLayerId ] );
-										} else {
-											layer.addLayer( map );
-										}
+						this.mapLoaded.then( () => {
+							if ( usingComposedStyle ) {
+								addComposedInteractions( map, this.composedManifest );
+							} else {
+								this.addComposedStyleWarningMessage();
+								layers.forEach( ( layer ) => {
+									if ( this.isMapboxStyleLayer( layer ) ) {
+										return;
 									}
+
+									layer.addLayer( map );
 								} );
-							} );
+							}
 
 							// Add attributions
 							const customAttribution = [];
@@ -322,7 +290,7 @@ export default class JeoMap {
 							map.on( 'resize', () => this.queueCompactAttributionCollapse() );
 
 							this.getRelatedPosts();
-						});
+						} );
 
 						this.addLayersControl( amountLayers );
 						this.addMoreButtonAndLegends();
@@ -369,11 +337,122 @@ export default class JeoMap {
 			this.map_post_object = data;
 
 			await this.getLayers();
+			await this.fetchComposedStyleData( data.id );
 		} else if ( this.getArg( 'layers' ) ) {
 			// One-time maps have no map_id but store layer settings
 			// in the data-layers attribute. We still need to fetch
-			// the full layer objects so getStyleLayer() can resolve.
+			// the full layer objects so direct layer types can render.
 			await this.getLayers();
+			await this.fetchOnetimeComposedStyleData();
+		}
+	}
+
+	async fetchComposedStyleData( mapId ) {
+		if (
+			! mapId ||
+			! window.jeoMapVars?.composedStyleUrlBase
+		) {
+			return;
+		}
+
+		await this.loadComposedStyleData(
+			() => loadComposedStyleData( {
+				mapId,
+				unavailableMessage: __(
+					'Mapbox style composition is unavailable for this map.',
+					'jeowp'
+				),
+				emptyManifestMessage: __(
+					'Mapbox style composition did not return renderable layers for this map.',
+					'jeowp'
+				),
+			} ),
+			__(
+				'Unable to load composed Mapbox style for this map.',
+				'jeowp'
+			),
+			'Unable to load composed Mapbox style. Mapbox style layers will be omitted.'
+		);
+	}
+
+	async fetchOnetimeComposedStyleData() {
+		if (
+			! window.jeoMapVars?.composedStyleComposeUrl ||
+			! this.layers.some( ( layer ) => this.isMapboxStyleLayer( layer ) )
+		) {
+			return;
+		}
+
+		await this.loadComposedStyleData(
+			() => loadComposedStyleData( {
+				payload: this.getOnetimeComposedStylePayload(),
+				unavailableMessage: __(
+					'Mapbox style composition is unavailable for this one-time map.',
+					'jeowp'
+				),
+				emptyManifestMessage: __(
+					'Mapbox style composition did not return renderable layers for this one-time map.',
+					'jeowp'
+				),
+			} ),
+			__(
+				'Unable to load composed Mapbox style for this one-time map.',
+				'jeowp'
+			),
+			'Unable to load composed Mapbox style for one-time map. Mapbox style layers will be omitted.'
+		);
+	}
+
+	async loadComposedStyleData( fetchData, fallbackErrorMessage, consoleMessage ) {
+		try {
+			const { manifest, metadata } = await fetchData();
+
+			this.composedStyleMetadata = metadata;
+			this.composedManifest = manifest;
+			this.usingComposedStyle = true;
+			this.composedStyleError = null;
+		} catch ( error ) {
+			this.composedStyleMetadata = null;
+			this.composedManifest = null;
+			this.usingComposedStyle = false;
+			this.composedStyleError = error?.message || fallbackErrorMessage;
+			console.warn( consoleMessage, error );
+		}
+	}
+
+	getOnetimeComposedStylePayload() {
+		return {
+			scope: 'onetime',
+			kind: 'onetime-map',
+			layers: this.layersDefinitions || this.getArg( 'layers' ) || [],
+			center_lat: this.getArg( 'center_lat' ) || null,
+			center_lon: this.getArg( 'center_lon' ) || null,
+			initial_zoom: this.getArg( 'initial_zoom' ) || null,
+		};
+	}
+
+	isMapboxStyleLayer( layer ) {
+		return layer?.attributes?.layer_type === 'mapbox';
+	}
+
+	addComposedStyleWarningMessage() {
+		if (
+			! this.layers.some( ( layer ) => this.isMapboxStyleLayer( layer ) ) ||
+			this.element.querySelector( '.jeomap-composed-style-warning' )
+		) {
+			return;
+		}
+
+		const warning = document.createElement( 'div' );
+		warning.className = 'jeomap-composed-style-warning';
+		warning.innerHTML = `<p class="jeomap-no-layers__text">${ __(
+			'Mapbox style layers could not be loaded because the composed style is unavailable.',
+			'jeowp'
+		) }</p>`;
+		this.element.appendChild( warning );
+
+		if ( this.composedStyleError ) {
+			console.warn( this.composedStyleError );
 		}
 	}
 
@@ -616,14 +695,115 @@ export default class JeoMap {
 	}
 
 	/**
-	 * Adds the "More" button that will open the Content of the Map post in an overlayer
-	 *
-	 * This will only work for maps stored in the database and not for one-time use maps
+	 * Adds the "More" button that opens map post content or layer source
+	 * information in an overlayer.
 	 */
+	hasMeaningfulHtml( html = '' ) {
+		if ( ! html ) {
+			return false;
+		}
+
+		if ( typeof document !== 'undefined' ) {
+			const wrapper = document.createElement( 'div' );
+			wrapper.innerHTML = html;
+
+			const textContent = ( wrapper.textContent || '' )
+				.replace( /\u00a0/g, ' ' )
+				.trim();
+
+			if ( textContent.length ) {
+				return true;
+			}
+
+			return Boolean(
+				wrapper.querySelector(
+					'img,video,audio,iframe,table,ul,ol,svg'
+				)
+			);
+		}
+
+		return String( html )
+			.replace( /<[^>]+>/g, '' )
+			.replace( /&nbsp;|&#160;/gi, ' ' )
+			.trim().length > 0;
+	}
+
+	getMoreInfoContent() {
+		if ( this.map_post_object ) {
+			if (
+				! this.hasMeaningfulHtml(
+					this.map_post_object?.content?.rendered
+				)
+			) {
+				return '';
+			}
+
+			return this.moreInfoTemplate( {
+				map: this.map_post_object,
+			} );
+		}
+
+		let innerHTML = '';
+
+		this.layers.forEach( ( layer ) => {
+			const layerInfo = [];
+			const attributionLink = normalizeOptionalUrl(
+				layer.attributes.attribution
+			);
+			const attributionName = layer.attributes.attribution_name;
+			const sourceLink = normalizeOptionalUrl( layer.source_url );
+
+			if ( attributionLink ) {
+				const attributionLabel = attributionName || attributionLink;
+				layerInfo.push(
+					`<p>${ __(
+						'Attribution:',
+						'jeowp'
+					) } <a href="${ attributionLink }">${ attributionLabel }</a></p>`
+				);
+			}
+
+			if ( sourceLink ) {
+				layerInfo.push(
+					`<a
+						style="font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
+						background: #fff;
+						border: 1px solid rgba(0,0,0,0.4);
+						color: #404040;
+						margin-top: 8px;
+						padding: 4px 10px;
+						text-decoration: none;
+						border-bottom: 1px solid rgba(0,0,0,0.25);
+						text-align: center;
+						cursor: pointer;
+						display: inline-block;
+						font-size: 16px;
+						font-weight: bold;
+						transition: all .2 ease-in-out;"
+						href="${ sourceLink }" class="download-source">${ __(
+							'Download from source',
+							'jeowp'
+						) }
+					</a>`
+				);
+			}
+
+			if ( layerInfo.length ) {
+				innerHTML += `<h3>${ layer.attributes.layer_name }</h3>${ layerInfo.join(
+					''
+				) }`;
+			}
+		} );
+
+		return innerHTML;
+	}
+
 	addMoreButtonAndLegends() {
 		const container = document.createElement( 'div' );
 		container.classList.add( 'legend-container' );
 		const startCollapsed = this.shouldStartControlsCollapsed();
+		const moreInfoHtml = this.getMoreInfoContent();
+		const hasMoreInfo = Boolean( moreInfoHtml.trim() );
 
 		const hideableContent = document.createElement( 'div' );
 		hideableContent.classList.add( 'hideable-content' );
@@ -715,6 +895,10 @@ export default class JeoMap {
 			} );
 		}
 
+		if ( ! hasAppearingLegends && ! hasMoreInfo ) {
+			return;
+		}
+
 		if ( ! hasAppearingLegends ) {
 			if ( startCollapsed ) {
 				container.classList.add( 'hidden' );
@@ -755,92 +939,48 @@ export default class JeoMap {
 			} );
 		}
 
-		const moreDiv = document.createElement( 'div' );
+		if ( hasMoreInfo ) {
+			const moreDiv = document.createElement( 'div' );
 
-		moreDiv.classList.add( 'more-info-overlayer' );
-		if ( this.map_post_object ) {
-			moreDiv.innerHTML = this.moreInfoTemplate( {
-				map: this.map_post_object,
-			} );
-		} else {
-			let innerHTML = '';
-			this.layers.forEach( ( layer ) => {
-				innerHTML += `<h3>${ layer.attributes.layer_name }</h1>`;
+			moreDiv.classList.add( 'more-info-overlayer' );
+			moreDiv.innerHTML = moreInfoHtml;
 
-				const attributionLink = normalizeOptionalUrl(
-					layer.attributes.attribution
-				);
-				const attributionName = layer.attributes.attribution_name;
-				const sourceLink = normalizeOptionalUrl( layer.source_url );
+			const closeButton = document.createElement( 'div' );
+			closeButton.classList.add( 'more-info-close' );
+			closeButton.innerHTML =
+				`<button class="${MAP_RUNTIME}-popup-close-button" type="button" aria-label="${ __(
+					'Close popup',
+					'jeowp'
+				) }"><span>×</span></button>`;
 
-				if ( attributionLink ) {
-					const attributionLabel = attributionName || attributionLink;
-					innerHTML += `<p>${ __(
-						'Attribution:',
-						'jeowp'
-					) } <a href="${ attributionLink }">${ attributionLabel }</a></p>`;
-				}
-				if ( sourceLink ) {
-					innerHTML += `<a
-									style="font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-									background: #fff;
-									border: 1px solid rgba(0,0,0,0.4);
-									color: #404040;
-									margin-top: 8px;
-									padding: 4px 10px;
-									text-decoration: none;
-									border-bottom: 1px solid rgba(0,0,0,0.25);
-									text-align: center;
-									cursor: pointer;
-									display: inline-block;
-									font-size: 16px;
-									font-weight: bold;
-									transition: all .2 ease-in-out;"
-									href="${ sourceLink }" class="download-source">${ __(
-										'Download from source',
-										'jeowp'
-									) }
-								  </a>`;
-				}
-			} );
-			moreDiv.innerHTML = innerHTML;
+			closeButton.click( function ( e ) {} );
+
+			closeButton.onclick = ( e ) => {
+				e.preventDefault();
+				e.stopPropagation();
+
+				jQuery( e.currentTarget ).parent().hide();
+			};
+
+			moreDiv.appendChild( closeButton );
+
+			const moreButton = document.createElement( 'a' );
+			moreButton.classList.add( 'more-info-button' );
+			moreButton.innerHTML = __( 'Info', 'jeowp' );
+
+			moreButton.onclick = ( e ) => {
+				e.preventDefault();
+				e.stopPropagation();
+				jQuery( e.currentTarget )
+					.parent()
+					.parent()
+					.siblings( '.more-info-overlayer' )
+					.show();
+			};
+
+			this.element.appendChild( moreDiv );
+			hideableContent.appendChild( moreButton );
 		}
-
-		const closeButton = document.createElement( 'div' );
-		closeButton.classList.add( 'more-info-close' );
-		closeButton.innerHTML =
-			`<button class="${MAP_RUNTIME}-popup-close-button" type="button" aria-label="${ __(
-				'Close popup',
-				'jeowp'
-			) }"><span>×</span></button>`;
-
-		closeButton.click( function ( e ) {} );
-
-		closeButton.onclick = ( e ) => {
-			e.preventDefault();
-			e.stopPropagation();
-
-			jQuery( e.currentTarget ).parent().hide();
-		};
-
-		moreDiv.appendChild( closeButton );
-
-		const moreButton = document.createElement( 'a' );
-		moreButton.classList.add( 'more-info-button' );
-		moreButton.innerHTML = __( 'Info', 'jeowp' );
-
-		moreButton.onclick = ( e ) => {
-			e.preventDefault();
-			e.stopPropagation();
-			jQuery( e.currentTarget )
-				.parent()
-				.parent()
-				.siblings( '.more-info-overlayer' )
-				.show();
-		};
-
-		this.element.appendChild( moreDiv );
-		hideableContent.appendChild( moreButton );
 
 		container.appendChild( hideableContent );
 		this.element.appendChild( container );
@@ -907,6 +1047,7 @@ export default class JeoMap {
 									new window.JeoLayer( layerObject.meta.type, {
 										layer_post_id: layerObject.id,
 										layer_id: layerObject.slug,
+										layer_type: layerObject.meta.type,
 										layer_name: layerObject.title.rendered,
 										attribution: layerObject.meta.attribution,
 										attribution_name: layerObject.meta.attribution_name,
@@ -942,23 +1083,14 @@ export default class JeoMap {
 		} );
 	}
 
+	hasComposedStyle() {
+		return this.usingComposedStyle &&
+			hasComposedStyle( this.composedStyleMetadata, this.composedManifest );
+	}
+
 	getStyleLayer() {
-		const mapLayersSettings = this.getArg( 'layers' );
-		const layers = this.layers;
-
-		for ( const layerSettings of mapLayersSettings ) {
-			if ( layerSettings.load_as_style ) {
-				const layer = layers.find(
-					( layer ) => layer.attributes.layer_post_id === layerSettings.id
-				);
-
-				if ( layer ) {
-					const styleUrl = layer.getStyleUrl();
-					if ( styleUrl ) {
-						return styleUrl;
-					}
-				}
-			}
+		if ( this.hasComposedStyle() ) {
+			return this.composedStyleMetadata.style;
 		}
 
 		return EMPTY_STYLE;
@@ -1086,8 +1218,11 @@ export default class JeoMap {
 						map.on( 'click', 'unclustered-points', () => {} );
 
 						map.on( 'click', 'unclustered-points-hitarea', ( e ) => {
+							const point = e.point
+								? { x: e.point.x, y: e.point.y }
+								: null;
 							const featuresAtPoint = e.point
-								? map.queryRenderedFeatures( e.point, {
+								? map.queryRenderedFeatures( point, {
 									layers: [ 'unclustered-points-hitarea' ],
 								} )
 								: e.features;
@@ -1913,7 +2048,13 @@ export default class JeoMap {
 
 					let visibility = false;
 
-					if ( layerSetting.load_as_style ) {
+					if ( this.hasComposedStyle() ) {
+						visibility = getComposedLayerVisibility(
+							this.map,
+							this.composedManifest,
+							clickedLayer
+						);
+					} else if ( layerSetting.load_as_style ) {
 						if (
 							layerSetting.style_layers &&
 							layerSetting.style_layers.length
@@ -1927,7 +2068,7 @@ export default class JeoMap {
 								}
 							} );
 						}
-					} else {
+					} else if ( this.map.getLayer( clickedLayer ) ) {
 						visibility = this.map.getLayoutProperty(
 							clickedLayer,
 							'visibility'
@@ -1994,6 +2135,16 @@ export default class JeoMap {
 	}
 
 	changeLayerVisibitly( layer_id, visibility ) {
+		if ( this.hasComposedStyle() ) {
+			setComposedLayerVisibility(
+				this.map,
+				this.composedManifest,
+				layer_id,
+				visibility
+			);
+			return;
+		}
+
 		const mapLayersSettings = this.getArg( 'layers' );
 		const layers = this.layers;
 
@@ -2019,7 +2170,9 @@ export default class JeoMap {
 								}
 							} );
 						} else {
-							this.map.setLayoutProperty( layer_id, 'visibility', visibility );
+							if ( this.map.getLayer( layer_id ) ) {
+								this.map.setLayoutProperty( layer_id, 'visibility', visibility );
+							}
 						}
 					}
 				} );
@@ -2059,6 +2212,13 @@ export default class JeoMap {
 	}
 
 	transformRequestUrl( url, resourceType ) {
+		const tokenPlaceholder = '__JEO_MAPBOX_ACCESS_TOKEN__';
+		if ( url.includes( tokenPlaceholder ) ) {
+			url = url.split( tokenPlaceholder ).join(
+				encodeURIComponent( jeo_settings.mapbox_key || '' )
+			);
+		}
+
 		for ( const user of Object.keys( this.customTokens ) ) {
 			if ( url.includes( `${user}/` ) || url.includes( `${user}.` ) ) {
 				const accessToken = this.customTokens[ user ];

--- a/src/js/src/jeo-map/class-jeo-map.js
+++ b/src/js/src/jeo-map/class-jeo-map.js
@@ -2214,7 +2214,8 @@ export default class JeoMap {
 	transformRequestUrl( url, resourceType ) {
 		const tokenPlaceholder = '__JEO_MAPBOX_ACCESS_TOKEN__';
 		if ( url.includes( tokenPlaceholder ) ) {
-			url = url.split( tokenPlaceholder ).join(
+			url = url.replaceAll(
+			    tokenPlaceholder,
 				encodeURIComponent( jeo_settings.mapbox_key || '' )
 			);
 		}

--- a/src/js/src/jeo-map/class-jeo-map.js
+++ b/src/js/src/jeo-map/class-jeo-map.js
@@ -2215,7 +2215,7 @@ export default class JeoMap {
 		const tokenPlaceholder = '__JEO_MAPBOX_ACCESS_TOKEN__';
 		if ( url.includes( tokenPlaceholder ) ) {
 			url = url.replaceAll(
-			    tokenPlaceholder,
+				tokenPlaceholder,
 				encodeURIComponent( jeo_settings.mapbox_key || '' )
 			);
 		}

--- a/src/js/src/jeo-storymap/storymap-display.js
+++ b/src/js/src/jeo-storymap/storymap-display.js
@@ -157,8 +157,9 @@ class StoryMapDisplay extends Component {
 		}
 
 		this.initialized = false;
+		this.composedInteractionCleanups = [];
 
-        this.state = {
+		this.state = {
 			currentChapter: config.chapters[0],
 			// map: null,
 			isNavigating: false,
@@ -167,8 +168,8 @@ class StoryMapDisplay extends Component {
 			hiddenLayersIds: [],
 			inSlides,
 			hasStartedStorymap: ! props.hasIntroduction,
-        };
-    }
+		};
+	}
 
 	componentDidMount() {
 		this.eagerInitStorymap();
@@ -179,6 +180,7 @@ class StoryMapDisplay extends Component {
 
 	componentWillUnmount() {
 		this.isIntroductionScrollLocked = false;
+		this.cleanupComposedInteractions();
 		window.removeEventListener( 'resize', this.handleScrollerResize );
 		this.pauseStoryScroller();
 		document.removeEventListener( 'fullscreenchange', this.handleFullscreenChange );
@@ -353,6 +355,29 @@ class StoryMapDisplay extends Component {
 		if ( this.composedStyleError ) {
 			console.warn( this.composedStyleError );
 		}
+	}
+
+	addComposedInteractions( map ) {
+		this.cleanupComposedInteractions();
+		this.composedInteractionCleanups = addComposedInteractions(
+			map,
+			this.composedManifest
+		);
+
+		if ( typeof map?.once === 'function' ) {
+			map.once( 'remove', () => this.cleanupComposedInteractions() );
+		}
+	}
+
+	cleanupComposedInteractions() {
+		this.composedInteractionCleanups.forEach( ( cleanup ) => {
+			try {
+				cleanup();
+			} catch ( error ) {
+				// Map layers may already be gone when the map runtime tears down.
+			}
+		} );
+		this.composedInteractionCleanups = [];
 	}
 
 	setStoryLayerVisibility( layerSlug, visibility ) {
@@ -545,7 +570,7 @@ class StoryMapDisplay extends Component {
 			map.on( 'resize', () => this.syncMapLibreAttributionControl() );
 
 			if ( this.hasComposedStyle() ) {
-				addComposedInteractions( map, this.composedManifest );
+				this.addComposedInteractions( map );
 			} else {
 				( this.props.navigateMapLayers || [] ).forEach(layer => {
 					if ( this.isMapboxStyleLayer( layer ) ) {

--- a/src/js/src/jeo-storymap/storymap-display.js
+++ b/src/js/src/jeo-storymap/storymap-display.js
@@ -4,6 +4,12 @@ import classNames from 'classnames';
 import scrollama from 'scrollama';
 
 import { createMap, MAP_RUNTIME } from '../lib/mapgl-loader';
+import { loadComposedStyleData } from '../shared/composed-style-data';
+import {
+	addComposedInteractions,
+	hasComposedStyle,
+	setComposedLayerVisibility,
+} from '../shared/composed-style-layers';
 import { onFirstIntersection } from '../shared/intersect';
 import { renderLayer } from '../map-blocks/map-preview-layer';
 import JeoMap from '../jeo-map/class-jeo-map';
@@ -62,8 +68,30 @@ class StoryMapDisplay extends Component {
 		this.mapContainer = null;
 		this.navigable = Boolean(this.props.navigateButton);
 		this.navigateMap = null;
+		this.composedStyleMetadata = null;
+		this.composedManifest = null;
+		this.usingComposedStyle = false;
+		this.composedStyleError = null;
 		this.cid = ++storyCounter;
 		this.isIntroductionScrollLocked = false;
+		this.scrollerResizeFrame = null;
+		this.resizeScroller = () => {
+			if ( this.state?.isNavigating || ! this.hasMeasurableScrollerSteps() ) {
+				return;
+			}
+
+			this.scroller?.resize?.();
+		};
+		this.handleScrollerResize = () => {
+			if ( this.scrollerResizeFrame ) {
+				return;
+			}
+
+			this.scrollerResizeFrame = window.requestAnimationFrame( () => {
+				this.scrollerResizeFrame = null;
+				this.resizeScroller();
+			} );
+		};
 		this.handleFullscreenChange = () => {
 			const returnToSlidesContainer = this.el?.querySelector( '.return-to-slides-container' );
 
@@ -151,10 +179,39 @@ class StoryMapDisplay extends Component {
 
 	componentWillUnmount() {
 		this.isIntroductionScrollLocked = false;
-		window.removeEventListener( 'resize', this.scroller.resize );
+		window.removeEventListener( 'resize', this.handleScrollerResize );
+		this.pauseStoryScroller();
 		document.removeEventListener( 'fullscreenchange', this.handleFullscreenChange );
 	}
 
+	hasMeasurableScrollerSteps() {
+		const steps = this.el?.querySelectorAll( '.step' );
+		if ( ! steps?.length ) {
+			return false;
+		}
+
+		return Array.from( steps ).every( ( step ) => step.offsetHeight > 0 );
+	}
+
+	pauseStoryScroller() {
+		if ( this.scrollerResizeFrame ) {
+			window.cancelAnimationFrame( this.scrollerResizeFrame );
+			this.scrollerResizeFrame = null;
+		}
+
+		this.scroller?.disable?.();
+	}
+
+	resumeStoryScroller() {
+		window.requestAnimationFrame( () => {
+			if ( this.state.isNavigating || ! this.hasMeasurableScrollerSteps() ) {
+				return;
+			}
+
+			this.scroller?.enable?.();
+			this.resizeScroller();
+		} );
+	}
 	syncIntroductionScrollLock() {
 		this.isIntroductionScrollLocked = Boolean(
 			isSingle && this.isIntroductionActive() && ! this.state.isNavigating
@@ -169,7 +226,7 @@ class StoryMapDisplay extends Component {
 		this.isIntroductionScrollLocked = false;
 		this.setState( { ...this.state, mapBrightness: 1, inSlides: true, hasStartedStorymap: true }, () => {
 			window.requestAnimationFrame( () => {
-				this.scroller.resize();
+				this.resizeScroller();
 				this.el?.querySelector( '.storymap-features' )?.scrollIntoView();
 			} );
 		} );
@@ -223,7 +280,92 @@ class StoryMapDisplay extends Component {
 		attributionButton?.setAttribute( 'hidden', 'hidden' );
 	}
 
+	async fetchComposedStyleData( mapId ) {
+		if (
+			! mapId ||
+			! window.jeoMapVars?.composedStyleUrlBase
+		) {
+			return;
+		}
+
+		try {
+			const { manifest, metadata } = await loadComposedStyleData( {
+				mapId,
+				unavailableMessage: __(
+					'Mapbox style composition is unavailable for this storymap.',
+					'jeowp'
+				),
+				emptyManifestMessage: __(
+					'Mapbox style composition did not return renderable layers for this storymap.',
+					'jeowp'
+				),
+			} );
+
+			this.composedStyleMetadata = metadata;
+			this.composedManifest = manifest;
+			this.usingComposedStyle = true;
+			this.composedStyleError = null;
+		} catch ( error ) {
+			this.composedStyleMetadata = null;
+			this.composedManifest = null;
+			this.usingComposedStyle = false;
+			this.composedStyleError = error?.message || __( 'Unable to load composed Mapbox style for this storymap.', 'jeowp' );
+			console.warn( 'Unable to load composed Mapbox style for storymap. Mapbox style layers will be omitted.', error );
+		}
+	}
+
+	hasComposedStyle() {
+		return this.usingComposedStyle &&
+			hasComposedStyle( this.composedStyleMetadata, this.composedManifest );
+	}
+
+	getVisibilityLayerRefs() {
+		if ( this.hasComposedStyle() ) {
+			return ( this.composedManifest.layers || [] ).map( ( layer ) => ( {
+				slug: layer.slug,
+				id: layer.layerPostId,
+			} ) );
+		}
+
+		return this.props.navigateMapLayers || [];
+	}
+
+	isMapboxStyleLayer( layer ) {
+		return layer?.meta?.type === 'mapbox';
+	}
+
+	addComposedStyleWarningMessage() {
+		if (
+			! ( this.props.navigateMapLayers || [] ).some( ( layer ) => this.isMapboxStyleLayer( layer ) ) ||
+			this.mapContainer?.querySelector( '.jeomap-composed-style-warning' )
+		) {
+			return;
+		}
+
+		const warning = document.createElement( 'div' );
+		warning.className = 'jeomap-composed-style-warning';
+		warning.innerHTML = `<p class="jeomap-no-layers__text">${ __(
+			'Mapbox style layers could not be loaded because the composed style is unavailable.',
+			'jeowp'
+		) }</p>`;
+		this.mapContainer?.appendChild( warning );
+
+		if ( this.composedStyleError ) {
+			console.warn( this.composedStyleError );
+		}
+	}
+
 	setStoryLayerVisibility( layerSlug, visibility ) {
+		if ( this.hasComposedStyle() ) {
+			setComposedLayerVisibility(
+				this.map,
+				this.composedManifest,
+				layerSlug,
+				visibility
+			);
+			return;
+		}
+
 		setMapLayerVisibility( this.map, layerSlug, visibility );
 	}
 
@@ -233,8 +375,9 @@ class StoryMapDisplay extends Component {
 		}
 
 		const selectedLayers = chapter.selectedLayers || [];
+		const visibilityLayers = this.getVisibilityLayerRefs();
 
-		this.props.navigateMapLayers.forEach( ( layer ) => {
+		visibilityLayers.forEach( ( layer ) => {
 			const isLayerUsed = selectedLayers.some(
 				( selectedLayer ) =>
 					selectedLayer.slug === layer.slug || selectedLayer.id === layer.id
@@ -245,7 +388,7 @@ class StoryMapDisplay extends Component {
 			}
 		} );
 
-		this.props.navigateMapLayers.forEach( ( layer ) => {
+		visibilityLayers.forEach( ( layer ) => {
 			const isLayerUsed = selectedLayers.some(
 				( selectedLayer ) =>
 					selectedLayer.slug === layer.slug || selectedLayer.id === layer.id
@@ -265,7 +408,7 @@ class StoryMapDisplay extends Component {
 			.setup({
 				step: `#story-map-${this.cid} .step`,
 				offset: 0.5,
-				progress: true,
+				progress: false,
 			})
 			.onStepEnter(response => {
 				if ( this.isIntroductionActive() ) {
@@ -315,7 +458,7 @@ class StoryMapDisplay extends Component {
 			}
 		});
 
-		window.addEventListener('resize', this.scroller.resize);
+		window.addEventListener( 'resize', this.handleScrollerResize );
 
 		if (this.navigable) {
 			const navigateMapDiv = document.createElement('div');
@@ -350,6 +493,7 @@ class StoryMapDisplay extends Component {
 	}
 
 	enterNavigationMode() {
+		this.pauseStoryScroller();
 		this.setState( { isNavigating: true, mapBrightness: 1 }, () => {
 			this.el?.scrollIntoView( { block: 'start' } );
 			window.requestAnimationFrame( () => {
@@ -367,10 +511,11 @@ class StoryMapDisplay extends Component {
 		this.setState( { isNavigating: false, mapBrightness: 1, inSlides: true, hasStartedStorymap: true }, () => {
 			this.map?.resize();
 			this.el?.scrollIntoView( { block: 'start' } );
+			this.resumeStoryScroller();
 		} );
 	}
 
-	lazyInitStorymap() {
+	async lazyInitStorymap() {
 		if ( this.initialized ) {
 			return;
 		}
@@ -379,12 +524,14 @@ class StoryMapDisplay extends Component {
 		const config = this.config;
 		const firstChapter = config.chapters[0];
 		const initialLocation = firstChapter.location;
+		await this.fetchComposedStyleData( this.props.map_id );
 
 		const map = createMap( {
 			container: this.mapContainer,
 			center: [ initialLocation.center[0] || mapDefaults.lng, initialLocation.center[1] || mapDefaults.lat ],
 			zoom: initialLocation.zoom || mapDefaults.zoom,
 			...config,
+			style: this.hasComposedStyle() ? this.composedStyleMetadata.style : config.style,
 		} );
 
 		this.map = map;
@@ -397,12 +544,20 @@ class StoryMapDisplay extends Component {
 			map.once( 'idle', () => this.scheduleInitialMapLibreAttributionSync() );
 			map.on( 'resize', () => this.syncMapLibreAttributionControl() );
 
-			this.props.navigateMapLayers.forEach(layer => {
-				const isInitialLayer = firstChapter.selectedLayers.some(selectedLayer => selectedLayer.slug === layer.slug);
+			if ( this.hasComposedStyle() ) {
+				addComposedInteractions( map, this.composedManifest );
+			} else {
+				( this.props.navigateMapLayers || [] ).forEach(layer => {
+					if ( this.isMapboxStyleLayer( layer ) ) {
+						return;
+					}
+					const isInitialLayer = firstChapter.selectedLayers.some(selectedLayer => selectedLayer.slug === layer.slug);
 
-				const jeoLayer = new window.JeoLayer(layer.meta.type, { ...layer.meta, layer_id: layer.slug, visible: isInitialLayer });
-				jeoLayer.addLayer(map);
-			});
+					const jeoLayer = new window.JeoLayer(layer.meta.type, { ...layer.meta, layer_id: layer.slug, visible: isInitialLayer });
+					jeoLayer.addLayer(map);
+				});
+				this.addComposedStyleWarningMessage();
+			}
 			this.applyChapterLayerVisibility( this.state.currentChapter || firstChapter );
 
 			const mapEl = this.el?.querySelector( `.${MAP_RUNTIME}-map` );
@@ -480,7 +635,8 @@ class StoryMapDisplay extends Component {
 						className={ classNames(
 							'story-map-element',
 							STORYMAP_MAP_CONTAINER_CLASS,
-							STORYMAP_MAP_CONTAINER_JS_CLASS
+							STORYMAP_MAP_CONTAINER_JS_CLASS,
+							`${MAP_RUNTIME}-map`
 						) }
 					>
 					</div>

--- a/src/js/src/layers-sidebar/layer-settings.js
+++ b/src/js/src/layers-sidebar/layer-settings.js
@@ -146,6 +146,7 @@ const LayerSettings = ( { postId, postMeta, sendNotice, setPostMeta } ) => {
 			const refreshed = Number.parseInt( response?.refreshed || 0, 10 );
 			const failed = Number.parseInt( response?.failed || 0, 10 );
 			const refreshedLabel = sprintf(
+				/* translators: %d: number of maps whose composed style cache was refreshed. */
 				_n(
 					'%d map',
 					'%d maps',
@@ -155,6 +156,7 @@ const LayerSettings = ( { postId, postMeta, sendNotice, setPostMeta } ) => {
 				refreshed
 			);
 			const failedLabel = sprintf(
+				/* translators: %d: number of map refresh failures. */
 				_n(
 					'%d failure',
 					'%d failures',
@@ -168,6 +170,7 @@ const LayerSettings = ( { postId, postMeta, sendNotice, setPostMeta } ) => {
 				sendNotice(
 					'warning',
 					sprintf(
+						/* translators: 1: refreshed maps count label, 2: failed refresh count label. */
 						__( 'Composed style cache refreshed for %1$s, with %2$s.', 'jeowp' ),
 						refreshedLabel,
 						failedLabel
@@ -176,7 +179,11 @@ const LayerSettings = ( { postId, postMeta, sendNotice, setPostMeta } ) => {
 			} else {
 				sendNotice(
 					'success',
-					sprintf( __( 'Composed style cache refreshed for %s.', 'jeowp' ), refreshedLabel )
+					sprintf(
+						/* translators: %s: refreshed maps count label. */
+						__( 'Composed style cache refreshed for %s.', 'jeowp' ),
+						refreshedLabel
+					)
 				);
 			}
 		} catch ( error ) {

--- a/src/js/src/layers-sidebar/layer-settings.js
+++ b/src/js/src/layers-sidebar/layer-settings.js
@@ -1,3 +1,4 @@
+import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
 import { select, withDispatch, withSelect } from '@wordpress/data';
 import {
@@ -8,7 +9,7 @@ import {
 	useState,
 	useRef,
 } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import InteractionsSettings from './interactions-settings';
 import { useDebounce } from 'use-debounce';
 import SchemaForm, { mergeSchemaFormData } from '../shared/schema-form';
@@ -86,7 +87,7 @@ function usePrevious( value ) {
 	return ref.current;
 }
 
-const LayerSettings = ( { postMeta, setPostMeta } ) => {
+const LayerSettings = ( { postId, postMeta, sendNotice, setPostMeta } ) => {
 	const [ widgets, setWidgets ] = useState( {} );
 	const [ options, setOptions ] = useState( {} );
 	const [ formData, setFormData ] = useState( () =>
@@ -98,6 +99,7 @@ const LayerSettings = ( { postMeta, setPostMeta } ) => {
 	const [ styleLayers, setStyleLayers ] = useState( null );
 	const [ styleDefinition, setStyleDefinition ]= useState( null );
 	const [ modalOpen, setModalStatus ] = useState( false );
+	const [ isRefreshingComposerCache, setIsRefreshingComposerCache ] = useState( false );
 	const closeModal = useCallback( () => setModalStatus( false ), [
 		setModalStatus,
 	] );
@@ -128,6 +130,65 @@ const LayerSettings = ( { postMeta, setPostMeta } ) => {
 	const interactions = useMemo( () => {
 		return formData.layer_type_options?.interactions || [];
 	}, [ formData.layer_type_options?.interactions ] );
+
+	const refreshComposerCache = useCallback( async () => {
+		if ( ! postId || isRefreshingComposerCache ) {
+			return;
+		}
+
+		setIsRefreshingComposerCache( true );
+
+		try {
+			const response = await apiFetch( {
+				path: `/jeo/v1/map-style/layer/${ postId }/refresh`,
+				method: 'POST',
+			} );
+			const refreshed = Number.parseInt( response?.refreshed || 0, 10 );
+			const failed = Number.parseInt( response?.failed || 0, 10 );
+			const refreshedLabel = sprintf(
+				_n(
+					'%d map',
+					'%d maps',
+					refreshed,
+					'jeowp'
+				),
+				refreshed
+			);
+			const failedLabel = sprintf(
+				_n(
+					'%d failure',
+					'%d failures',
+					failed,
+					'jeowp'
+				),
+				failed
+			);
+
+			if ( failed > 0 ) {
+				sendNotice(
+					'warning',
+					sprintf(
+						__( 'Composed style cache refreshed for %1$s, with %2$s.', 'jeowp' ),
+						refreshedLabel,
+						failedLabel
+					)
+				);
+			} else {
+				sendNotice(
+					'success',
+					sprintf( __( 'Composed style cache refreshed for %s.', 'jeowp' ), refreshedLabel )
+				);
+			}
+		} catch ( error ) {
+			sendNotice(
+				'error',
+				error?.message ||
+					__( 'Unable to refresh composed style cache.', 'jeowp' )
+			);
+		} finally {
+			setIsRefreshingComposerCache( false );
+		}
+	}, [ isRefreshingComposerCache, postId, sendNotice ] );
 
 	useEffect( () => {
 		setFormData( normalizeLayerFormData( postMeta ) );
@@ -226,6 +287,19 @@ const LayerSettings = ( { postMeta, setPostMeta } ) => {
 				<div />
 			</SchemaForm>
 
+			{ formData.type === 'mapbox' && (
+				<Button
+					isBusy={ isRefreshingComposerCache }
+					disabled={ isRefreshingComposerCache || ! postId }
+					onClick={ refreshComposerCache }
+					variant="secondary"
+				>
+					{ isRefreshingComposerCache
+						? __( 'Refreshing composed style cache', 'jeowp' )
+						: __( 'Refresh composed style cache', 'jeowp' ) }
+				</Button>
+			) }
+
 			{ styleLayers && interactions && (
 				<Fragment>
 					{ modalOpen && (
@@ -256,8 +330,15 @@ export default withDispatch( ( dispatch ) => ( {
 			meta: { ...currentMeta, ...meta },
 		} );
 	},
+	sendNotice: ( type, message ) => {
+		dispatch( 'core/notices' ).createNotice( type, message, {
+			id: 'jeo-layer-composer-cache-refresh',
+			isDismissible: true,
+		} );
+	},
 } ) )(
 	withSelect( ( select ) => ( {
+		postId: select( 'core/editor' ).getCurrentPostId(),
 		postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {},
 	} ) )( LayerSettings )
 );

--- a/src/js/src/lib/mapboxgl/mapboxgl-loader.js
+++ b/src/js/src/lib/mapboxgl/mapboxgl-loader.js
@@ -258,7 +258,7 @@ function ensureMapboxRuntimePatched() {
 /** @type string */
 export const mapboxToken = jeo_settings.mapbox_key
 
-export const defaultStyle = 'mapbox://styles/mapbox/streets-v11'
+export const defaultStyle = 'mapbox://styles/mapbox/standard'
 export const transformRequest = undefined
 
 export function getMapLibrary() {

--- a/src/js/src/lib/maplibregl/maplibregl-loader.js
+++ b/src/js/src/lib/maplibregl/maplibregl-loader.js
@@ -1,22 +1,26 @@
-import U from 'map-gl-utils'
-import MapLibreGL from 'maplibre-gl'
-import { isMapboxURL, transformMapboxStyle, transformMapboxUrl } from 'maplibregl-mapbox-request-transformer'
+import U from 'map-gl-utils';
+import MapLibreGL from 'maplibre-gl';
+import {
+	isMapboxURL,
+	transformMapboxStyle,
+	transformMapboxUrl,
+} from 'maplibregl-mapbox-request-transformer';
 
-import 'maplibre-gl/dist/maplibre-gl.css'
+import 'maplibre-gl/dist/maplibre-gl.css';
 
 if ( typeof MapLibreGL.Map?.prototype?.getLight === 'function' ) {
 	try {
 		Object.defineProperty( MapLibreGL.Map.prototype, 'getLight', {
 			value: function () {
-				return this.style?.getLight?.() ?? null
+				return this.style?.getLight?.() ?? null;
 			},
 			configurable: true,
 			writable: true,
-		} )
+		} );
 	} catch ( error ) {
 		MapLibreGL.Map.prototype.getLight = function () {
-			return this.style?.getLight?.() ?? null
-		}
+			return this.style?.getLight?.() ?? null;
+		};
 	}
 }
 
@@ -48,7 +52,8 @@ function patchInstanceOf( Ctor, duckTest ) {
 	try {
 		Object.defineProperty( Ctor, Symbol.hasInstance, {
 			value: function ( instance ) {
-				if ( instance == null || typeof instance !== 'object' ) return false;
+				if ( instance == null || typeof instance !== 'object' )
+					return false;
 				// Base class: use duck-typing
 				if ( this === Ctor ) {
 					return duckTest( instance );
@@ -73,13 +78,21 @@ function patchInstanceOf( Ctor, duckTest ) {
 patchInstanceOf( HTMLElement, ( i ) => i.nodeType === 1 );
 
 // MouseEvent — duck-type: has clientX/clientY and is an Event
-patchInstanceOf( MouseEvent, ( i ) =>
-	typeof i.clientX === 'number' && typeof i.clientY === 'number' && typeof i.type === 'string'
+patchInstanceOf(
+	MouseEvent,
+	( i ) =>
+		typeof i.clientX === 'number' &&
+		typeof i.clientY === 'number' &&
+		typeof i.type === 'string'
 );
 
 // WheelEvent — duck-type: has deltaY and is a MouseEvent
-patchInstanceOf( WheelEvent, ( i ) =>
-	typeof i.deltaY === 'number' && typeof i.clientX === 'number' && typeof i.type === 'string'
+patchInstanceOf(
+	WheelEvent,
+	( i ) =>
+		typeof i.deltaY === 'number' &&
+		typeof i.clientX === 'number' &&
+		typeof i.type === 'string'
 );
 
 // Fix: Patch FullscreenControl for cross-document (iframe) compatibility.
@@ -110,9 +123,13 @@ patchInstanceOf( WheelEvent, ( i ) =>
 
 		// 1. Move fullscreenchange listener from parent doc to iframe doc
 		const oldFSChange = this._onFullscreenChange;
-		window.document.removeEventListener( this._fullscreenchange, oldFSChange );
+		window.document.removeEventListener(
+			this._fullscreenchange,
+			oldFSChange
+		);
 		this._onFullscreenChange = function () {
-			let fse = ownerDoc.fullscreenElement ||
+			let fse =
+				ownerDoc.fullscreenElement ||
 				ownerDoc.mozFullScreenElement ||
 				ownerDoc.webkitFullscreenElement ||
 				ownerDoc.msFullscreenElement;
@@ -123,7 +140,10 @@ patchInstanceOf( WheelEvent, ( i ) =>
 				self._handleFullscreenChange();
 			}
 		};
-		ownerDoc.addEventListener( this._fullscreenchange, this._onFullscreenChange );
+		ownerDoc.addEventListener(
+			this._fullscreenchange,
+			this._onFullscreenChange
+		);
 
 		// 2. Replace click handler to exit on the correct document
 		const oldClick = this._onClickFullscreen;
@@ -145,26 +165,36 @@ patchInstanceOf( WheelEvent, ( i ) =>
 			}
 		};
 		this._fullscreenButton.removeEventListener( 'click', oldClick );
-		this._fullscreenButton.addEventListener( 'click', this._onClickFullscreen );
+		this._fullscreenButton.addEventListener(
+			'click',
+			this._onClickFullscreen
+		);
 
 		return result;
 	};
 
 	// onRemove: clean up from the correct document
 	proto.onRemove = function () {
-		const ownerDoc = ( this._container && this._container.ownerDocument ) || window.document;
-		ownerDoc.removeEventListener( this._fullscreenchange, this._onFullscreenChange );
+		const ownerDoc =
+			( this._container && this._container.ownerDocument ) ||
+			window.document;
+		ownerDoc.removeEventListener(
+			this._fullscreenchange,
+			this._onFullscreenChange
+		);
 		if ( this._controlContainer && this._controlContainer.parentNode ) {
-			this._controlContainer.parentNode.removeChild( this._controlContainer );
+			this._controlContainer.parentNode.removeChild(
+				this._controlContainer
+			);
 		}
 		this._map = null;
 	};
 } )();
 
 /** @type string */
-export const mapboxToken = jeo_settings.mapbox_key
+export const mapboxToken = jeo_settings.mapbox_key;
 
-export const mapgl = MapLibreGL
+export const mapgl = MapLibreGL;
 
 export const defaultStyle = {
 	version: 8,
@@ -187,65 +217,169 @@ export const defaultStyle = {
 			source: 'osm',
 		},
 	],
-}
+};
 
-export function mapboxTransformRequest(url, resourceType) {
-	if (isMapboxURL(url)) {
-		return transformMapboxUrl(url, resourceType, mapboxToken)
-  	} else if (url.includes('tiles.mapbox.com') && url.includes('.jpg?')) {
-		// MapLibreGL don't remove black backgrounds from Mapbox JPEG static tiles
-		return { url: url.replace('.jpg?', '.webp?') }
-	}
-	    return { url }
-}
+function extractMapboxAccessToken( url ) {
+	try {
+		const parsedUrl = new URL( url );
+		const accessToken = parsedUrl.searchParams.get( 'access_token' );
 
-export const transformRequest = mapboxTransformRequest
-
-function createTransformRequest(baseTransformRequest) {
-	if (baseTransformRequest) {
-		return (url, resourceType) => {
-			const { url: baseUrl } = baseTransformRequest(url, resourceType)
-			return mapboxTransformRequest(baseUrl, resourceType)
+		if ( ! accessToken ) {
+			return { url, accessToken: null };
 		}
-	} else {
-		return mapboxTransformRequest
+
+		parsedUrl.searchParams.delete( 'access_token' );
+		return {
+			url: parsedUrl.toString(),
+			accessToken,
+		};
+	} catch ( error ) {
+		const queryStart = url.indexOf( '?' );
+		if ( queryStart === -1 ) {
+			return { url, accessToken: null };
+		}
+
+		const baseUrl = url.slice( 0, queryStart );
+		const params = url
+			.slice( queryStart + 1 )
+			.split( '&' )
+			.filter( Boolean );
+		let accessToken = null;
+		const nextParams = [];
+
+		params.forEach( ( param ) => {
+			const [ key, ...valueParts ] = param.split( '=' );
+
+			if ( decodeURIComponent( key ) === 'access_token' ) {
+				accessToken =
+					accessToken || decodeURIComponent( valueParts.join( '=' ) );
+				return;
+			}
+
+			nextParams.push( param );
+		} );
+
+		if ( ! accessToken ) {
+			return { url, accessToken: null };
+		}
+
+		return {
+			url: nextParams.length
+				? `${ baseUrl }?${ nextParams.join( '&' ) }`
+				: baseUrl,
+			accessToken,
+		};
 	}
 }
 
-export function createMap({ container, style, transformRequest, ...options }) {
-	const map = new MapLibreGL.Map({
+function normalizeMapboxTerrainDemTileUrl( url ) {
+	try {
+		const parsedUrl = new URL( url );
+		if (
+			! parsedUrl.hostname.endsWith( 'tiles.mapbox.com' ) ||
+			! parsedUrl.pathname.startsWith(
+				'/raster/v1/mapbox.mapbox-terrain-dem-v1/'
+			)
+		) {
+			return null;
+		}
+
+		const tilePath = parsedUrl.pathname
+			.replace( '/raster/v1/', '/v4/' )
+			.replace( /\.png$/, '.pngraw' );
+
+		const nextUrl = new URL( `https://api.mapbox.com${ tilePath }` );
+		parsedUrl.searchParams.forEach( ( value, key ) => {
+			nextUrl.searchParams.set( key, value );
+		} );
+		if ( ! nextUrl.searchParams.has( 'access_token' ) ) {
+			nextUrl.searchParams.set( 'access_token', mapboxToken );
+		}
+
+		return nextUrl.toString();
+	} catch ( error ) {
+		return null;
+	}
+}
+
+export function mapboxTransformRequest( url, resourceType ) {
+	const terrainDemTileUrl = normalizeMapboxTerrainDemTileUrl( url );
+
+	if ( isMapboxURL( url ) ) {
+		const transformedUrl = extractMapboxAccessToken( url );
+		return (
+			transformMapboxUrl(
+				transformedUrl.url,
+				resourceType,
+				transformedUrl.accessToken || mapboxToken
+			) || { url: transformedUrl.url }
+		);
+	} else if ( terrainDemTileUrl ) {
+		return { url: terrainDemTileUrl };
+	} else if (
+		url.includes( 'tiles.mapbox.com' ) &&
+		url.includes( '.jpg?' )
+	) {
+		// MapLibreGL don't remove black backgrounds from Mapbox JPEG static tiles
+		return { url: url.replace( '.jpg?', '.webp?' ) };
+	}
+	return { url };
+}
+
+export const transformRequest = mapboxTransformRequest;
+
+function createTransformRequest( baseTransformRequest ) {
+	if ( baseTransformRequest ) {
+		return ( url, resourceType ) => {
+			const { url: baseUrl } = baseTransformRequest( url, resourceType );
+			return mapboxTransformRequest( baseUrl, resourceType );
+		};
+	} else {
+		return mapboxTransformRequest;
+	}
+}
+
+export function createMap( {
+	container,
+	style,
+	transformRequest,
+	...options
+} ) {
+	const map = new MapLibreGL.Map( {
 		container: container,
 		maplibreLogo: false,
 		projection: 'equirectangular',
 		validateStyle: false,
-		transformRequest: createTransformRequest(transformRequest),
+		transformRequest: createTransformRequest( transformRequest ),
 		...options,
-	})
+	} );
 
-	map.setStyle(style ?? defaultStyle, {
+	map.setStyle( style ?? defaultStyle, {
 		transformStyle: transformMapboxStyle,
-	})
+	} );
 
-	U.init(map, MapLibreGL)
+	U.init( map, MapLibreGL );
 
-	return map
+	return map;
 }
 
 /**
  * @param {import('maplibre-gl').GeoJSONSource} source
  */
-export function getClusterLeaves(source, cluster, limit, offset) {
-	return source.getClusterLeaves(cluster, limit, offset)
+export function getClusterLeaves( source, cluster, limit, offset ) {
+	return source.getClusterLeaves( cluster, limit, offset );
 }
 
 /**
  * @param {import('maplibre-gl').Map} map
  */
-export function loadImage(map, id, url) {
-	return new Promise((resolve, reject) => {
-		map.loadImage(url).then((image) => {
-			map.addImage(id, image.data)
-			resolve(id)
-		}).catch(reject)
-	})
+export function loadImage( map, id, url ) {
+	return new Promise( ( resolve, reject ) => {
+		map.loadImage( url )
+			.then( ( image ) => {
+				map.addImage( id, image.data );
+				resolve( id );
+			} )
+			.catch( reject );
+	} );
 }

--- a/src/js/src/lib/maplibregl/maplibregl-react.js
+++ b/src/js/src/lib/maplibregl/maplibregl-react.js
@@ -4,6 +4,8 @@ import MapLibre, { FullscreenControl, NavigationControl } from 'react-map-gl/map
 import { computeInlineStart } from '../../shared/direction';
 import { defaultStyle, mapgl, transformRequest } from '../mapgl-loader'
 
+const defaultProjection = { name: 'equirectangular' };
+
 // Fix: Ensure the HTMLElement instanceof patch is also applied in this chunk.
 // Depending on how webpack groups the runtime and vendor code, react-map-gl may
 // still evaluate against a different HTMLElement reference from the loader chunk.
@@ -128,6 +130,7 @@ function MapGL( { children, controls = undefined, fullscreen = true, onLoad, ...
 			ref={ setRef }
 			mapLib={ mapgl }
 			mapStyle={ defaultStyle }
+			projection={ defaultProjection }
 			reuseMaps={ false }
 			transformRequest={ transformRequest }
 			onLoad={ handleLoad }

--- a/src/js/src/map-blocks/layer-editor-preview.js
+++ b/src/js/src/map-blocks/layer-editor-preview.js
@@ -1,4 +1,5 @@
 import { useBlockProps } from '@wordpress/block-editor';
+import { Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { useDebounce } from 'use-debounce';
@@ -6,6 +7,12 @@ import { useDebounce } from 'use-debounce';
 import { Map } from '../lib/mapgl-react';
 import { MemoizedRenderLayer } from './map-preview-layer';
 import { getEditorLayerTypeSchema } from '../layers-sidebar/layer-type-definitions';
+import {
+	getMapboxStyleUrl,
+	handleEditorMapPreviewError,
+	useMapboxStylePreview,
+	useEditorMapboxTransformRequest,
+} from './mapbox-style-preview';
 
 const mapDefaults = {
 	initial_zoom: jeo_settings.map_defaults.zoom,
@@ -30,6 +37,28 @@ export default function LayerEditorPreview() {
 	const [ renderControl, setRenderControl ] = useState( { status: 'incomplete_form' } );
 	const [ debouncedPostMeta ] = useDebounce( postMeta, 1500 );
 	const prevPostMeta = useRef( {} );
+	const mapboxStyleUrl =
+		debouncedPostMeta?.type === 'mapbox' &&
+		[ 'ready', 'loaded' ].includes( renderControl.status )
+			? getMapboxStyleUrl( debouncedPostMeta.layer_type_options )
+			: null;
+	const mapboxStylePreview = useMapboxStylePreview( mapboxStyleUrl );
+	const transformRequest = useEditorMapboxTransformRequest( [
+		{ meta: debouncedPostMeta },
+	] );
+	const shouldRenderMap =
+		debouncedPostMeta?.type !== 'mapbox' ||
+		Boolean( mapboxStylePreview.style ) ||
+		Boolean( mapboxStylePreview.error );
+
+	useEffect( () => {
+		if ( mapboxStylePreview.viewState ) {
+			setViewState( ( currentViewState ) => ( {
+				...currentViewState,
+				...mapboxStylePreview.viewState,
+			} ) );
+		}
+	}, [ mapboxStylePreview.viewState ] );
 
 	useEffect( () => {
 		if ( ! postMeta.type ) {
@@ -78,33 +107,42 @@ export default function LayerEditorPreview() {
 				onMouseDown={ stopPropagation }
 				onTouchStart={ stopPropagation }
 			>
-				<Map
-					key={ key }
-					onError={ () => {
-						setRenderControl( { status: 'request_error', statusCode: 400 } );
-					} }
-					onSourceData={ () => {
-						setRenderControl( { status: 'loaded' } );
-					} }
-					style={ { height: '500px', width: '100%' } }
-					latitude={ viewState.latitude || 0 }
-					longitude={ viewState.longitude || 0 }
-					zoom={ viewState.zoom || 0 }
-					onMove={ ( { viewState } ) => {
-						setViewState( {
-							latitude: viewState.latitude,
-							longitude: viewState.longitude,
-							zoom: Math.round( viewState.zoom * 10 ) / 10,
-						} );
-					} }
-				>
-					{ [ 'ready', 'loaded' ].includes( renderControl.status ) && (
-						<MemoizedRenderLayer
-							layer={ debouncedPostMeta }
-							instance={ { id: 1, use: 'fixed' } }
-						/>
-					) }
-				</Map>
+				{ ! shouldRenderMap && <Spinner /> }
+				{ shouldRenderMap && (
+					<Map
+						key={ `${ key }:${ mapboxStyleUrl || 'default' }` }
+						mapStyle={ mapboxStylePreview.style || undefined }
+						transformRequest={ transformRequest }
+						onError={ ( error ) => {
+							handleEditorMapPreviewError( error );
+							if ( debouncedPostMeta?.type !== 'mapbox' ) {
+								setRenderControl( { status: 'request_error', statusCode: 400 } );
+							}
+						} }
+						onSourceData={ () => {
+							setRenderControl( { status: 'loaded' } );
+						} }
+						style={ { height: '500px', width: '100%' } }
+						latitude={ viewState.latitude || 0 }
+						longitude={ viewState.longitude || 0 }
+						zoom={ viewState.zoom || 0 }
+						onMove={ ( { viewState } ) => {
+							setViewState( {
+								latitude: viewState.latitude,
+								longitude: viewState.longitude,
+								zoom: Math.round( viewState.zoom * 10 ) / 10,
+							} );
+						} }
+					>
+						{ [ 'ready', 'loaded' ].includes( renderControl.status ) &&
+							debouncedPostMeta?.type !== 'mapbox' && (
+							<MemoizedRenderLayer
+								layer={ debouncedPostMeta }
+								instance={ { id: 1, use: 'fixed' } }
+							/>
+						) }
+					</Map>
+				) }
 			</div>
 		</div>
 	);

--- a/src/js/src/map-blocks/layer-settings.js
+++ b/src/js/src/map-blocks/layer-settings.js
@@ -112,7 +112,7 @@ const LayerSettings = (
 
 					<div className="default-control" style={ setWidth( 4 ) }>
 						{ settings.layer.meta.type === 'mapbox' && (
-							<RadioControl
+							<CheckboxControl
 								label={ __( 'Load interactions', 'jeowp' ) }
 								checked={ settings.load_as_style }
 								onChange={ switchUseStyle }

--- a/src/js/src/map-blocks/layers-settings.js
+++ b/src/js/src/map-blocks/layers-settings.js
@@ -294,12 +294,30 @@ export default function LayersSettings ( { attributes, setAttributes, loadedLaye
 									}
 
 									const switchUseStyle = ( def ) => {
+										if ( ! def ) {
+											setLayers(
+												attributes.layers.map( ( settings ) => {
+													return settings.id === layer.id
+														? { ...settings, load_as_style: false, style_layers: [] }
+														: settings;
+												} )
+											);
+											return;
+										}
+
 										const currentJeoLayerProps = loadedLayers.find(layerPost => layerPost.id === layer.id);
+										if ( ! currentJeoLayerProps ) {
+											return;
+										}
+
 										const layerType = window.JeoLayerTypes.getLayerType(
 											currentJeoLayerProps.meta.type
 										);
+										if ( ! layerType?._getStyleDefinition ) {
+											return;
+										}
 
-										if(def) {
+										if ( def ) {
 											layerType._getStyleDefinition( { ...currentJeoLayerProps.meta, layer_id: currentJeoLayerProps.id  } ).then( response => {
 												if(!response) {
 													return;
@@ -325,7 +343,7 @@ export default function LayersSettings ( { attributes, setAttributes, loadedLaye
 													attributes.layers.map( ( settings ) => {
 														return settings.id === layer.id?
 															{ ...settings, load_as_style: true, style_layers: styleLayers }
-															: { ...settings, load_as_style: false, style_layers: [] }
+															: settings
 													} )
 												);
 											} );
@@ -334,7 +352,7 @@ export default function LayersSettings ( { attributes, setAttributes, loadedLaye
 												attributes.layers.map( ( settings ) => {
 													return settings.id === layer.id?
 														{ ...settings, load_as_style: true, style_layers: [] }
-														: { ...settings, load_as_style: false, style_layers: [] }
+														: settings
 												} )
 											);
 										}

--- a/src/js/src/map-blocks/map-editor-preview.js
+++ b/src/js/src/map-blocks/map-editor-preview.js
@@ -1,5 +1,5 @@
 import { useBlockProps } from '@wordpress/block-editor';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { select, useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -7,6 +7,13 @@ import { __ } from '@wordpress/i18n';
 import { Map } from '../lib/mapgl-react';
 import { renderLayer } from './map-preview-layer';
 import { useRecordsByIds } from '../shared/rest-records';
+import {
+	applyComposedVisibilityFromSettings,
+	handleEditorMapPreviewError,
+	hasMapboxStyleLayers,
+	useComposedPayloadPreviewStyle,
+	useEditorMapboxTransformRequest,
+} from './mapbox-style-preview';
 
 const mapDefaults = {
 	initial_zoom: jeo_settings.map_defaults.zoom,
@@ -21,6 +28,10 @@ export default function MapEditorPreview() {
 
 	const postMeta = useSelect( ( select ) =>
 		select( 'core/editor' ).getEditedPostAttribute( 'meta' ), [] ) || {};
+	const postId = useSelect( ( select ) =>
+		select( 'core/editor' ).getCurrentPostId(), [] );
+	const isSavingPost = useSelect( ( select ) =>
+		select( 'core/editor' ).isSavingPost(), [] );
 	const { editPost } = useDispatch( 'core/editor' );
 	const setPostMeta = useCallback(
 		( meta ) => {
@@ -79,12 +90,60 @@ export default function MapEditorPreview() {
 		[ postMeta.layers ]
 	);
 
-	const { records: loadedLayers = [] } = useRecordsByIds( {
+	const {
+		records: loadedLayers = [],
+		isLoading: loadingLayers,
+		hasResolved: hasResolvedLayers,
+	} = useRecordsByIds( {
 		path: '/jeo/v1/map-layer',
 		ids: layerIds,
 		enabled: layerIds.length > 0,
 		query: { context: 'edit' },
 	} );
+	const hasMapboxLayers = hasMapboxStyleLayers( loadedLayers );
+	const composedPayload = useMemo( () => ( {
+		scope: 'preview',
+		kind: 'map-preview',
+		postId,
+		layers: postMeta.layers || [],
+	} ), [ postId, layerSettingsKey ] );
+	const composedPreview = useComposedPayloadPreviewStyle( {
+		enabled: hasMapboxLayers,
+		payload: composedPayload,
+		refreshKey: `${ layerSettingsKey }:${ isSavingPost ? 'saving' : 'idle' }`,
+	} );
+	const useComposedPreview = Boolean(
+		hasMapboxLayers && composedPreview.style
+	);
+	const isPreparingLayerPreview = Boolean(
+		layerIds.length > 0 && ( loadingLayers || ! hasResolvedLayers )
+	);
+	const isPreparingComposedPreview = Boolean(
+		! isPreparingLayerPreview &&
+			hasMapboxLayers &&
+			! composedPreview.style &&
+			! composedPreview.error
+	);
+	const shouldRenderMap = ! isPreparingLayerPreview && ! isPreparingComposedPreview;
+	const transformRequest = useEditorMapboxTransformRequest( loadedLayers );
+
+	const applyComposedVisibility = useCallback( () => {
+		if ( useComposedPreview ) {
+			applyComposedVisibilityFromSettings(
+				mapRef.current,
+				composedPreview.manifest,
+				postMeta.layers || []
+			);
+		}
+	}, [
+		composedPreview.manifest,
+		postMeta.layers,
+		useComposedPreview,
+	] );
+
+	useEffect( () => {
+		applyComposedVisibility();
+	}, [ applyComposedVisibility, layerSettingsKey ] );
 
 	const buttonStyle = ( selected ) => ( {
 		color: selected ? '#fff' : '#000',
@@ -155,37 +214,44 @@ export default function MapEditorPreview() {
 						</Button>
 					</div>
 				</div>
-				<Map
-					key={ `${ key }:${ zoomState }:${ layerSettingsKey }` }
-					ref={ mapRef }
-					style={ { height: '500px', width: '100%' } }
-					latitude={ centerLat || 0 }
-					longitude={ centerLon || 0 }
-					zoom={ currentZoom || initialZoom || 11 }
-					onMove={ ( { viewState } ) => {
-						setPostMeta( {
-							center_lat: viewState.latitude,
-							center_lon: viewState.longitude,
-						} );
-					} }
-					onZoom={ ( { viewState } ) => {
-						let zoom = Math.round( viewState.zoom * 10 ) / 10;
-						setPostMeta( { [ zoomState ]: zoom } );
-					} }
-				>
-					{ loadedLayers &&
-						( postMeta.layers || [] ).map( ( layer ) => {
-							const layerOptions = loadedLayers.find(
-								( { id } ) => id === layer.id
-							);
-							if ( layerOptions ) {
-								return renderLayer( {
-									layer: layerOptions.meta,
-									instance: layer,
-								} );
-							}
-						} ) }
-				</Map>
+				{ ! shouldRenderMap && <Spinner /> }
+				{ shouldRenderMap && (
+					<Map
+						key={ `${ key }:${ zoomState }:${ layerSettingsKey }:${ composedPreview.metadata?.hash || 'default' }` }
+						ref={ mapRef }
+						mapStyle={ useComposedPreview ? composedPreview.style : undefined }
+						style={ { height: '500px', width: '100%' } }
+						transformRequest={ transformRequest }
+						latitude={ centerLat || 0 }
+						longitude={ centerLon || 0 }
+						zoom={ currentZoom || initialZoom || 11 }
+						onError={ handleEditorMapPreviewError }
+						onStyleData={ applyComposedVisibility }
+						onMove={ ( { viewState } ) => {
+							setPostMeta( {
+								center_lat: viewState.latitude,
+								center_lon: viewState.longitude,
+							} );
+						} }
+						onZoom={ ( { viewState } ) => {
+							let zoom = Math.round( viewState.zoom * 10 ) / 10;
+							setPostMeta( { [ zoomState ]: zoom } );
+						} }
+					>
+						{ ! useComposedPreview && loadedLayers &&
+							( postMeta.layers || [] ).map( ( layer ) => {
+								const layerOptions = loadedLayers.find(
+									( { id } ) => id === layer.id
+								);
+								if ( layerOptions ) {
+									return renderLayer( {
+										layer: layerOptions.meta,
+										instance: layer,
+									} );
+								}
+							} ) }
+					</Map>
+				) }
 			</div>
 		</div>
 	);

--- a/src/js/src/map-blocks/map-editor.js
+++ b/src/js/src/map-blocks/map-editor.js
@@ -8,6 +8,13 @@ import { Map } from '../lib/mapgl-react';
 import { renderLayer } from './map-preview-layer';
 import JeoAutosuggest from './jeo-autosuggest';
 import { useRecordsByIds } from '../shared/rest-records';
+import {
+	applyComposedVisibilityFromSettings,
+	handleEditorMapPreviewError,
+	hasMapboxStyleLayers,
+	useComposedMapPreviewStyle,
+	useEditorMapboxTransformRequest,
+} from './mapbox-style-preview';
 import './map-editor.css';
 
 const { map_defaults: mapDefaults } = window.jeo_settings;
@@ -43,12 +50,50 @@ export default function MapEditor ( {attributes, setAttributes } ) {
 		[ loadedMap?.meta.layers ]
 	);
 
-	const { records: loadedLayers = [] } = useRecordsByIds( {
+	const {
+		records: loadedLayers = [],
+		isLoading: loadingLayers,
+		hasResolved: hasResolvedLayers,
+	} = useRecordsByIds( {
 		path: '/jeo/v1/map-layer',
 		ids: layerIds,
 		enabled: layerIds.length > 0,
 		query: { context: 'edit' },
 	} );
+	const hasMapboxLayers = hasMapboxStyleLayers( loadedLayers );
+	const composedPreview = useComposedMapPreviewStyle( {
+		enabled: hasMapboxLayers,
+		mapId: attributes.map_id,
+		refreshKey: layerSettingsKey,
+	} );
+	const useComposedPreview = Boolean(
+		hasMapboxLayers && composedPreview.style
+	);
+	const isPreparingLayerPreview = Boolean(
+		layerIds.length > 0 && ( loadingLayers || ! hasResolvedLayers )
+	);
+	const isPreparingComposedPreview = Boolean(
+		! isPreparingLayerPreview &&
+			hasMapboxLayers &&
+			! composedPreview.style &&
+			! composedPreview.error
+	);
+	const shouldRenderMap = ! isPreparingLayerPreview && ! isPreparingComposedPreview;
+	const transformRequest = useEditorMapboxTransformRequest( loadedLayers );
+
+	const applyComposedVisibility = () => {
+		if ( useComposedPreview ) {
+			applyComposedVisibilityFromSettings(
+				mapRef.current,
+				composedPreview.manifest,
+				loadedMap?.meta?.layers || []
+			);
+		}
+	};
+
+	useEffect( () => {
+		applyComposedVisibility();
+	}, [ useComposedPreview, composedPreview.manifest, layerSettingsKey ] );
 
 	return (
 		<div { ...blockProps }>
@@ -56,44 +101,51 @@ export default function MapEditor ( {attributes, setAttributes } ) {
 			{ attributes.map_id && ! loadingMap && loadedMap && (
 				<>
 					<div className="jeo-preview-area">
-						<Map
-							key={ `${ key }:${ layerSettingsKey }` }
-							ref={ mapRef }
-							onStyleData={ () => {
-								const { current: map } = mapRef;
-								if ( map ) {
-									if ( loadedMap.meta.disable_scroll_zoom ) {
-										map.scrollZoom?.disable();
-									}
+						{ ! shouldRenderMap && <Spinner /> }
+						{ shouldRenderMap && (
+							<Map
+								key={ `${ key }:${ layerSettingsKey }:${ composedPreview.metadata?.hash || 'default' }` }
+								ref={ mapRef }
+								mapStyle={ useComposedPreview ? composedPreview.style : undefined }
+								transformRequest={ transformRequest }
+								onError={ handleEditorMapPreviewError }
+								onStyleData={ () => {
+									const { current: map } = mapRef;
+									if ( map ) {
+										if ( loadedMap.meta.disable_scroll_zoom ) {
+											map.scrollZoom?.disable();
+										}
 
-									if ( loadedMap.meta.disable_drag_pan ) {
-										map.dragPan.disable();
-										map.touchZoomRotate?.disable();
-									}
+										if ( loadedMap.meta.disable_drag_pan ) {
+											map.dragPan.disable();
+											map.touchZoomRotate?.disable();
+										}
 
-									if ( loadedMap.meta.disable_drag_rotate ) {
-										map.dragRotate?.disable();
+										if ( loadedMap.meta.disable_drag_rotate ) {
+											map.dragRotate?.disable();
+										}
 									}
-								}
-							} }
-							style={ { height: '100%', width: '100%' } }
-							latitude={ loadedMap.meta.center_lat || mapDefaults.lat }
-							longitude={ loadedMap.meta.center_lon || mapDefaults.lng }
-							zoom={ loadedMap.meta.initial_zoom || mapDefaults.zoom }
-						>
-							{ loadedLayers &&
-								loadedMap.meta.layers.map( ( layer ) => {
-									const layerOptions = loadedLayers.find(
-										( { id } ) => id === layer.id
-									);
-									if ( layerOptions ) {
-										return renderLayer( {
-											layer: layerOptions.meta,
-											instance: layer,
-										} );
-									}
-								} ) }
-						</Map>
+									applyComposedVisibility();
+								} }
+								style={ { height: '100%', width: '100%' } }
+								latitude={ loadedMap.meta.center_lat || mapDefaults.lat }
+								longitude={ loadedMap.meta.center_lon || mapDefaults.lng }
+								zoom={ loadedMap.meta.initial_zoom || mapDefaults.zoom }
+							>
+								{ ! useComposedPreview && loadedLayers &&
+									loadedMap.meta.layers.map( ( layer ) => {
+										const layerOptions = loadedLayers.find(
+											( { id } ) => id === layer.id
+										);
+										if ( layerOptions ) {
+											return renderLayer( {
+												layer: layerOptions.meta,
+												instance: layer,
+											} );
+										}
+									} ) }
+							</Map>
+						) }
 					</div>
 					<div className="jeo-preview-controls">
 						<p>

--- a/src/js/src/map-blocks/map-preview-layer.js
+++ b/src/js/src/map-blocks/map-preview-layer.js
@@ -1,13 +1,7 @@
 import { memo } from '@wordpress/element';
 import { isEqual } from 'lodash-es';
 
-import { mapboxToken } from '../lib/mapgl-loader';
 import { Layer, Source } from '../lib/mapgl-react';
-
-const MAPBOX_RASTER_ATTRIBUTION =
-	'&copy; <a href="https://www.mapbox.com/about/maps/">Mapbox</a> ' +
-	'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
-	'<a href="https://www.mapbox.com/map-feedback/">Improve this map</a>';
 
 export function renderLayer( { layer, instance } ) {
 	if ( [ 'swappable', 'switchable' ].includes( instance.use ) && ! instance.default ) {
@@ -20,22 +14,7 @@ export function renderLayer( { layer, instance } ) {
 
 	switch ( layer.type ) {
 		case 'mapbox': {
-			const accessToken = options.access_token || mapboxToken;
-
-			const styleId = options.style_id?.replace( 'mapbox://styles/', '' );
-			const styleUrl = `https://api.mapbox.com/styles/v1/${ styleId }/tiles/512/{z}/{x}/{y}@2x?access_token=${ accessToken }`
-
-			return (
-				<Source
-					key={ styleUrl }
-					id={ sourceId }
-					type="raster"
-					tiles={ [ styleUrl ] }
-					attribution={ MAPBOX_RASTER_ATTRIBUTION }
-				>
-					<Layer id={ layerId } type="raster" />
-				</Source>
-			);
+			return null;
 		}
 
 		case 'mapbox-tileset-raster': {

--- a/src/js/src/map-blocks/mapbox-style-preview.js
+++ b/src/js/src/map-blocks/mapbox-style-preview.js
@@ -387,17 +387,17 @@ function useComposedPreviewStyle( {
 			return undefined;
 		}
 
-		let didCancel = false;
 		const abortController = new AbortController();
+		const { signal } = abortController;
 		setState( ( currentState ) => ( {
 			...currentState,
 			error: null,
 			isLoading: true,
 		} ) );
 
-		loadPreview( { signal: abortController.signal } )
+		loadPreview( { signal } )
 			.then( ( { manifest, metadata, style } ) => {
-				if ( didCancel ) {
+				if ( signal.aborted ) {
 					return;
 				}
 
@@ -410,13 +410,11 @@ function useComposedPreviewStyle( {
 				} );
 			} )
 			.catch( ( error ) => {
-				if ( didCancel ) {
+				if ( signal.aborted || isAbortError( error ) ) {
 					return;
 				}
 
-				if ( ! isAbortError( error ) ) {
-					console.warn( warningMessage, error );
-				}
+				console.warn( warningMessage, error );
 				setState( {
 					error,
 					isLoading: false,
@@ -427,7 +425,6 @@ function useComposedPreviewStyle( {
 			} );
 
 		return () => {
-			didCancel = true;
 			abortController.abort();
 		};
 	}, dependencies );
@@ -454,8 +451,8 @@ export function useMapboxStylePreview( styleUrl ) {
 			return undefined;
 		}
 
-		let didCancel = false;
 		const abortController = new AbortController();
+		const { signal } = abortController;
 
 		setState( ( currentState ) => ( {
 			...currentState,
@@ -463,15 +460,15 @@ export function useMapboxStylePreview( styleUrl ) {
 			isLoading: true,
 		} ) );
 
-		fetchJson( styleUrl, { signal: abortController.signal } )
+		fetchJson( styleUrl, { signal } )
 			.then( async ( style ) => {
 				const viewState =
 					getStyleViewState( style ) ||
 					( await getTileJsonViewState( style, styleUrl, {
-						signal: abortController.signal,
+						signal,
 					} ) );
 
-				if ( didCancel ) {
+				if ( signal.aborted ) {
 					return;
 				}
 
@@ -483,13 +480,11 @@ export function useMapboxStylePreview( styleUrl ) {
 				} );
 			} )
 			.catch( ( error ) => {
-				if ( didCancel ) {
+				if ( signal.aborted || isAbortError( error ) ) {
 					return;
 				}
 
-				if ( ! isAbortError( error ) ) {
-					console.warn( 'Unable to load Mapbox style preview.', error );
-				}
+				console.warn( 'Unable to load Mapbox style preview.', error );
 
 				setState( {
 					error,
@@ -500,7 +495,6 @@ export function useMapboxStylePreview( styleUrl ) {
 			} );
 
 		return () => {
-			didCancel = true;
 			abortController.abort();
 		};
 	}, [ styleUrl ] );

--- a/src/js/src/map-blocks/mapbox-style-preview.js
+++ b/src/js/src/map-blocks/mapbox-style-preview.js
@@ -1,0 +1,570 @@
+import { useEffect, useMemo, useState } from '@wordpress/element';
+
+import {
+	mapboxToken,
+	transformRequest as baseTransformRequest,
+} from '../lib/mapgl-loader';
+import {
+	fetchJson,
+	loadComposedStyleData,
+} from '../shared/composed-style-data';
+
+const TOKEN_PLACEHOLDER = '__JEO_MAPBOX_ACCESS_TOKEN__';
+
+function normalizeStyleId( styleId = '' ) {
+	return String( styleId ).replace( 'mapbox://styles/', '' ).replace( /^\/+/, '' );
+}
+
+function getLayerMeta( layer ) {
+	return layer?.meta || layer || {};
+}
+
+function getLayerTypeOptions( layer ) {
+	return getLayerMeta( layer )?.layer_type_options || {};
+}
+
+function getLayerId( layer ) {
+	return Number.parseInt( layer?.id ?? layer?.layerPostId, 10 );
+}
+
+function getLayerSettingId( layer ) {
+	return Number.parseInt( layer?.id ?? layer?.layer_post_id, 10 );
+}
+
+function shouldDisplayLayerInstance( instance ) {
+	return ! (
+		[ 'swappable', 'switchable' ].includes( instance?.use ) &&
+		! instance?.default
+	);
+}
+
+function getMapInstance( map ) {
+	if ( typeof map?.getMap === 'function' ) {
+		return map.getMap();
+	}
+
+	return map;
+}
+
+function getMapboxOwner( layer ) {
+	const options = getLayerTypeOptions( layer );
+	const styleId = normalizeStyleId( options.style_id || '' );
+	const tilesetId = String( options.tileset_id || '' ).replace(
+		'mapbox://',
+		''
+	);
+
+	return styleId.split( '/' )[ 0 ] || tilesetId.split( '.' )[ 0 ] || '';
+}
+
+function prepareEditorStyle( style ) {
+	if ( ! style || typeof style !== 'object' ) {
+		return style;
+	}
+
+	const { projection, ...preparedStyle } = style;
+
+	return {
+		...preparedStyle,
+	};
+}
+
+function getAccessTokenFromStyleUrl( styleUrl ) {
+	try {
+		return new URL( styleUrl ).searchParams.get( 'access_token' ) || mapboxToken || '';
+	} catch ( error ) {
+		return mapboxToken || '';
+	}
+}
+
+function getViewStateFromCenter( center, fallbackZoom = null ) {
+	if ( ! Array.isArray( center ) || center.length < 2 ) {
+		return null;
+	}
+
+	const longitude = Number.parseFloat( center[ 0 ] );
+	const latitude = Number.parseFloat( center[ 1 ] );
+	const zoom = Number.parseFloat( center[ 2 ] ?? fallbackZoom );
+
+	if ( ! Number.isFinite( longitude ) || ! Number.isFinite( latitude ) ) {
+		return null;
+	}
+
+	return {
+		longitude,
+		latitude,
+		zoom: Number.isFinite( zoom ) ? zoom : undefined,
+	};
+}
+
+function getViewStateFromBounds( bounds, fallbackZoom = null ) {
+	if ( ! Array.isArray( bounds ) || bounds.length < 4 ) {
+		return null;
+	}
+
+	const west = Number.parseFloat( bounds[ 0 ] );
+	const south = Number.parseFloat( bounds[ 1 ] );
+	const east = Number.parseFloat( bounds[ 2 ] );
+	const north = Number.parseFloat( bounds[ 3 ] );
+
+	if (
+		! Number.isFinite( west ) ||
+		! Number.isFinite( south ) ||
+		! Number.isFinite( east ) ||
+		! Number.isFinite( north )
+	) {
+		return null;
+	}
+
+	return {
+		longitude: ( west + east ) / 2,
+		latitude: ( south + north ) / 2,
+		zoom: Number.isFinite( Number.parseFloat( fallbackZoom ) )
+			? Number.parseFloat( fallbackZoom )
+			: undefined,
+	};
+}
+
+function getStyleViewState( style ) {
+	return getViewStateFromCenter( style?.center, style?.zoom );
+}
+
+function getSourceTilesetIds( source ) {
+	const sourceUrl = String( source?.url || '' );
+
+	if ( ! sourceUrl.startsWith( 'mapbox://' ) ) {
+		return [];
+	}
+
+	return sourceUrl
+		.replace( 'mapbox://', '' )
+		.split( ',' )
+		.map( ( tilesetId ) => tilesetId.trim() )
+		.filter( Boolean );
+}
+
+async function getTileJsonViewState( style, styleUrl ) {
+	const sourceTilesets = Object.values( style?.sources || {} )
+		.flatMap( getSourceTilesetIds );
+	const preferredTilesets =
+		sourceTilesets.filter( ( tilesetId ) => ! tilesetId.startsWith( 'mapbox.' ) );
+	const tilesets = preferredTilesets.length ? preferredTilesets : sourceTilesets;
+	const accessToken = getAccessTokenFromStyleUrl( styleUrl );
+
+	for ( const tilesetId of tilesets ) {
+		if ( ! accessToken ) {
+			continue;
+		}
+
+		const url = new URL(
+			`https://api.mapbox.com/v4/${ tilesetId }.json`
+		);
+		url.searchParams.set( 'access_token', accessToken );
+
+		try {
+			const tileJson = await fetchJson( url.toString() );
+			const viewState =
+				getViewStateFromCenter( tileJson.center ) ||
+				getViewStateFromBounds(
+					tileJson.bounds,
+					tileJson.center?.[ 2 ] || tileJson.minzoom
+				);
+
+			if ( viewState ) {
+				return viewState;
+			}
+		} catch ( error ) {
+			// Try the next tileset; the style itself can still render without this.
+		}
+	}
+
+	return null;
+}
+
+export function isAbortError( error ) {
+	const message = String( error?.message || error || '' );
+
+	return /aborted|aborterror/i.test( message );
+}
+
+export function handleEditorMapPreviewError( event ) {
+	const error = event?.error || event;
+
+	if ( isAbortError( error ) ) {
+		return;
+	}
+
+	console.warn( 'Map preview error.', error );
+}
+
+export function getMapboxStyleUrl( options = {} ) {
+	const styleId = normalizeStyleId( options.style_id || '' );
+
+	if ( ! styleId ) {
+		return null;
+	}
+
+	const url = new URL( `https://api.mapbox.com/styles/v1/${ styleId }` );
+	const accessToken = options.access_token || mapboxToken || '';
+
+	if ( accessToken ) {
+		url.searchParams.set( 'access_token', accessToken );
+	}
+
+	return url.toString();
+}
+
+export function hasMapboxStyleLayers( layers = [] ) {
+	return layers.some( ( layer ) => getLayerMeta( layer )?.type === 'mapbox' );
+}
+
+export function getVisibleMapboxStyleUrl( layerSettings = [], loadedLayers = [] ) {
+	for ( const instance of layerSettings ) {
+		if ( ! shouldDisplayLayerInstance( instance ) ) {
+			continue;
+		}
+
+		const layer = loadedLayers.find(
+			( loadedLayer ) => getLayerId( loadedLayer ) === getLayerSettingId( instance )
+		);
+
+		if ( getLayerMeta( layer )?.type !== 'mapbox' ) {
+			continue;
+		}
+
+		return getMapboxStyleUrl( getLayerTypeOptions( layer ) );
+	}
+
+	return null;
+}
+
+export function useEditorMapboxTransformRequest( layers = [] ) {
+	const customTokens = useMemo( () => {
+		const tokens = {};
+
+		layers.forEach( ( layer ) => {
+			const options = getLayerTypeOptions( layer );
+			const accessToken = options.access_token;
+			const owner = getMapboxOwner( layer );
+
+			if ( accessToken && owner ) {
+				tokens[ owner ] = accessToken;
+			}
+		} );
+
+		return tokens;
+	}, [ JSON.stringify( layers.map( ( layer ) => {
+		const options = getLayerTypeOptions( layer );
+		return {
+			id: getLayerId( layer ),
+			type: getLayerMeta( layer )?.type,
+			styleId: options.style_id,
+			tilesetId: options.tileset_id,
+			accessToken: options.access_token,
+		};
+	} ) ) ] );
+
+	return useMemo( () => {
+		return ( url, resourceType ) => {
+			let nextUrl = String( url || '' );
+			let transformed = { url: nextUrl };
+
+			if ( nextUrl.includes( TOKEN_PLACEHOLDER ) ) {
+				nextUrl = nextUrl
+					.split( TOKEN_PLACEHOLDER )
+					.join( encodeURIComponent( mapboxToken || '' ) );
+			}
+
+			if ( typeof baseTransformRequest === 'function' ) {
+				transformed = baseTransformRequest( nextUrl, resourceType ) || {
+					url: nextUrl,
+				};
+				nextUrl = transformed.url || nextUrl;
+			}
+
+			for ( const owner of Object.keys( customTokens ) ) {
+				if (
+					! nextUrl.includes( `${ owner }/` ) &&
+					! nextUrl.includes( `${ owner }.` )
+				) {
+					continue;
+				}
+
+				try {
+					const parsedUrl = new URL( nextUrl );
+					parsedUrl.searchParams.set(
+						'access_token',
+						customTokens[ owner ]
+					);
+					nextUrl = parsedUrl.toString();
+				} catch ( error ) {
+					// Keep the URL produced by the base transformer.
+				}
+			}
+
+			return {
+				...transformed,
+				url: nextUrl,
+			};
+		};
+	}, [ customTokens ] );
+}
+
+export function useComposedMapPreviewStyle( {
+	enabled = true,
+	forceRefresh = false,
+	mapId,
+	refreshKey = '',
+} ) {
+	return useComposedPreviewStyle( {
+		dependencies: [ enabled, forceRefresh, mapId, refreshKey ],
+		enabled:
+			enabled &&
+			Boolean( mapId ) &&
+			Boolean( window.jeoMapVars?.composedStyleUrlBase ),
+		loadPreview: () => loadComposedStyleData( {
+			forceRefresh,
+			includeStyle: true,
+			mapId,
+		} ),
+		warningMessage:
+			'Unable to load composed Mapbox style in the editor preview.',
+	} );
+}
+
+export function useComposedPayloadPreviewStyle( {
+	enabled = true,
+	payload,
+	refreshKey = '',
+} ) {
+	const payloadKey = useMemo( () => JSON.stringify( payload || null ), [ payload ] );
+
+	return useComposedPreviewStyle( {
+		dependencies: [ enabled, payloadKey, refreshKey ],
+		enabled:
+			enabled &&
+			Boolean( payload ) &&
+			Boolean( window.jeoMapVars?.composedStyleComposeUrl ),
+		loadPreview: () => loadComposedStyleData( {
+			includeStyle: true,
+			payload,
+		} ),
+		warningMessage:
+			'Unable to load composed Mapbox style payload in the editor preview.',
+	} );
+}
+
+function useComposedPreviewStyle( {
+	dependencies,
+	enabled,
+	loadPreview,
+	warningMessage,
+} ) {
+	const [ state, setState ] = useState( {
+		error: null,
+		isLoading: false,
+		manifest: null,
+		metadata: null,
+		style: null,
+	} );
+
+	useEffect( () => {
+		if ( ! enabled ) {
+			setState( {
+				error: null,
+				isLoading: false,
+				manifest: null,
+				metadata: null,
+				style: null,
+			} );
+			return undefined;
+		}
+
+		let didCancel = false;
+		setState( ( currentState ) => ( {
+			...currentState,
+			error: null,
+			isLoading: true,
+		} ) );
+
+		loadPreview()
+			.then( ( { manifest, metadata, style } ) => {
+				if ( didCancel ) {
+					return;
+				}
+
+				setState( {
+					error: null,
+					isLoading: false,
+					manifest,
+					metadata,
+					style: prepareEditorStyle( style ),
+				} );
+			} )
+			.catch( ( error ) => {
+				if ( didCancel ) {
+					return;
+				}
+
+				console.warn( warningMessage, error );
+				setState( {
+					error,
+					isLoading: false,
+					manifest: null,
+					metadata: null,
+					style: null,
+				} );
+			} );
+
+		return () => {
+			didCancel = true;
+		};
+	}, dependencies );
+
+	return state;
+}
+
+export function useMapboxStylePreview( styleUrl ) {
+	const [ state, setState ] = useState( {
+		error: null,
+		isLoading: false,
+		style: null,
+		viewState: null,
+	} );
+
+	useEffect( () => {
+		if ( ! styleUrl ) {
+			setState( {
+				error: null,
+				isLoading: false,
+				style: null,
+				viewState: null,
+			} );
+			return undefined;
+		}
+
+		let didCancel = false;
+
+		setState( ( currentState ) => ( {
+			...currentState,
+			error: null,
+			isLoading: true,
+		} ) );
+
+		fetchJson( styleUrl )
+			.then( async ( style ) => {
+				const viewState =
+					getStyleViewState( style ) ||
+					( await getTileJsonViewState( style, styleUrl ) );
+
+				if ( didCancel ) {
+					return;
+				}
+
+				setState( {
+					error: null,
+					isLoading: false,
+					style: prepareEditorStyle( style ),
+					viewState,
+				} );
+			} )
+			.catch( ( error ) => {
+				if ( didCancel ) {
+					return;
+				}
+
+				if ( ! isAbortError( error ) ) {
+					console.warn( 'Unable to load Mapbox style preview.', error );
+				}
+
+				setState( {
+					error,
+					isLoading: false,
+					style: null,
+					viewState: null,
+				} );
+			} );
+
+		return () => {
+			didCancel = true;
+		};
+	}, [ styleUrl ] );
+
+	return state;
+}
+
+export function applyComposedVisibilityFromSettings(
+	map,
+	manifest,
+	layerSettings = []
+) {
+	const mapInstance = getMapInstance( map );
+
+	if ( ! mapInstance || ! manifest?.layers ) {
+		return;
+	}
+
+	const settingsByLayerId = new Map(
+		layerSettings.map( ( layer ) => [ String( getLayerSettingId( layer ) ), layer ] )
+	);
+
+	manifest.layers.forEach( ( manifestLayer ) => {
+		const setting = settingsByLayerId.get(
+			String( manifestLayer.layerPostId )
+		);
+		const visible = setting
+			? shouldDisplayLayerInstance( setting )
+			: manifestLayer.initialVisible;
+
+		( manifestLayer.compositeLayers || [] ).forEach( ( compositeLayer ) => {
+			if ( ! mapInstance.getLayer( compositeLayer.compositeId ) ) {
+				return;
+			}
+
+			mapInstance.setLayoutProperty(
+				compositeLayer.compositeId,
+				'visibility',
+				visible && compositeLayer.visibleWhenLayerOn !== false
+					? 'visible'
+					: 'none'
+			);
+		} );
+	} );
+}
+
+export function applyComposedVisibilityFromSelection(
+	map,
+	manifest,
+	selectedLayers = []
+) {
+	const mapInstance = getMapInstance( map );
+
+	if ( ! mapInstance || ! manifest?.layers ) {
+		return;
+	}
+
+	const selectedLayerIds = new Set(
+		selectedLayers
+			.map( ( layer ) => getLayerSettingId( layer ) )
+			.filter( Number.isFinite )
+			.map( String )
+	);
+
+	manifest.layers.forEach( ( manifestLayer ) => {
+		const visible = selectedLayerIds.has( String( manifestLayer.layerPostId ) );
+
+		( manifestLayer.compositeLayers || [] ).forEach( ( compositeLayer ) => {
+			if ( ! mapInstance.getLayer( compositeLayer.compositeId ) ) {
+				return;
+			}
+
+			mapInstance.setLayoutProperty(
+				compositeLayer.compositeId,
+				'visibility',
+				visible && compositeLayer.visibleWhenLayerOn !== false
+					? 'visible'
+					: 'none'
+			);
+		} );
+	} );
+}

--- a/src/js/src/map-blocks/mapbox-style-preview.js
+++ b/src/js/src/map-blocks/mapbox-style-preview.js
@@ -270,9 +270,10 @@ export function useEditorMapboxTransformRequest( layers = [] ) {
 			let transformed = { url: nextUrl };
 
 			if ( nextUrl.includes( TOKEN_PLACEHOLDER ) ) {
-				nextUrl = nextUrl
-					.split( TOKEN_PLACEHOLDER )
-					.join( encodeURIComponent( mapboxToken || '' ) );
+				nextUrl = nextUrl.replaceAll(
+				    TOKEN_PLACEHOLDER,
+					encodeURIComponent( mapboxToken || '' )
+				);
 			}
 
 			if ( typeof baseTransformRequest === 'function' ) {

--- a/src/js/src/map-blocks/mapbox-style-preview.js
+++ b/src/js/src/map-blocks/mapbox-style-preview.js
@@ -143,7 +143,7 @@ function getSourceTilesetIds( source ) {
 		.filter( Boolean );
 }
 
-async function getTileJsonViewState( style, styleUrl ) {
+async function getTileJsonViewState( style, styleUrl, options = {} ) {
 	const sourceTilesets = Object.values( style?.sources || {} )
 		.flatMap( getSourceTilesetIds );
 	const preferredTilesets =
@@ -162,7 +162,7 @@ async function getTileJsonViewState( style, styleUrl ) {
 		url.searchParams.set( 'access_token', accessToken );
 
 		try {
-			const tileJson = await fetchJson( url.toString() );
+			const tileJson = await fetchJson( url.toString(), options );
 			const viewState =
 				getViewStateFromCenter( tileJson.center ) ||
 				getViewStateFromBounds(
@@ -174,6 +174,10 @@ async function getTileJsonViewState( style, styleUrl ) {
 				return viewState;
 			}
 		} catch ( error ) {
+			if ( isAbortError( error ) ) {
+				throw error;
+			}
+
 			// Try the next tileset; the style itself can still render without this.
 		}
 	}
@@ -184,7 +188,7 @@ async function getTileJsonViewState( style, styleUrl ) {
 export function isAbortError( error ) {
 	const message = String( error?.message || error || '' );
 
-	return /aborted|aborterror/i.test( message );
+	return error?.name === 'AbortError' || /aborted|aborterror/i.test( message );
 }
 
 export function handleEditorMapPreviewError( event ) {
@@ -271,7 +275,7 @@ export function useEditorMapboxTransformRequest( layers = [] ) {
 
 			if ( nextUrl.includes( TOKEN_PLACEHOLDER ) ) {
 				nextUrl = nextUrl.replaceAll(
-				    TOKEN_PLACEHOLDER,
+					TOKEN_PLACEHOLDER,
 					encodeURIComponent( mapboxToken || '' )
 				);
 			}
@@ -323,10 +327,11 @@ export function useComposedMapPreviewStyle( {
 			enabled &&
 			Boolean( mapId ) &&
 			Boolean( window.jeoMapVars?.composedStyleUrlBase ),
-		loadPreview: () => loadComposedStyleData( {
+		loadPreview: ( { signal } ) => loadComposedStyleData( {
 			forceRefresh,
 			includeStyle: true,
 			mapId,
+			signal,
 		} ),
 		warningMessage:
 			'Unable to load composed Mapbox style in the editor preview.',
@@ -346,9 +351,10 @@ export function useComposedPayloadPreviewStyle( {
 			enabled &&
 			Boolean( payload ) &&
 			Boolean( window.jeoMapVars?.composedStyleComposeUrl ),
-		loadPreview: () => loadComposedStyleData( {
+		loadPreview: ( { signal } ) => loadComposedStyleData( {
 			includeStyle: true,
 			payload,
+			signal,
 		} ),
 		warningMessage:
 			'Unable to load composed Mapbox style payload in the editor preview.',
@@ -382,13 +388,14 @@ function useComposedPreviewStyle( {
 		}
 
 		let didCancel = false;
+		const abortController = new AbortController();
 		setState( ( currentState ) => ( {
 			...currentState,
 			error: null,
 			isLoading: true,
 		} ) );
 
-		loadPreview()
+		loadPreview( { signal: abortController.signal } )
 			.then( ( { manifest, metadata, style } ) => {
 				if ( didCancel ) {
 					return;
@@ -407,7 +414,9 @@ function useComposedPreviewStyle( {
 					return;
 				}
 
-				console.warn( warningMessage, error );
+				if ( ! isAbortError( error ) ) {
+					console.warn( warningMessage, error );
+				}
 				setState( {
 					error,
 					isLoading: false,
@@ -419,6 +428,7 @@ function useComposedPreviewStyle( {
 
 		return () => {
 			didCancel = true;
+			abortController.abort();
 		};
 	}, dependencies );
 
@@ -445,6 +455,7 @@ export function useMapboxStylePreview( styleUrl ) {
 		}
 
 		let didCancel = false;
+		const abortController = new AbortController();
 
 		setState( ( currentState ) => ( {
 			...currentState,
@@ -452,11 +463,13 @@ export function useMapboxStylePreview( styleUrl ) {
 			isLoading: true,
 		} ) );
 
-		fetchJson( styleUrl )
+		fetchJson( styleUrl, { signal: abortController.signal } )
 			.then( async ( style ) => {
 				const viewState =
 					getStyleViewState( style ) ||
-					( await getTileJsonViewState( style, styleUrl ) );
+					( await getTileJsonViewState( style, styleUrl, {
+						signal: abortController.signal,
+					} ) );
 
 				if ( didCancel ) {
 					return;
@@ -488,6 +501,7 @@ export function useMapboxStylePreview( styleUrl ) {
 
 		return () => {
 			didCancel = true;
+			abortController.abort();
 		};
 	}, [ styleUrl ] );
 

--- a/src/js/src/map-blocks/onetime-map-editor.js
+++ b/src/js/src/map-blocks/onetime-map-editor.js
@@ -1,5 +1,6 @@
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { Button, PanelBody } from '@wordpress/components';
+import { Button, PanelBody, Spinner } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -11,12 +12,21 @@ import MapPanel from './map-panel';
 import LayersPanel from './layers-panel';
 import PostsSelector from '../posts-selector';
 import { useRecordsByIds } from '../shared/rest-records';
+import {
+	applyComposedVisibilityFromSettings,
+	handleEditorMapPreviewError,
+	hasMapboxStyleLayers,
+	useComposedPayloadPreviewStyle,
+	useEditorMapboxTransformRequest,
+} from './mapbox-style-preview';
 import './onetime-map-editor.css';
 
 const { map_defaults: mapDefaults } = window.jeo_settings;
 
-export default function OnetimeMapEditor ( { attributes, setAttributes } ) {
+export default function OnetimeMapEditor ( { attributes, setAttributes, clientId } ) {
 	const blockProps = useBlockProps();
+	const postId = useSelect( ( select ) =>
+		select( 'core/editor' ).getCurrentPostId(), [] );
 	const [ modal, setModal ] = useState( false );
 	const [ key, setKey ] = useState( 0 );
 	const normalizedAttributes = useMemo( () => {
@@ -56,12 +66,59 @@ export default function OnetimeMapEditor ( { attributes, setAttributes } ) {
 		[ normalizedAttributes.layers ]
 	);
 
-	const { records: loadedLayers = [], isLoading: loadingLayers } = useRecordsByIds( {
+	const {
+		records: loadedLayers = [],
+		isLoading: loadingLayers,
+		hasResolved: hasResolvedLayers,
+	} = useRecordsByIds( {
 		path: '/jeo/v1/map-layer',
 		ids: layerIds,
 		enabled: layerIds.length > 0,
 		query: { context: 'edit' },
 	} );
+	const hasMapboxLayers = hasMapboxStyleLayers( loadedLayers );
+	const composedPayload = useMemo( () => ( {
+		scope: 'preview',
+		kind: 'onetime-map',
+		postId,
+		blockId: clientId,
+		layers: normalizedAttributes.layers || [],
+	} ), [ postId, clientId, layerSettingsKey ] );
+	const composedPreview = useComposedPayloadPreviewStyle( {
+		enabled: hasMapboxLayers,
+		payload: composedPayload,
+		refreshKey: layerSettingsKey,
+	} );
+	const useComposedPreview = Boolean(
+		hasMapboxLayers && composedPreview.style
+	);
+	const isPreparingLayerPreview = Boolean(
+		layerIds.length > 0 && ( loadingLayers || ! hasResolvedLayers )
+	);
+	const isPreparingComposedPreview = Boolean(
+		! isPreparingLayerPreview &&
+			hasMapboxLayers &&
+			! composedPreview.style &&
+			! composedPreview.error
+	);
+	const transformRequest = useEditorMapboxTransformRequest( loadedLayers );
+	const applyComposedVisibility = useCallback( () => {
+		if ( useComposedPreview ) {
+			applyComposedVisibilityFromSettings(
+				mapRef.current,
+				composedPreview.manifest,
+				normalizedAttributes.layers || []
+			);
+		}
+	}, [
+		composedPreview.manifest,
+		layerSettingsKey,
+		useComposedPreview,
+	] );
+
+	useEffect( () => {
+		applyComposedVisibility();
+	}, [ applyComposedVisibility ] );
 
 	const setPanLimitsFromMap = () => {
 		const { current: map } = mapRef;
@@ -116,37 +173,52 @@ export default function OnetimeMapEditor ( { attributes, setAttributes } ) {
 			</InspectorControls>
 
 			<div className="jeo-preview-area">
-				<Map
-					key={ `${ key }:${ currentZoom }:${ layerSettingsKey }` }
-					ref={ mapRef }
-					style={ { height: '100%', width: '100%' } }
-					latitude={ normalizedAttributes.center_lat }
-					longitude={ normalizedAttributes.center_lon }
-					zoom={ currentZoom || mapDefaults.zoom }
-					onMove={ ( { viewState } ) => {
-						setAttributes( {
-							center_lat: viewState.latitude,
-							center_lon: viewState.longitude,
-						} );
-					} }
-					onZoom={ ( { viewState } ) => {
-						const zoom = Math.round( viewState.zoom * 10 ) / 10;
-						setAttributes( { [ zoomState ]: zoom } );
-					} }
-				>
-					{ loadedLayers &&
-						normalizedAttributes.layers.map( ( layer ) => {
-							const layerRecord = loadedLayers.find(
-								( { id } ) => id === layer.id
-							);
+				{ ( isPreparingLayerPreview || isPreparingComposedPreview ) && <Spinner /> }
+				{ ! isPreparingLayerPreview && ! isPreparingComposedPreview && (
+					<Map
+						key={ `${ key }:${ currentZoom }:${ layerSettingsKey }:${ composedPreview.metadata?.hash || 'default' }` }
+						ref={ mapRef }
+						mapStyle={ useComposedPreview ? composedPreview.style : undefined }
+						transformRequest={ transformRequest }
+						onError={ handleEditorMapPreviewError }
+						onStyleData={ applyComposedVisibility }
+						style={ { height: '100%', width: '100%' } }
+						latitude={ normalizedAttributes.center_lat }
+						longitude={ normalizedAttributes.center_lon }
+						zoom={ currentZoom || mapDefaults.zoom }
+						onMove={ ( { viewState } ) => {
+							setAttributes( {
+								center_lat: viewState.latitude,
+								center_lon: viewState.longitude,
+							} );
+						} }
+						onZoom={ ( { viewState } ) => {
+							const zoom = Math.round( viewState.zoom * 10 ) / 10;
+							setAttributes( { [ zoomState ]: zoom } );
+						} }
+					>
+						{ loadedLayers &&
+							normalizedAttributes.layers.map( ( layer ) => {
+								const layerRecord = loadedLayers.find(
+									( { id } ) => id === layer.id
+								);
 
-							if ( ! layerRecord?.meta ) {
-								return null;
-							}
+								if ( ! layerRecord?.meta ) {
+									return null;
+								}
 
-							return renderLayer( { layer: layerRecord.meta, instance: layer } );
-						} ) }
-				</Map>
+								if ( useComposedPreview ) {
+									return null;
+								}
+
+								if ( hasMapboxLayers && layerRecord.meta.type === 'mapbox' ) {
+									return null;
+								}
+
+								return renderLayer( { layer: layerRecord.meta, instance: layer } );
+							} ) }
+					</Map>
+				) }
 			</div>
 
 			<div className="jeo-preview-controls">

--- a/src/js/src/map-blocks/storymap-editor.js
+++ b/src/js/src/map-blocks/storymap-editor.js
@@ -30,7 +30,7 @@ import { Button, Icon, Panel, PanelBody, Spinner } from '@wordpress/components';
 import { chevronDown, chevronUp, lock, unlock, seen, trash, plus } from '@wordpress/icons';
 import { useEntityRecord } from '@wordpress/core-data';
 import { useSelect, select } from '@wordpress/data';
-import { Fragment, useEffect, useId, useMemo, useRef, useState } from '@wordpress/element';
+import { Fragment, useCallback, useEffect, useId, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '../shared/wp-form-controls';
 
@@ -50,6 +50,13 @@ import {
 import { useRecordsByIds } from '../shared/rest-records';
 import { computeInlineEnd } from '../shared/direction';
 import { getCKEditorLanguage } from '../shared/locale';
+import {
+	applyComposedVisibilityFromSelection,
+	handleEditorMapPreviewError,
+	hasMapboxStyleLayers,
+	useComposedMapPreviewStyle,
+	useEditorMapboxTransformRequest,
+} from './mapbox-style-preview';
 import './map-editor.css';
 import './storymap-editor.scss';
 
@@ -556,6 +563,31 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 		enabled: layerIds.length > 0,
 		query: { context: 'edit' },
 	} );
+	const previewLayers = attributes.navigateMapLayers?.length
+		? attributes.navigateMapLayers
+		: loadedLayers;
+	const hasMapboxLayers = hasMapboxStyleLayers( previewLayers );
+	const composedPreview = useComposedMapPreviewStyle( {
+		enabled: hasMapboxLayers,
+		mapId: attributes.map_id,
+		refreshKey: layerIds.join( ',' ),
+	} );
+	const useComposedPreview = Boolean(
+		hasMapboxLayers && composedPreview.style
+	);
+	const isPreparingLayerPreview = Boolean(
+		! attributes.navigateMapLayers?.length &&
+			layerIds.length > 0 &&
+			( loadingLayers || ! layersResolved )
+	);
+	const isPreparingComposedPreview = Boolean(
+		! isPreparingLayerPreview &&
+			hasMapboxLayers &&
+			! composedPreview.style &&
+			! composedPreview.error
+	);
+	const shouldRenderMap = ! isPreparingLayerPreview && ! isPreparingComposedPreview;
+	const transformRequest = useEditorMapboxTransformRequest( previewLayers );
 	const currentSlidePreviewKey = useMemo(
 		() =>
 			JSON.stringify( {
@@ -566,6 +598,21 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 			} ),
 		[ attributes.slides, attributes.navigateMapLayers, currentSlideIndex ]
 	);
+	const currentSlideSelectedLayers =
+		attributes.slides?.[ currentSlideIndex ]?.selectedLayers || [];
+	const applyCurrentSlideComposedVisibility = useCallback( () => {
+		if ( useComposedPreview ) {
+			applyComposedVisibilityFromSelection(
+				mapRef.current,
+				composedPreview.manifest,
+				currentSlideSelectedLayers
+			);
+		}
+	}, [
+		composedPreview.manifest,
+		currentSlidePreviewKey,
+		useComposedPreview,
+	] );
 
 	useEffect( () => {
 		const currentSlide = attributes.slides?.[ currentSlideIndex ];
@@ -577,6 +624,10 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 			pitch: currentSlide?.pitch || 0,
 		} );
 	}, [ attributes.slides, currentSlideIndex, setViewState ] );
+
+	useEffect( () => {
+		applyCurrentSlideComposedVisibility();
+	}, [ applyCurrentSlideComposedVisibility ] );
 
 	useEffect( () => {
 		if ( ! attributes.slides?.length ) {
@@ -801,37 +852,44 @@ export default function StoryMapEditor ( { attributes, setAttributes } ) {
 			{ attributes.map_id && loadedMap && (
 				<Fragment>
 					<div className="jeo-preview-area">
-						<MapPreview
-							ref={ mapRef }
-							key={ `${ key }:${ currentSlideIndex }:${ currentSlidePreviewKey }` }
-							controls={ `top-${inlineEnd}` }
-							fullscreen={ loadedMap.meta.enable_fullscreen }
-							style={ { height: '85vh' } }
-							latitude={ viewState.latitude }
-							longitude={ viewState.longitude }
-							zoom={ viewState.zoom }
-							bearing={ viewState.bearing }
-							pitch={ viewState.pitch }
-							onMove={ ( event ) => {
-								setViewState( event.viewState );
-							} }
-						>
-							{ attributes.slides[ currentSlideIndex ].selectedLayers.map(
-								( layer ) => {
-									if(attributes.navigateMapLayers) {
-										const layerOptions = attributes.navigateMapLayers.find(
-											( item ) => layerIdsMatch( item, layer )
-										);
-										if ( layerOptions ) {
-											return renderLayer( {
-												layer: layerOptions.meta,
-												instance: layer,
-											} );
+						{ ! shouldRenderMap && <Spinner /> }
+						{ shouldRenderMap && (
+							<MapPreview
+								ref={ mapRef }
+								key={ `${ key }:${ currentSlideIndex }:${ currentSlidePreviewKey }:${ composedPreview.metadata?.hash || 'default' }` }
+								controls={ `top-${inlineEnd}` }
+								fullscreen={ loadedMap.meta.enable_fullscreen }
+								mapStyle={ useComposedPreview ? composedPreview.style : undefined }
+								style={ { height: '85vh' } }
+								transformRequest={ transformRequest }
+								latitude={ viewState.latitude }
+								longitude={ viewState.longitude }
+								zoom={ viewState.zoom }
+								bearing={ viewState.bearing }
+								pitch={ viewState.pitch }
+								onError={ handleEditorMapPreviewError }
+								onStyleData={ applyCurrentSlideComposedVisibility }
+								onMove={ ( event ) => {
+									setViewState( event.viewState );
+								} }
+							>
+								{ ! useComposedPreview && attributes.slides[ currentSlideIndex ].selectedLayers.map(
+									( layer ) => {
+										if(attributes.navigateMapLayers) {
+											const layerOptions = attributes.navigateMapLayers.find(
+												( item ) => layerIdsMatch( item, layer )
+											);
+											if ( layerOptions ) {
+												return renderLayer( {
+													layer: layerOptions.meta,
+													instance: layer,
+												} );
+											}
 										}
 									}
-								}
-							) }
-						</MapPreview>
+								) }
+							</MapPreview>
+						) }
 					</div>
 					<div className="storymap-controls">
 						{ showStorySettings && (

--- a/src/js/src/map-blocks/storymap-editor.scss
+++ b/src/js/src/map-blocks/storymap-editor.scss
@@ -17,6 +17,8 @@
 			border-radius: 7px;
 			box-sizing: border-box;
 			box-shadow: 1px 3px 4px 0 rgba(0,0,0,.1);
+			contain: paint;
+			transform: translateZ(0);
 
 			.heading {
 				display: flex;

--- a/src/js/src/shared/composed-style-data.js
+++ b/src/js/src/shared/composed-style-data.js
@@ -1,0 +1,122 @@
+const DEFAULT_COMPOSITION_UNAVAILABLE_MESSAGE =
+	'Mapbox style composition is unavailable.';
+const DEFAULT_EMPTY_MANIFEST_MESSAGE =
+	'Mapbox style composition did not return renderable layers.';
+
+function getJeoMapVars() {
+	return globalThis.jeoMapVars || {};
+}
+
+function getJsonHeaders( url ) {
+	const { nonce } = getJeoMapVars();
+
+	if ( ! nonce ) {
+		return {};
+	}
+
+	try {
+		const requestOrigin = new URL( url, globalThis.location?.href ).origin;
+		const currentOrigin = globalThis.location?.origin;
+
+		return requestOrigin === currentOrigin
+			? {
+					'X-WP-Nonce': nonce,
+			  }
+			: {};
+	} catch ( error ) {
+		return {};
+	}
+}
+
+function addQueryParams( url, params = {} ) {
+	try {
+		const nextUrl = new URL( url, globalThis.location?.href );
+
+		Object.entries( params ).forEach( ( [ key, value ] ) => {
+			if ( value !== undefined && value !== null && value !== false ) {
+				nextUrl.searchParams.set( key, String( value ) );
+			}
+		} );
+
+		return nextUrl.toString();
+	} catch ( error ) {
+		return url;
+	}
+}
+
+export function fetchJson( url, options = {} ) {
+	return fetch( url, {
+		...options,
+		headers: {
+			...getJsonHeaders( url ),
+			...( options.headers || {} ),
+		},
+	} ).then( ( response ) => {
+		if ( ! response.ok ) {
+			throw new Error( `${ response.status } ${ response.statusText }` );
+		}
+
+		return response.json();
+	} );
+}
+
+export function postJson( url, data, options = {} ) {
+	return fetchJson( url, {
+		...options,
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...( options.headers || {} ),
+		},
+		body: JSON.stringify( data ),
+	} );
+}
+
+export async function loadComposedStyleData( {
+	forceRefresh = false,
+	includeStyle = false,
+	mapId,
+	payload,
+	unavailableMessage = DEFAULT_COMPOSITION_UNAVAILABLE_MESSAGE,
+	emptyManifestMessage = DEFAULT_EMPTY_MANIFEST_MESSAGE,
+} = {} ) {
+	const { composedStyleComposeUrl, composedStyleUrlBase } = getJeoMapVars();
+
+	let metadata;
+	if ( payload ) {
+		if ( ! composedStyleComposeUrl ) {
+			throw new Error( unavailableMessage );
+		}
+
+		metadata = await postJson( composedStyleComposeUrl, payload );
+	} else {
+		if ( ! mapId || ! composedStyleUrlBase ) {
+			throw new Error( unavailableMessage );
+		}
+
+		const metadataUrl = addQueryParams(
+			`${ composedStyleUrlBase }${ mapId }`,
+			forceRefresh ? { refresh: true } : {}
+		);
+		metadata = await fetchJson( metadataUrl );
+	}
+
+	if ( ! metadata?.enabled || ! metadata.style || ! metadata.manifest ) {
+		throw new Error( metadata?.error || unavailableMessage );
+	}
+
+	const [ manifest, style ] = await Promise.all( [
+		fetchJson( metadata.manifest ),
+		includeStyle ? fetchJson( metadata.style ) : Promise.resolve( null ),
+	] );
+
+	if ( ! manifest?.layers?.length ) {
+		throw new Error( emptyManifestMessage );
+	}
+
+	return {
+		manifest,
+		metadata,
+		style,
+	};
+}

--- a/src/js/src/shared/composed-style-data.js
+++ b/src/js/src/shared/composed-style-data.js
@@ -77,6 +77,7 @@ export async function loadComposedStyleData( {
 	includeStyle = false,
 	mapId,
 	payload,
+	signal,
 	unavailableMessage = DEFAULT_COMPOSITION_UNAVAILABLE_MESSAGE,
 	emptyManifestMessage = DEFAULT_EMPTY_MANIFEST_MESSAGE,
 } = {} ) {
@@ -88,7 +89,7 @@ export async function loadComposedStyleData( {
 			throw new Error( unavailableMessage );
 		}
 
-		metadata = await postJson( composedStyleComposeUrl, payload );
+		metadata = await postJson( composedStyleComposeUrl, payload, { signal } );
 	} else {
 		if ( ! mapId || ! composedStyleUrlBase ) {
 			throw new Error( unavailableMessage );
@@ -98,7 +99,7 @@ export async function loadComposedStyleData( {
 			`${ composedStyleUrlBase }${ mapId }`,
 			forceRefresh ? { refresh: true } : {}
 		);
-		metadata = await fetchJson( metadataUrl );
+		metadata = await fetchJson( metadataUrl, { signal } );
 	}
 
 	if ( ! metadata?.enabled || ! metadata.style || ! metadata.manifest ) {
@@ -106,8 +107,8 @@ export async function loadComposedStyleData( {
 	}
 
 	const [ manifest, style ] = await Promise.all( [
-		fetchJson( metadata.manifest ),
-		includeStyle ? fetchJson( metadata.style ) : Promise.resolve( null ),
+		fetchJson( metadata.manifest, { signal } ),
+		includeStyle ? fetchJson( metadata.style, { signal } ) : Promise.resolve( null ),
 	] );
 
 	if ( ! manifest?.layers?.length ) {

--- a/src/js/src/shared/composed-style-layers.js
+++ b/src/js/src/shared/composed-style-layers.js
@@ -1,0 +1,265 @@
+export function hasComposedStyle( metadata, manifest ) {
+	return Boolean(
+		metadata?.style &&
+		manifest?.layers?.length
+	);
+}
+
+export function findComposedManifestLayer( manifest, layerId ) {
+	if ( ! manifest?.layers ) {
+		return null;
+	}
+
+	return manifest.layers.find(
+		( layer ) =>
+			layer.slug === layerId ||
+			String( layer.layerPostId ) === String( layerId )
+	) || null;
+}
+
+export function getComposedLayerVisibility( map, manifest, layerId ) {
+	const manifestLayer = findComposedManifestLayer( manifest, layerId );
+
+	if ( ! manifestLayer ) {
+		return undefined;
+	}
+
+	for ( const compositeLayer of manifestLayer.compositeLayers || [] ) {
+		if (
+			compositeLayer.visibleWhenLayerOn === false ||
+			! map.getLayer( compositeLayer.compositeId )
+		) {
+			continue;
+		}
+
+		const visibility = map.getLayoutProperty(
+			compositeLayer.compositeId,
+			'visibility'
+		);
+
+		if ( typeof visibility === 'undefined' || visibility === 'visible' ) {
+			return 'visible';
+		}
+	}
+
+	return 'none';
+}
+
+export function setComposedLayerVisibility( map, manifest, layerId, visibility ) {
+	const manifestLayer = findComposedManifestLayer( manifest, layerId );
+
+	if ( ! manifestLayer ) {
+		return;
+	}
+
+	( manifestLayer.compositeLayers || [] ).forEach( ( compositeLayer ) => {
+		if ( ! map.getLayer( compositeLayer.compositeId ) ) {
+			return;
+		}
+
+		const nextVisibility =
+			visibility === 'visible' && compositeLayer.visibleWhenLayerOn !== false
+				? 'visible'
+				: 'none';
+
+		map.setLayoutProperty(
+			compositeLayer.compositeId,
+			'visibility',
+			nextVisibility
+		);
+	} );
+}
+
+export function buildComposedInteractionPopupHtml( feature, interactions ) {
+	const properties = feature?.properties || {};
+	let html = '';
+
+	for ( const interaction of interactions ) {
+		if (
+			interaction.title &&
+			Object.prototype.hasOwnProperty.call( properties, interaction.title )
+		) {
+			html += '<h3>' + properties[ interaction.title ] + '</h3>';
+			break;
+		}
+	}
+
+	const fieldsSet = new Set();
+	for ( const interaction of interactions ) {
+		( interaction.fields || [] ).forEach( ( { field, label } ) => {
+			if (
+				! field ||
+				fieldsSet.has( field ) ||
+				! Object.prototype.hasOwnProperty.call( properties, field )
+			) {
+				return;
+			}
+
+			fieldsSet.add( field );
+			html +=
+				'<p><strong>' +
+				( label || field ) +
+				': </strong>' +
+				properties[ field ] +
+				'</p>';
+		} );
+	}
+
+	return html;
+}
+
+function groupComposedInteractions( map, manifestLayers, visibleLayerIds ) {
+	const groups = {};
+	const visibleLayerIdSet = visibleLayerIds ? new Set( visibleLayerIds ) : null;
+
+	( manifestLayers || [] ).forEach( ( layer ) => {
+		( layer.interactions || [] ).forEach( ( interaction ) => {
+			if (
+				! interaction.compositeId ||
+				( visibleLayerIdSet &&
+					! visibleLayerIdSet.has( interaction.compositeId ) ) ||
+				! map.getLayer( interaction.compositeId )
+			) {
+				return;
+			}
+
+			const interactionType =
+				interaction.on === 'mouseover' ? 'mouseover' : 'click';
+
+			if ( groups[ interactionType ] ) {
+				groups[ interactionType ].push( interaction );
+			} else {
+				groups[ interactionType ] = [ interaction ];
+			}
+		} );
+	} );
+
+	return groups;
+}
+
+export function addComposedInteractions(
+	map,
+	manifestOrLayers,
+	{ shouldIgnoreEvent = () => false, visibleLayerIds = null } = {}
+) {
+	if ( ! map || ! globalThis.mapboxgl?.Popup ) {
+		return [];
+	}
+
+	const manifestLayers = Array.isArray( manifestOrLayers )
+		? manifestOrLayers
+		: manifestOrLayers?.layers || [];
+	const groups = groupComposedInteractions(
+		map,
+		manifestLayers,
+		visibleLayerIds
+	);
+
+	return Object.entries( groups ).flatMap(
+		( [ interactionType, interactions ] ) => {
+			const layerIds = [
+				...new Set(
+					interactions
+						.map( ( interaction ) => interaction.compositeId )
+						.filter( ( layerId ) => map.getLayer( layerId ) )
+				),
+			];
+
+			if ( ! layerIds.length ) {
+				return [];
+			}
+
+			const popUp = new globalThis.mapboxgl.Popup( {
+				className:
+					interactionType === 'mouseover'
+						? 'jeo-popup__mouseover'
+						: '',
+				closeButton: interactionType === 'click',
+				closeOnClick: interactionType === 'click',
+				maxWidth: '300px',
+			} );
+			const showInteractionPopup = ( feature, lngLat ) => {
+				map.getCanvas().style.cursor = 'pointer';
+
+				if ( ! feature || ! lngLat ) {
+					return;
+				}
+
+				const featureInteractions = interactions.filter(
+					( interaction ) =>
+						interaction.compositeId === feature.layer?.id
+				);
+				const html = buildComposedInteractionPopupHtml(
+					feature,
+					featureInteractions.length
+						? featureInteractions
+						: interactions
+				);
+
+				if ( ! html ) {
+					return;
+				}
+
+				popUp
+					.setLngLat( [ lngLat.lng, lngLat.lat ] )
+					.setHTML( html )
+					.addTo( map );
+			};
+
+			if ( interactionType === 'mouseover' ) {
+				const handleMouseMove = ( e ) => {
+					if ( ! e?.point || ! e?.lngLat ) {
+						return;
+					}
+
+					if ( shouldIgnoreEvent( e ) ) {
+						popUp.remove();
+						return;
+					}
+
+					const features = map.queryRenderedFeatures( e.point, {
+						layers: layerIds,
+					} );
+
+					if ( features.length ) {
+						showInteractionPopup( features[ 0 ], e.lngLat );
+					} else {
+						map.getCanvas().style.cursor = '';
+						popUp.remove();
+					}
+				};
+
+				map.on( 'mousemove', handleMouseMove );
+				return [
+					() => {
+						map.off( 'mousemove', handleMouseMove );
+						popUp.remove();
+					},
+				];
+			}
+
+			const handleClick = ( e ) => {
+				if ( shouldIgnoreEvent( e ) ) {
+					popUp.remove();
+					return;
+				}
+
+				showInteractionPopup( e?.features?.[ 0 ], e?.lngLat );
+			};
+
+			map.on( 'click', layerIds, handleClick );
+			return [
+				() => {
+					try {
+						map.off( 'click', layerIds, handleClick );
+					} catch ( error ) {
+						layerIds.forEach( ( layerId ) => {
+							map.off( 'click', layerId, handleClick );
+						} );
+					}
+					popUp.remove();
+				},
+			];
+		}
+	);
+}

--- a/src/languages/jeowp-es_CO.po
+++ b/src/languages/jeowp-es_CO.po
@@ -36,15 +36,15 @@ msgstr "Mapas interactivos para el editor de bloques de WordPress"
 msgid "InfoAmazonia"
 msgstr "InfoAmazonia"
 
-#: includes/class-jeo.php:568
+#: includes/class-jeo.php:569
 msgid "Mapbox was selected as the rendering library, but no Mapbox API key is configured. Falling back to MapLibre."
 msgstr "Se seleccionó Mapbox como biblioteca de renderizado, pero no hay ninguna clave de API de Mapbox configurada. Se volverá a MapLibre."
 
-#: includes/class-jeo.php:569
+#: includes/class-jeo.php:570
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr "Se seleccionó Mapbox como biblioteca de renderizado, pero no se pudo cargar el SDK externo de Mapbox. Se volverá a MapLibre."
 
-#: includes/class-jeo.php:1075
+#: includes/class-jeo.php:1091
 msgid "Read more"
 msgstr "Leer más"
 
@@ -207,7 +207,7 @@ msgid "Layer type not registered"
 msgstr "Tipo de capa no registrada"
 
 #. translators: Explore is the name of JEO's discovery page feature.
-#: includes/loaders.php:526
+#: includes/loaders.php:535
 #: templates/embed-discovery.php:18
 #: js/build/discovery.js:6
 msgid "Explore"
@@ -604,7 +604,7 @@ msgid "You may use a local or external image URL. Large logos will be scaled dow
 msgstr "Puedes usar una URL local o externa de imagen. Los logotipos grandes se reducirán automáticamente en el pie de la incrustación."
 
 #. translators: 1: Mapbox terms URL, 2: Mapbox privacy URL, 3: Nominatim usage policy URL, 4: OSMF privacy URL, 5: OSM tile policy URL.
-#: includes/loaders.php:342
+#: includes/loaders.php:351
 #, php-format
 msgid "<p>JEO can connect to third-party services depending on your configuration.</p><ul><li><strong>Mapbox</strong>: only used when Mapbox is selected as the rendering library or when a map uses Mapbox-hosted resources. In that case the site loads JavaScript/CSS from Mapbox and sends the configured access token plus the visitor&#8217;s IP address, browser details and requested map resources to Mapbox. Terms: <a href=\"%1$s\">Mapbox Terms of Service</a>. Privacy Policy: <a href=\"%2$s\">Mapbox Privacy Policy</a>.</li><li><strong>Nominatim (OpenStreetMap)</strong>: used when an editor explicitly runs an address search or reverse geocoding request in the post geolocation UI. The typed address or selected coordinates, the site URL in the user agent string and the server IP address are sent to the Nominatim service. Usage Policy: <a href=\"%3$s\">Nominatim Usage Policy</a>. Privacy Policy: <a href=\"%4$s\">OpenStreetMap Foundation Privacy Policy</a>.</li><li><strong>OpenStreetMap raster tiles</strong>: the default MapLibre preview style requests map tiles from the OpenStreetMap tile service, which receives the visitor&#8217;s IP address, browser details and requested tile URLs. Tile Policy: <a href=\"%5$s\">OpenStreetMap Tile Usage Policy</a>. Privacy Policy: <a href=\"%4$s\">OpenStreetMap Foundation Privacy Policy</a>.</li><li><strong>Optional external asset URLs configured by the site administrator</strong>: if you configure an external typography stylesheet or footer logo URL, visitors&#8217; browsers will request that asset directly from the selected host. That host may receive the visitor&#8217;s IP address, browser details and referrer according to its own terms and privacy policy.</li></ul>"
 msgstr "<p>JEO puede conectarse a servicios de terceros según tu configuración.</p><ul><li><strong>Mapbox</strong>: solo se usa cuando Mapbox se selecciona como biblioteca de renderizado o cuando un mapa usa recursos alojados en Mapbox. En ese caso, el sitio carga JavaScript/CSS desde Mapbox y envía el token de acceso configurado, además de la dirección IP del visitante, detalles del navegador y los recursos de mapa solicitados a Mapbox. Términos: <a href=\"%1$s\">Términos de Servicio de Mapbox</a>. Política de Privacidad: <a href=\"%2$s\">Política de Privacidad de Mapbox</a>.</li><li><strong>Nominatim (OpenStreetMap)</strong>: se usa cuando un editor ejecuta explícitamente una búsqueda de dirección o una solicitud de geocodificación inversa en la interfaz de geolocalización de entradas. La dirección escrita o las coordenadas seleccionadas, la URL del sitio en la cadena del user agent y la dirección IP del servidor se envían al servicio Nominatim. Política de Uso: <a href=\"%3$s\">Política de Uso de Nominatim</a>. Política de Privacidad: <a href=\"%4$s\">Política de Privacidad de la OpenStreetMap Foundation</a>.</li><li><strong>Teselas ráster de OpenStreetMap</strong>: el estilo de vista previa predeterminado de MapLibre solicita teselas al servicio de teselas de OpenStreetMap, que recibe la dirección IP del visitante, detalles del navegador y las URL de teselas solicitadas. Política de Teselas: <a href=\"%5$s\">Política de Uso de Teselas de OpenStreetMap</a>. Política de Privacidad: <a href=\"%4$s\">Política de Privacidad de la OpenStreetMap Foundation</a>.</li><li><strong>URLs externas opcionales de recursos configuradas por el administrador del sitio</strong>: si configuras una URL externa para la hoja de estilos tipográfica o para el logotipo del pie, los navegadores de los visitantes solicitarán ese recurso directamente al host seleccionado. Ese host puede recibir la dirección IP del visitante, detalles del navegador y el referente, según sus propios términos y política de privacidad.</li></ul>"
@@ -790,7 +790,7 @@ msgstr "Qué datos debe mostrar el mapa."
 msgid "The layer source type style"
 msgstr "El tipo de fuente del estilo de la capa"
 
-#: includes/layer-types/mapbox.js:10
+#: includes/layer-types/mapbox.js:5
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
@@ -798,25 +798,25 @@ msgstr "El tipo de fuente del estilo de la capa"
 msgid "Mapbox Style"
 msgstr "Estilo de Mapbox"
 
-#: includes/layer-types/mapbox.js:155
+#: includes/layer-types/mapbox.js:117
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "Style ID"
 msgstr "ID del estilo"
 
-#: includes/layer-types/mapbox.js:157
+#: includes/layer-types/mapbox.js:119
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "The Mapbox Style ID includes the user name and id. Example: username/id or mapbox://styles/username/id"
 msgstr "El ID del estilo de Mapbox incluye el nombre de usuario y el ID. Ejemplo: username/id o mapbox://styles/username/id"
 
-#: includes/layer-types/mapbox.js:164
+#: includes/layer-types/mapbox.js:126
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "Access token"
 msgstr "Token de acceso"
 
-#: includes/layer-types/mapbox.js:166
+#: includes/layer-types/mapbox.js:128
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "Optional. If this layer needs a different access token from the one set in Settings, inform it here."
@@ -1219,10 +1219,12 @@ msgstr "Leyenda"
 msgid "This map doesn't have layers"
 msgstr "Este mapa no tiene capas"
 
+#: js/build/discovery.js:6
 #: js/build/jeoMap.js:1
 msgid "Close popup"
 msgstr "Cerrar ventana emergente"
 
+#: js/build/discovery.js:6
 #: js/build/jeoMap.js:1
 msgid "Info"
 msgstr "Información"
@@ -1986,11 +1988,11 @@ msgstr "Geolocalizar este post"
 msgid "Geolocation"
 msgstr "Geolocalización"
 
-#: includes/class-jeo.php:367
+#: includes/class-jeo.php:368
 msgid "Ordered list of map-layer IDs to return."
 msgstr "Lista ordenada de IDs de capas de mapa que se devolverán."
 
-#: includes/class-jeo.php:372
+#: includes/class-jeo.php:373
 msgid "Request context."
 msgstr "Contexto de la solicitud."
 
@@ -2008,10 +2010,123 @@ msgstr "Ej. https://ejemplo.com/wp-content/uploads/fonts/jeo-story-font.css"
 msgid "By %s"
 msgstr "Por %s"
 
-#: includes/class-jeo.php:1300
+#: includes/class-jeo.php:1316
 msgid "This JEO embed is not available."
 msgstr "Este embed de JEO no está disponible."
 
-#: includes/class-jeo.php:1301
+#: includes/class-jeo.php:1317
 msgid "Embed not available"
 msgstr "Embed no disponible"
+
+#: includes/maps/class-map-style-composer.php:424
+#: includes/maps/class-map-style-composer.php:477
+msgid "Mapbox composed styles are disabled."
+msgstr "Los estilos compuestos de Mapbox están desactivados."
+
+#: includes/maps/class-map-style-composer.php:449
+#: includes/maps/class-map-style-composer.php:501
+msgid "Could not create the Mapbox composed style cache directory."
+msgstr "No fue posible crear el directorio de caché de estilos compuestos de Mapbox."
+
+#: includes/maps/class-map-style-composer.php:589
+msgid "Map not found."
+msgstr "Mapa no encontrado."
+
+#: includes/maps/class-map-style-composer.php:599
+#: includes/maps/class-map-style-composer.php:662
+msgid "A Mapbox access token is required to compose Mapbox styles."
+msgstr "Se requiere un token de acceso de Mapbox para componer estilos de Mapbox."
+
+#: includes/maps/class-map-style-composer.php:639
+msgid "Public payload composition is only available for one-time maps."
+msgstr "La composición con datos públicos solo está disponible para mapas de un solo uso."
+
+#: includes/maps/class-map-style-composer.php:645
+msgid "The map preview payload is too large."
+msgstr "Los datos de la vista previa del mapa son demasiado grandes."
+
+#: includes/maps/class-map-style-composer.php:657
+msgid "The map preview has too many layers to compose."
+msgstr "La vista previa del mapa tiene demasiadas capas para componer."
+
+#: includes/maps/class-map-style-composer.php:668
+msgid "The map preview does not include any renderable layers."
+msgstr "La vista previa del mapa no incluye ninguna capa renderizable."
+
+#: includes/maps/class-map-style-composer.php:690
+msgid "Map preview"
+msgstr "Vista previa del mapa"
+
+#: includes/maps/class-map-style-composer.php:931
+msgid "Invalid composed style hash."
+msgstr "Hash de estilo compuesto no válido."
+
+#: includes/maps/class-map-style-composer.php:1019
+msgid "One or more Mapbox styles could not be fetched."
+msgstr "No fue posible obtener uno o más estilos de Mapbox."
+
+#: includes/maps/class-map-style-composer.php:1404
+msgid "The PHP GD extension is required to merge Mapbox sprites."
+msgstr "Se requiere la extensión PHP GD para fusionar sprites de Mapbox."
+
+#: includes/maps/class-map-style-composer.php:1521
+msgid "Could not decode a Mapbox sprite image."
+msgstr "No fue posible decodificar una imagen de sprite de Mapbox."
+
+#: includes/maps/class-map-style-composer.php:2238
+msgid "Composed style artifact was not found."
+msgstr "No se encontró el artefacto del estilo compuesto."
+
+#: js/build/discovery.js:6
+msgid "Mapbox style composition is unavailable."
+msgstr "La composición de estilos de Mapbox no está disponible."
+
+#: js/build/discovery.js:6
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition is unavailable for this map."
+msgstr "La composición de estilos de Mapbox no está disponible para este mapa."
+
+#: js/build/discovery.js:6
+msgid "Unable to load map information right now."
+msgstr "No fue posible cargar la información del mapa en este momento."
+
+#: js/build/discovery.js:6
+msgid "Map information"
+msgstr "Información del mapa"
+
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition did not return renderable layers for this map."
+msgstr "La composición de estilos de Mapbox no devolvió capas renderizables para este mapa."
+
+#: js/build/jeoMap.js:1
+msgid "Unable to load composed Mapbox style for this map."
+msgstr "No fue posible cargar el estilo compuesto de Mapbox para este mapa."
+
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition is unavailable for this one-time map."
+msgstr "La composición de estilos de Mapbox no está disponible para este mapa de un solo uso."
+
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition did not return renderable layers for this one-time map."
+msgstr "La composición de estilos de Mapbox no devolvió capas renderizables para este mapa de un solo uso."
+
+#: js/build/jeoMap.js:1
+msgid "Unable to load composed Mapbox style for this one-time map."
+msgstr "No fue posible cargar el estilo compuesto de Mapbox para este mapa de un solo uso."
+
+#: js/build/jeoMap.js:1
+#: js/build/jeoStorymap.js:3
+msgid "Mapbox style layers could not be loaded because the composed style is unavailable."
+msgstr "No fue posible cargar las capas de estilo de Mapbox porque el estilo compuesto no está disponible."
+
+#: js/build/jeoStorymap.js:3
+msgid "Mapbox style composition is unavailable for this storymap."
+msgstr "La composición de estilos de Mapbox no está disponible para este mapa narrativo."
+
+#: js/build/jeoStorymap.js:3
+msgid "Mapbox style composition did not return renderable layers for this storymap."
+msgstr "La composición de estilos de Mapbox no devolvió capas renderizables para este mapa narrativo."
+
+#: js/build/jeoStorymap.js:3
+msgid "Unable to load composed Mapbox style for this storymap."
+msgstr "No fue posible cargar el estilo compuesto de Mapbox para este mapa narrativo."

--- a/src/languages/jeowp-es_CO.po
+++ b/src/languages/jeowp-es_CO.po
@@ -36,15 +36,15 @@ msgstr "Mapas interactivos para el editor de bloques de WordPress"
 msgid "InfoAmazonia"
 msgstr "InfoAmazonia"
 
-#: includes/class-jeo.php:569
+#: includes/class-jeo.php:583
 msgid "Mapbox was selected as the rendering library, but no Mapbox API key is configured. Falling back to MapLibre."
 msgstr "Se seleccionó Mapbox como biblioteca de renderizado, pero no hay ninguna clave de API de Mapbox configurada. Se volverá a MapLibre."
 
-#: includes/class-jeo.php:570
+#: includes/class-jeo.php:584
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr "Se seleccionó Mapbox como biblioteca de renderizado, pero no se pudo cargar el SDK externo de Mapbox. Se volverá a MapLibre."
 
-#: includes/class-jeo.php:1091
+#: includes/class-jeo.php:1107
 msgid "Read more"
 msgstr "Leer más"
 
@@ -423,7 +423,7 @@ msgstr "Mapbox requiere una clave de API válida. La configuración de la biblio
 
 #: includes/settings/class-settings.php:347
 #: includes/settings/class-settings.php:348
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Settings"
 msgstr "Configuraciones"
 
@@ -713,7 +713,7 @@ msgid "Download from source"
 msgstr "Descargar desde la fuente"
 
 #: includes/layer-types/mapbox-tileset-raster.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -722,14 +722,14 @@ msgstr "Fuente ráster de teselas de Mapbox"
 
 #: includes/layer-types/mapbox-tileset-raster.js:68
 #: includes/layer-types/mapbox-tileset-vector.js:70
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Tileset ID"
 msgstr "ID del tileset"
 
 #: includes/layer-types/mapbox-tileset-raster.js:69
 #: includes/layer-types/mapbox-tileset-vector.js:71
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Example: username.tilesetid"
 msgstr "Ejemplo: username.tilesetid"
@@ -737,34 +737,34 @@ msgstr "Ejemplo: username.tilesetid"
 #: includes/layer-types/mapbox-tileset-raster.js:72
 #: includes/layer-types/mapbox-tileset-vector.js:99
 #: includes/layer-types/mvt.js:101
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Style Source Type"
 msgstr "Tipo de fuente del estilo"
 
 #: includes/layer-types/mapbox-tileset-raster.js:73
 #: includes/layer-types/mvt.js:102
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Which data the map should display"
 msgstr "Qué datos debe mostrar el mapa"
 
 #: includes/layer-types/mapbox-tileset-raster.js:79
 #: includes/layer-types/mapbox-tileset-vector.js:79
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Layer Type"
 msgstr "Tipo de capa"
 
 #: includes/layer-types/mapbox-tileset-raster.js:81
 #: includes/layer-types/mapbox-tileset-vector.js:81
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Layers take the data that they get from a source, optionally filter features, and then define how those features are styled."
 msgstr "Las capas toman los datos que reciben de una fuente, opcionalmente filtran entidades y luego definen cómo se aplican los estilos a esas entidades."
 
 #: includes/layer-types/mapbox-tileset-vector.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -773,25 +773,25 @@ msgstr "Fuente vectorial de teselas de Mapbox"
 
 #: includes/layer-types/mapbox-tileset-vector.js:75
 #: includes/layer-types/mvt.js:83
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Source layer"
 msgstr "Capa de origen"
 
 #: includes/layer-types/mapbox-tileset-vector.js:76
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Which data the map should display."
 msgstr "Qué datos debe mostrar el mapa."
 
 #: includes/layer-types/mapbox-tileset-vector.js:100
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "The layer source type style"
 msgstr "El tipo de fuente del estilo de la capa"
 
 #: includes/layer-types/mapbox.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -799,31 +799,31 @@ msgid "Mapbox Style"
 msgstr "Estilo de Mapbox"
 
 #: includes/layer-types/mapbox.js:117
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Style ID"
 msgstr "ID del estilo"
 
 #: includes/layer-types/mapbox.js:119
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "The Mapbox Style ID includes the user name and id. Example: username/id or mapbox://styles/username/id"
 msgstr "El ID del estilo de Mapbox incluye el nombre de usuario y el ID. Ejemplo: username/id o mapbox://styles/username/id"
 
 #: includes/layer-types/mapbox.js:126
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Access token"
 msgstr "Token de acceso"
 
 #: includes/layer-types/mapbox.js:128
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Optional. If this layer needs a different access token from the one set in Settings, inform it here."
 msgstr "Opcional. Si esta capa necesita un token de acceso diferente del configurado en Ajustes, indícalo aquí."
 
 #: includes/layer-types/mvt.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -834,19 +834,19 @@ msgstr "Teselas vectoriales de Mapbox (MVT)"
 #: includes/layer-types/tilelayer.js:57
 #: includes/legend-types/circles.js:25
 #: includes/legend-types/icons.js:25
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "URL"
 msgstr "URL"
 
 #: includes/layer-types/mvt.js:84
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Layer to use from a vector tile source."
 msgstr "Capa que se usará de una fuente de teselas vectoriales."
 
 #: includes/layer-types/tilelayer.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -854,25 +854,25 @@ msgid "Raster Tiled Source"
 msgstr "Fuente ráster de teselas"
 
 #: includes/layer-types/tilelayer.js:61
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Scheme"
 msgstr "Esquema"
 
 #: includes/layer-types/tilelayer.js:62
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Influences the Y direction of the tile coordinates."
 msgstr "Influye en la dirección Y de las coordenadas de las teselas."
 
 #: includes/layer-types/tilelayer.js:65
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Slippy Map tilenames (XYZ)"
 msgstr "Nombres de teselas de Slippy Map (XYZ)"
 
 #: includes/layer-types/tilelayer.js:66
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "OSGeo spec (TMS)"
 msgstr "Especificación OSGeo (TMS)"
@@ -1211,7 +1211,7 @@ msgstr "Expandir panel Discovery"
 
 #: js/build/discovery.js:6
 #: js/build/jeoMap.js:1
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Legend"
 msgstr "Leyenda"
 
@@ -1389,35 +1389,35 @@ msgstr "Interacciones"
 msgid "Done"
 msgstr "Hecho"
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Edit interactions"
 msgstr "Editar interacciones"
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Please fill all required fields, you will not be able to publish or update until that."
 msgstr "Complete todos los campos obligatorios, no podrá publicar ni actualizar hasta ese momento."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Your Mapbox access token may be invalid. You will not be able to publish or update. Please check your settings."
 msgstr "Es posible que su token de acceso de Mapbox no sea válido. No podrá publicar ni actualizar. Por favor revise su configuración."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Your layer was not found. You will not be able to publish or update. Please check your settings."
 msgstr "No se encontró la capa. No podrá publicar ni actualizar. Por favor revise su configuración."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Error loading your layer, you will not be able to publish or update. Please check your settings."
 msgstr "Error al cargar la capa, no podrá publicar ni actualizar. Compruebe la configuración."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Your Mapbox API Key was not found in your JEO Settings. You will not be able to publish or update."
 msgstr "No se encontró la clave de API de Mapbox en la configuración de JEO. No podrá publicar ni actualizar."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Please, check your settings."
 msgstr "Por favor, revise su configuración."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Attributions"
 msgstr "Atribuciones"
 
@@ -1988,11 +1988,11 @@ msgstr "Geolocalizar este post"
 msgid "Geolocation"
 msgstr "Geolocalización"
 
-#: includes/class-jeo.php:368
+#: includes/class-jeo.php:382
 msgid "Ordered list of map-layer IDs to return."
 msgstr "Lista ordenada de IDs de capas de mapa que se devolverán."
 
-#: includes/class-jeo.php:373
+#: includes/class-jeo.php:387
 msgid "Request context."
 msgstr "Contexto de la solicitud."
 
@@ -2010,70 +2010,70 @@ msgstr "Ej. https://ejemplo.com/wp-content/uploads/fonts/jeo-story-font.css"
 msgid "By %s"
 msgstr "Por %s"
 
-#: includes/class-jeo.php:1316
+#: includes/class-jeo.php:1332
 msgid "This JEO embed is not available."
 msgstr "Este embed de JEO no está disponible."
 
-#: includes/class-jeo.php:1317
+#: includes/class-jeo.php:1333
 msgid "Embed not available"
 msgstr "Embed no disponible"
 
-#: includes/maps/class-map-style-composer.php:424
-#: includes/maps/class-map-style-composer.php:477
+#: includes/maps/class-map-style-composer.php:511
+#: includes/maps/class-map-style-composer.php:564
 msgid "Mapbox composed styles are disabled."
 msgstr "Los estilos compuestos de Mapbox están desactivados."
 
-#: includes/maps/class-map-style-composer.php:449
-#: includes/maps/class-map-style-composer.php:501
+#: includes/maps/class-map-style-composer.php:536
+#: includes/maps/class-map-style-composer.php:588
 msgid "Could not create the Mapbox composed style cache directory."
 msgstr "No fue posible crear el directorio de caché de estilos compuestos de Mapbox."
 
-#: includes/maps/class-map-style-composer.php:589
+#: includes/maps/class-map-style-composer.php:676
 msgid "Map not found."
 msgstr "Mapa no encontrado."
 
-#: includes/maps/class-map-style-composer.php:599
-#: includes/maps/class-map-style-composer.php:662
+#: includes/maps/class-map-style-composer.php:686
+#: includes/maps/class-map-style-composer.php:749
 msgid "A Mapbox access token is required to compose Mapbox styles."
 msgstr "Se requiere un token de acceso de Mapbox para componer estilos de Mapbox."
 
-#: includes/maps/class-map-style-composer.php:639
+#: includes/maps/class-map-style-composer.php:726
 msgid "Public payload composition is only available for one-time maps."
 msgstr "La composición con datos públicos solo está disponible para mapas de un solo uso."
 
-#: includes/maps/class-map-style-composer.php:645
+#: includes/maps/class-map-style-composer.php:732
 msgid "The map preview payload is too large."
 msgstr "Los datos de la vista previa del mapa son demasiado grandes."
 
-#: includes/maps/class-map-style-composer.php:657
+#: includes/maps/class-map-style-composer.php:744
 msgid "The map preview has too many layers to compose."
 msgstr "La vista previa del mapa tiene demasiadas capas para componer."
 
-#: includes/maps/class-map-style-composer.php:668
+#: includes/maps/class-map-style-composer.php:755
 msgid "The map preview does not include any renderable layers."
 msgstr "La vista previa del mapa no incluye ninguna capa renderizable."
 
-#: includes/maps/class-map-style-composer.php:690
+#: includes/maps/class-map-style-composer.php:777
 msgid "Map preview"
 msgstr "Vista previa del mapa"
 
-#: includes/maps/class-map-style-composer.php:931
+#: includes/maps/class-map-style-composer.php:1018
 msgid "Invalid composed style hash."
 msgstr "Hash de estilo compuesto no válido."
 
-#: includes/maps/class-map-style-composer.php:1019
+#: includes/maps/class-map-style-composer.php:1106
 msgid "One or more Mapbox styles could not be fetched."
 msgstr "No fue posible obtener uno o más estilos de Mapbox."
 
-#: includes/maps/class-map-style-composer.php:1404
+#: includes/maps/class-map-style-composer.php:1507
 msgid "The PHP GD extension is required to merge Mapbox sprites."
 msgstr "Se requiere la extensión PHP GD para fusionar sprites de Mapbox."
 
-#: includes/maps/class-map-style-composer.php:1521
+#: includes/maps/class-map-style-composer.php:1626
 msgid "Could not decode a Mapbox sprite image."
 msgstr "No fue posible decodificar una imagen de sprite de Mapbox."
 
-#: includes/maps/class-map-style-composer.php:2238
+#: includes/maps/class-map-style-composer.php:2343
 msgid "Composed style artifact was not found."
 msgstr "No se encontró el artefacto del estilo compuesto."
 
@@ -2130,3 +2130,43 @@ msgstr "La composición de estilos de Mapbox no devolvió capas renderizables pa
 #: js/build/jeoStorymap.js:3
 msgid "Unable to load composed Mapbox style for this storymap."
 msgstr "No fue posible cargar el estilo compuesto de Mapbox para este mapa narrativo."
+
+#. translators: %d: number of maps whose composed style cache was refreshed.
+#: js/build/layersSidebar.js:8
+#, js-format
+msgid "%d map"
+msgid_plural "%d maps"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: number of map refresh failures.
+#: js/build/layersSidebar.js:9
+#, js-format
+msgid "%d failure"
+msgid_plural "%d failures"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: refreshed maps count label, 2: failed refresh count label.
+#: js/build/layersSidebar.js:10
+#, js-format
+msgid "Composed style cache refreshed for %1$s, with %2$s."
+msgstr ""
+
+#. translators: %s: refreshed maps count label.
+#: js/build/layersSidebar.js:11
+#, js-format
+msgid "Composed style cache refreshed for %s."
+msgstr ""
+
+#: js/build/layersSidebar.js:11
+msgid "Unable to refresh composed style cache."
+msgstr ""
+
+#: js/build/layersSidebar.js:11
+msgid "Refreshing composed style cache"
+msgstr ""
+
+#: js/build/layersSidebar.js:11
+msgid "Refresh composed style cache"
+msgstr ""

--- a/src/languages/jeowp-pt_BR.po
+++ b/src/languages/jeowp-pt_BR.po
@@ -36,15 +36,15 @@ msgstr "Mapas interativos para o editor de blocos do WordPress"
 msgid "InfoAmazonia"
 msgstr "InfoAmazonia"
 
-#: includes/class-jeo.php:569
+#: includes/class-jeo.php:583
 msgid "Mapbox was selected as the rendering library, but no Mapbox API key is configured. Falling back to MapLibre."
 msgstr "Mapbox foi selecionado como biblioteca de renderização, mas nenhuma chave de API do Mapbox está configurada. Voltando para MapLibre."
 
-#: includes/class-jeo.php:570
+#: includes/class-jeo.php:584
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr "Mapbox foi selecionado como biblioteca de renderização, mas o SDK externo do Mapbox não pôde ser carregado. Voltando para MapLibre."
 
-#: includes/class-jeo.php:1091
+#: includes/class-jeo.php:1107
 msgid "Read more"
 msgstr "Ler mais"
 
@@ -423,7 +423,7 @@ msgstr "O Mapbox exige uma chave de API válida. A configuração da biblioteca 
 
 #: includes/settings/class-settings.php:347
 #: includes/settings/class-settings.php:348
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Settings"
 msgstr "Configurações"
 
@@ -713,7 +713,7 @@ msgid "Download from source"
 msgstr "Baixar da fonte"
 
 #: includes/layer-types/mapbox-tileset-raster.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -722,14 +722,14 @@ msgstr "Fonte raster de tiles do Mapbox"
 
 #: includes/layer-types/mapbox-tileset-raster.js:68
 #: includes/layer-types/mapbox-tileset-vector.js:70
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Tileset ID"
 msgstr "ID do tileset"
 
 #: includes/layer-types/mapbox-tileset-raster.js:69
 #: includes/layer-types/mapbox-tileset-vector.js:71
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Example: username.tilesetid"
 msgstr "Exemplo: username.tilesetid"
@@ -737,34 +737,34 @@ msgstr "Exemplo: username.tilesetid"
 #: includes/layer-types/mapbox-tileset-raster.js:72
 #: includes/layer-types/mapbox-tileset-vector.js:99
 #: includes/layer-types/mvt.js:101
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Style Source Type"
 msgstr "Tipo de fonte do estilo"
 
 #: includes/layer-types/mapbox-tileset-raster.js:73
 #: includes/layer-types/mvt.js:102
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Which data the map should display"
 msgstr "Quais dados o mapa deve exibir"
 
 #: includes/layer-types/mapbox-tileset-raster.js:79
 #: includes/layer-types/mapbox-tileset-vector.js:79
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Layer Type"
 msgstr "Tipo da camada"
 
 #: includes/layer-types/mapbox-tileset-raster.js:81
 #: includes/layer-types/mapbox-tileset-vector.js:81
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Layers take the data that they get from a source, optionally filter features, and then define how those features are styled."
 msgstr "As camadas usam os dados que recebem de uma fonte, podem filtrar feições e então definem como essas feições são estilizadas."
 
 #: includes/layer-types/mapbox-tileset-vector.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -773,25 +773,25 @@ msgstr "Fonte vetorial de tiles do Mapbox"
 
 #: includes/layer-types/mapbox-tileset-vector.js:75
 #: includes/layer-types/mvt.js:83
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Source layer"
 msgstr "Camada de origem"
 
 #: includes/layer-types/mapbox-tileset-vector.js:76
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Which data the map should display."
 msgstr "Quais dados o mapa deve exibir."
 
 #: includes/layer-types/mapbox-tileset-vector.js:100
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "The layer source type style"
 msgstr "O tipo de fonte do estilo da camada"
 
 #: includes/layer-types/mapbox.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -799,31 +799,31 @@ msgid "Mapbox Style"
 msgstr "Estilo do Mapbox"
 
 #: includes/layer-types/mapbox.js:117
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Style ID"
 msgstr "ID do estilo"
 
 #: includes/layer-types/mapbox.js:119
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "The Mapbox Style ID includes the user name and id. Example: username/id or mapbox://styles/username/id"
 msgstr "O ID do estilo do Mapbox inclui o nome de usuário e o ID. Exemplo: username/id ou mapbox://styles/username/id"
 
 #: includes/layer-types/mapbox.js:126
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Access token"
 msgstr "Token de acesso"
 
 #: includes/layer-types/mapbox.js:128
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Optional. If this layer needs a different access token from the one set in Settings, inform it here."
 msgstr "Opcional. Se esta camada precisar de um token de acesso diferente do definido em Configurações, informe-o aqui."
 
 #: includes/layer-types/mvt.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -834,19 +834,19 @@ msgstr "Tiles vetoriais do Mapbox (MVT)"
 #: includes/layer-types/tilelayer.js:57
 #: includes/legend-types/circles.js:25
 #: includes/legend-types/icons.js:25
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "URL"
 msgstr "URL"
 
 #: includes/layer-types/mvt.js:84
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Layer to use from a vector tile source."
 msgstr "Camada a ser usada de uma fonte de tiles vetoriais."
 
 #: includes/layer-types/tilelayer.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -854,25 +854,25 @@ msgid "Raster Tiled Source"
 msgstr "Fonte raster de tiles"
 
 #: includes/layer-types/tilelayer.js:61
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Scheme"
 msgstr "Esquema"
 
 #: includes/layer-types/tilelayer.js:62
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Influences the Y direction of the tile coordinates."
 msgstr "Influencia a direção Y das coordenadas dos tiles."
 
 #: includes/layer-types/tilelayer.js:65
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Slippy Map tilenames (XYZ)"
 msgstr "Nomes de tiles do Slippy Map (XYZ)"
 
 #: includes/layer-types/tilelayer.js:66
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "OSGeo spec (TMS)"
 msgstr "Especificação OSGeo (TMS)"
@@ -1211,7 +1211,7 @@ msgstr "Expandir painel Discovery"
 
 #: js/build/discovery.js:6
 #: js/build/jeoMap.js:1
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Legend"
 msgstr "Legenda"
 
@@ -1389,35 +1389,35 @@ msgstr "Interações"
 msgid "Done"
 msgstr "Feito"
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Edit interactions"
 msgstr "Editar interações"
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Please fill all required fields, you will not be able to publish or update until that."
 msgstr "Por favor preencha os campos requeridos, você não poderá publicar ou atualizar até lá."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Your Mapbox access token may be invalid. You will not be able to publish or update. Please check your settings."
 msgstr "Seu token de acesso do Mapbox pode ser inválido. Você não poderá publicar ou atualizar. Por favor, verifique suas configurações."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Your layer was not found. You will not be able to publish or update. Please check your settings."
 msgstr "Sua camada não foi encontrada. Você não poderá publicar ou atualizar. Por favor, verifique suas configurações."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Error loading your layer, you will not be able to publish or update. Please check your settings."
 msgstr "Erro ao carregar sua camada, você não poderá publicar ou atualizar. Por favor verifique as configurações."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Your Mapbox API Key was not found in your JEO Settings. You will not be able to publish or update."
 msgstr "Sua chave API do Mapbox não foi encontrada nas configurações do JEO. Você não poderá publicar ou atualizar."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Please, check your settings."
 msgstr "Por favor, verifique suas configurações."
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Attributions"
 msgstr "Atribuições"
 
@@ -1988,11 +1988,11 @@ msgstr "Geolocalizar este post"
 msgid "Geolocation"
 msgstr "Geolocalização"
 
-#: includes/class-jeo.php:368
+#: includes/class-jeo.php:382
 msgid "Ordered list of map-layer IDs to return."
 msgstr "Lista ordenada dos IDs das camadas a serem retornados."
 
-#: includes/class-jeo.php:373
+#: includes/class-jeo.php:387
 msgid "Request context."
 msgstr "Contexto da requisição."
 
@@ -2010,70 +2010,70 @@ msgstr "Ex. https://exemplo.com/wp-content/uploads/fonts/jeo-story-font.css"
 msgid "By %s"
 msgstr "Por %s"
 
-#: includes/class-jeo.php:1316
+#: includes/class-jeo.php:1332
 msgid "This JEO embed is not available."
 msgstr "Este embed JEO não está disponível."
 
-#: includes/class-jeo.php:1317
+#: includes/class-jeo.php:1333
 msgid "Embed not available"
 msgstr "Embed indisponível"
 
-#: includes/maps/class-map-style-composer.php:424
-#: includes/maps/class-map-style-composer.php:477
+#: includes/maps/class-map-style-composer.php:511
+#: includes/maps/class-map-style-composer.php:564
 msgid "Mapbox composed styles are disabled."
 msgstr "Os estilos compostos do Mapbox estão desativados."
 
-#: includes/maps/class-map-style-composer.php:449
-#: includes/maps/class-map-style-composer.php:501
+#: includes/maps/class-map-style-composer.php:536
+#: includes/maps/class-map-style-composer.php:588
 msgid "Could not create the Mapbox composed style cache directory."
 msgstr "Não foi possível criar o diretório de cache dos estilos compostos do Mapbox."
 
-#: includes/maps/class-map-style-composer.php:589
+#: includes/maps/class-map-style-composer.php:676
 msgid "Map not found."
 msgstr "Mapa não encontrado."
 
-#: includes/maps/class-map-style-composer.php:599
-#: includes/maps/class-map-style-composer.php:662
+#: includes/maps/class-map-style-composer.php:686
+#: includes/maps/class-map-style-composer.php:749
 msgid "A Mapbox access token is required to compose Mapbox styles."
 msgstr "Um token de acesso do Mapbox é necessário para compor estilos do Mapbox."
 
-#: includes/maps/class-map-style-composer.php:639
+#: includes/maps/class-map-style-composer.php:726
 msgid "Public payload composition is only available for one-time maps."
 msgstr "A composição com dados públicos está disponível apenas para mapas de uso único."
 
-#: includes/maps/class-map-style-composer.php:645
+#: includes/maps/class-map-style-composer.php:732
 msgid "The map preview payload is too large."
 msgstr "Os dados da prévia do mapa são grandes demais."
 
-#: includes/maps/class-map-style-composer.php:657
+#: includes/maps/class-map-style-composer.php:744
 msgid "The map preview has too many layers to compose."
 msgstr "A prévia do mapa tem camadas demais para compor."
 
-#: includes/maps/class-map-style-composer.php:668
+#: includes/maps/class-map-style-composer.php:755
 msgid "The map preview does not include any renderable layers."
 msgstr "A prévia do mapa não inclui nenhuma camada renderizável."
 
-#: includes/maps/class-map-style-composer.php:690
+#: includes/maps/class-map-style-composer.php:777
 msgid "Map preview"
 msgstr "Prévia do mapa"
 
-#: includes/maps/class-map-style-composer.php:931
+#: includes/maps/class-map-style-composer.php:1018
 msgid "Invalid composed style hash."
 msgstr "Hash do estilo composto inválido."
 
-#: includes/maps/class-map-style-composer.php:1019
+#: includes/maps/class-map-style-composer.php:1106
 msgid "One or more Mapbox styles could not be fetched."
 msgstr "Não foi possível obter um ou mais estilos do Mapbox."
 
-#: includes/maps/class-map-style-composer.php:1404
+#: includes/maps/class-map-style-composer.php:1507
 msgid "The PHP GD extension is required to merge Mapbox sprites."
 msgstr "A extensão PHP GD é necessária para mesclar sprites do Mapbox."
 
-#: includes/maps/class-map-style-composer.php:1521
+#: includes/maps/class-map-style-composer.php:1626
 msgid "Could not decode a Mapbox sprite image."
 msgstr "Não foi possível decodificar uma imagem de sprite do Mapbox."
 
-#: includes/maps/class-map-style-composer.php:2238
+#: includes/maps/class-map-style-composer.php:2343
 msgid "Composed style artifact was not found."
 msgstr "O artefato do estilo composto não foi encontrado."
 
@@ -2130,3 +2130,43 @@ msgstr "A composição de estilos do Mapbox não retornou camadas renderizáveis
 #: js/build/jeoStorymap.js:3
 msgid "Unable to load composed Mapbox style for this storymap."
 msgstr "Não foi possível carregar o estilo composto do Mapbox para este mapa narrativo."
+
+#. translators: %d: number of maps whose composed style cache was refreshed.
+#: js/build/layersSidebar.js:8
+#, js-format
+msgid "%d map"
+msgid_plural "%d maps"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: number of map refresh failures.
+#: js/build/layersSidebar.js:9
+#, js-format
+msgid "%d failure"
+msgid_plural "%d failures"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: refreshed maps count label, 2: failed refresh count label.
+#: js/build/layersSidebar.js:10
+#, js-format
+msgid "Composed style cache refreshed for %1$s, with %2$s."
+msgstr ""
+
+#. translators: %s: refreshed maps count label.
+#: js/build/layersSidebar.js:11
+#, js-format
+msgid "Composed style cache refreshed for %s."
+msgstr ""
+
+#: js/build/layersSidebar.js:11
+msgid "Unable to refresh composed style cache."
+msgstr ""
+
+#: js/build/layersSidebar.js:11
+msgid "Refreshing composed style cache"
+msgstr ""
+
+#: js/build/layersSidebar.js:11
+msgid "Refresh composed style cache"
+msgstr ""

--- a/src/languages/jeowp-pt_BR.po
+++ b/src/languages/jeowp-pt_BR.po
@@ -36,15 +36,15 @@ msgstr "Mapas interativos para o editor de blocos do WordPress"
 msgid "InfoAmazonia"
 msgstr "InfoAmazonia"
 
-#: includes/class-jeo.php:568
+#: includes/class-jeo.php:569
 msgid "Mapbox was selected as the rendering library, but no Mapbox API key is configured. Falling back to MapLibre."
 msgstr "Mapbox foi selecionado como biblioteca de renderização, mas nenhuma chave de API do Mapbox está configurada. Voltando para MapLibre."
 
-#: includes/class-jeo.php:569
+#: includes/class-jeo.php:570
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr "Mapbox foi selecionado como biblioteca de renderização, mas o SDK externo do Mapbox não pôde ser carregado. Voltando para MapLibre."
 
-#: includes/class-jeo.php:1075
+#: includes/class-jeo.php:1091
 msgid "Read more"
 msgstr "Ler mais"
 
@@ -207,7 +207,7 @@ msgid "Layer type not registered"
 msgstr "Tipo de camada não registrado"
 
 #. translators: Explore is the name of JEO's discovery page feature.
-#: includes/loaders.php:526
+#: includes/loaders.php:535
 #: templates/embed-discovery.php:18
 #: js/build/discovery.js:6
 msgid "Explore"
@@ -604,7 +604,7 @@ msgid "You may use a local or external image URL. Large logos will be scaled dow
 msgstr "Você pode usar uma URL local ou externa de imagem. Logos grandes serão reduzidos automaticamente no rodapé do embed."
 
 #. translators: 1: Mapbox terms URL, 2: Mapbox privacy URL, 3: Nominatim usage policy URL, 4: OSMF privacy URL, 5: OSM tile policy URL.
-#: includes/loaders.php:342
+#: includes/loaders.php:351
 #, php-format
 msgid "<p>JEO can connect to third-party services depending on your configuration.</p><ul><li><strong>Mapbox</strong>: only used when Mapbox is selected as the rendering library or when a map uses Mapbox-hosted resources. In that case the site loads JavaScript/CSS from Mapbox and sends the configured access token plus the visitor&#8217;s IP address, browser details and requested map resources to Mapbox. Terms: <a href=\"%1$s\">Mapbox Terms of Service</a>. Privacy Policy: <a href=\"%2$s\">Mapbox Privacy Policy</a>.</li><li><strong>Nominatim (OpenStreetMap)</strong>: used when an editor explicitly runs an address search or reverse geocoding request in the post geolocation UI. The typed address or selected coordinates, the site URL in the user agent string and the server IP address are sent to the Nominatim service. Usage Policy: <a href=\"%3$s\">Nominatim Usage Policy</a>. Privacy Policy: <a href=\"%4$s\">OpenStreetMap Foundation Privacy Policy</a>.</li><li><strong>OpenStreetMap raster tiles</strong>: the default MapLibre preview style requests map tiles from the OpenStreetMap tile service, which receives the visitor&#8217;s IP address, browser details and requested tile URLs. Tile Policy: <a href=\"%5$s\">OpenStreetMap Tile Usage Policy</a>. Privacy Policy: <a href=\"%4$s\">OpenStreetMap Foundation Privacy Policy</a>.</li><li><strong>Optional external asset URLs configured by the site administrator</strong>: if you configure an external typography stylesheet or footer logo URL, visitors&#8217; browsers will request that asset directly from the selected host. That host may receive the visitor&#8217;s IP address, browser details and referrer according to its own terms and privacy policy.</li></ul>"
 msgstr "<p>O JEO pode se conectar a serviços de terceiros dependendo da sua configuração.</p><ul><li><strong>Mapbox</strong>: usado apenas quando o Mapbox é selecionado como biblioteca de renderização ou quando um mapa usa recursos hospedados no Mapbox. Nesse caso, o site carrega JavaScript/CSS do Mapbox e envia o token de acesso configurado, além do endereço IP do visitante, detalhes do navegador e recursos de mapa solicitados ao Mapbox. Termos: <a href=\"%1$s\">Termos de Serviço do Mapbox</a>. Política de Privacidade: <a href=\"%2$s\">Política de Privacidade do Mapbox</a>.</li><li><strong>Nominatim (OpenStreetMap)</strong>: usado quando um editor executa explicitamente uma busca de endereço ou uma solicitação de geocodificação reversa na interface de geolocalização de posts. O endereço digitado ou as coordenadas selecionadas, a URL do site na string do user agent e o endereço IP do servidor são enviados ao serviço Nominatim. Política de Uso: <a href=\"%3$s\">Política de Uso do Nominatim</a>. Política de Privacidade: <a href=\"%4$s\">Política de Privacidade da OpenStreetMap Foundation</a>.</li><li><strong>Tiles raster do OpenStreetMap</strong>: o estilo padrão de pré-visualização do MapLibre solicita tiles ao serviço de tiles do OpenStreetMap, que recebe o endereço IP do visitante, detalhes do navegador e URLs de tiles solicitadas. Política de Tiles: <a href=\"%5$s\">Política de Uso de Tiles do OpenStreetMap</a>. Política de Privacidade: <a href=\"%4$s\">Política de Privacidade da OpenStreetMap Foundation</a>.</li><li><strong>URLs externas opcionais de assets configuradas pelo administrador do site</strong>: se você configurar uma URL externa para a folha de estilo tipográfica ou para o logo do rodapé, os navegadores dos visitantes solicitarão esse recurso diretamente ao host selecionado. Esse host pode receber o endereço IP do visitante, detalhes do navegador e o referenciador, de acordo com seus próprios termos e política de privacidade.</li></ul>"
@@ -790,7 +790,7 @@ msgstr "Quais dados o mapa deve exibir."
 msgid "The layer source type style"
 msgstr "O tipo de fonte do estilo da camada"
 
-#: includes/layer-types/mapbox.js:10
+#: includes/layer-types/mapbox.js:5
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
@@ -798,25 +798,25 @@ msgstr "O tipo de fonte do estilo da camada"
 msgid "Mapbox Style"
 msgstr "Estilo do Mapbox"
 
-#: includes/layer-types/mapbox.js:155
+#: includes/layer-types/mapbox.js:117
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "Style ID"
 msgstr "ID do estilo"
 
-#: includes/layer-types/mapbox.js:157
+#: includes/layer-types/mapbox.js:119
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "The Mapbox Style ID includes the user name and id. Example: username/id or mapbox://styles/username/id"
 msgstr "O ID do estilo do Mapbox inclui o nome de usuário e o ID. Exemplo: username/id ou mapbox://styles/username/id"
 
-#: includes/layer-types/mapbox.js:164
+#: includes/layer-types/mapbox.js:126
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "Access token"
 msgstr "Token de acesso"
 
-#: includes/layer-types/mapbox.js:166
+#: includes/layer-types/mapbox.js:128
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "Optional. If this layer needs a different access token from the one set in Settings, inform it here."
@@ -1219,10 +1219,12 @@ msgstr "Legenda"
 msgid "This map doesn't have layers"
 msgstr "Este mapa não tem camadas"
 
+#: js/build/discovery.js:6
 #: js/build/jeoMap.js:1
 msgid "Close popup"
 msgstr "Fechar pop-up"
 
+#: js/build/discovery.js:6
 #: js/build/jeoMap.js:1
 msgid "Info"
 msgstr "Informações"
@@ -1986,11 +1988,11 @@ msgstr "Geolocalizar este post"
 msgid "Geolocation"
 msgstr "Geolocalização"
 
-#: includes/class-jeo.php:367
+#: includes/class-jeo.php:368
 msgid "Ordered list of map-layer IDs to return."
 msgstr "Lista ordenada dos IDs das camadas a serem retornados."
 
-#: includes/class-jeo.php:372
+#: includes/class-jeo.php:373
 msgid "Request context."
 msgstr "Contexto da requisição."
 
@@ -2008,10 +2010,123 @@ msgstr "Ex. https://exemplo.com/wp-content/uploads/fonts/jeo-story-font.css"
 msgid "By %s"
 msgstr "Por %s"
 
-#: includes/class-jeo.php:1300
+#: includes/class-jeo.php:1316
 msgid "This JEO embed is not available."
 msgstr "Este embed JEO não está disponível."
 
-#: includes/class-jeo.php:1301
+#: includes/class-jeo.php:1317
 msgid "Embed not available"
 msgstr "Embed indisponível"
+
+#: includes/maps/class-map-style-composer.php:424
+#: includes/maps/class-map-style-composer.php:477
+msgid "Mapbox composed styles are disabled."
+msgstr "Os estilos compostos do Mapbox estão desativados."
+
+#: includes/maps/class-map-style-composer.php:449
+#: includes/maps/class-map-style-composer.php:501
+msgid "Could not create the Mapbox composed style cache directory."
+msgstr "Não foi possível criar o diretório de cache dos estilos compostos do Mapbox."
+
+#: includes/maps/class-map-style-composer.php:589
+msgid "Map not found."
+msgstr "Mapa não encontrado."
+
+#: includes/maps/class-map-style-composer.php:599
+#: includes/maps/class-map-style-composer.php:662
+msgid "A Mapbox access token is required to compose Mapbox styles."
+msgstr "Um token de acesso do Mapbox é necessário para compor estilos do Mapbox."
+
+#: includes/maps/class-map-style-composer.php:639
+msgid "Public payload composition is only available for one-time maps."
+msgstr "A composição com dados públicos está disponível apenas para mapas de uso único."
+
+#: includes/maps/class-map-style-composer.php:645
+msgid "The map preview payload is too large."
+msgstr "Os dados da prévia do mapa são grandes demais."
+
+#: includes/maps/class-map-style-composer.php:657
+msgid "The map preview has too many layers to compose."
+msgstr "A prévia do mapa tem camadas demais para compor."
+
+#: includes/maps/class-map-style-composer.php:668
+msgid "The map preview does not include any renderable layers."
+msgstr "A prévia do mapa não inclui nenhuma camada renderizável."
+
+#: includes/maps/class-map-style-composer.php:690
+msgid "Map preview"
+msgstr "Prévia do mapa"
+
+#: includes/maps/class-map-style-composer.php:931
+msgid "Invalid composed style hash."
+msgstr "Hash do estilo composto inválido."
+
+#: includes/maps/class-map-style-composer.php:1019
+msgid "One or more Mapbox styles could not be fetched."
+msgstr "Não foi possível obter um ou mais estilos do Mapbox."
+
+#: includes/maps/class-map-style-composer.php:1404
+msgid "The PHP GD extension is required to merge Mapbox sprites."
+msgstr "A extensão PHP GD é necessária para mesclar sprites do Mapbox."
+
+#: includes/maps/class-map-style-composer.php:1521
+msgid "Could not decode a Mapbox sprite image."
+msgstr "Não foi possível decodificar uma imagem de sprite do Mapbox."
+
+#: includes/maps/class-map-style-composer.php:2238
+msgid "Composed style artifact was not found."
+msgstr "O artefato do estilo composto não foi encontrado."
+
+#: js/build/discovery.js:6
+msgid "Mapbox style composition is unavailable."
+msgstr "A composição de estilos do Mapbox está indisponível."
+
+#: js/build/discovery.js:6
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition is unavailable for this map."
+msgstr "A composição de estilos do Mapbox está indisponível para este mapa."
+
+#: js/build/discovery.js:6
+msgid "Unable to load map information right now."
+msgstr "Não foi possível carregar as informações do mapa agora."
+
+#: js/build/discovery.js:6
+msgid "Map information"
+msgstr "Informações do mapa"
+
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition did not return renderable layers for this map."
+msgstr "A composição de estilos do Mapbox não retornou camadas renderizáveis para este mapa."
+
+#: js/build/jeoMap.js:1
+msgid "Unable to load composed Mapbox style for this map."
+msgstr "Não foi possível carregar o estilo composto do Mapbox para este mapa."
+
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition is unavailable for this one-time map."
+msgstr "A composição de estilos do Mapbox está indisponível para este mapa de uso único."
+
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition did not return renderable layers for this one-time map."
+msgstr "A composição de estilos do Mapbox não retornou camadas renderizáveis para este mapa de uso único."
+
+#: js/build/jeoMap.js:1
+msgid "Unable to load composed Mapbox style for this one-time map."
+msgstr "Não foi possível carregar o estilo composto do Mapbox para este mapa de uso único."
+
+#: js/build/jeoMap.js:1
+#: js/build/jeoStorymap.js:3
+msgid "Mapbox style layers could not be loaded because the composed style is unavailable."
+msgstr "Não foi possível carregar as camadas de estilo do Mapbox porque o estilo composto está indisponível."
+
+#: js/build/jeoStorymap.js:3
+msgid "Mapbox style composition is unavailable for this storymap."
+msgstr "A composição de estilos do Mapbox está indisponível para este mapa narrativo."
+
+#: js/build/jeoStorymap.js:3
+msgid "Mapbox style composition did not return renderable layers for this storymap."
+msgstr "A composição de estilos do Mapbox não retornou camadas renderizáveis para este mapa narrativo."
+
+#: js/build/jeoStorymap.js:3
+msgid "Unable to load composed Mapbox style for this storymap."
+msgstr "Não foi possível carregar o estilo composto do Mapbox para este mapa narrativo."

--- a/src/languages/jeowp.pot
+++ b/src/languages/jeowp.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-25T18:09:05+00:00\n"
+"POT-Creation-Date: 2026-07-01T19:37:18+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: jeowp\n"
@@ -36,31 +36,31 @@ msgstr ""
 msgid "InfoAmazonia"
 msgstr ""
 
-#: includes/class-jeo.php:368
+#: includes/class-jeo.php:382
 msgid "Ordered list of map-layer IDs to return."
 msgstr ""
 
-#: includes/class-jeo.php:373
+#: includes/class-jeo.php:387
 msgid "Request context."
 msgstr ""
 
-#: includes/class-jeo.php:569
+#: includes/class-jeo.php:583
 msgid "Mapbox was selected as the rendering library, but no Mapbox API key is configured. Falling back to MapLibre."
 msgstr ""
 
-#: includes/class-jeo.php:570
+#: includes/class-jeo.php:584
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr ""
 
-#: includes/class-jeo.php:1091
+#: includes/class-jeo.php:1107
 msgid "Read more"
 msgstr ""
 
-#: includes/class-jeo.php:1316
+#: includes/class-jeo.php:1332
 msgid "This JEO embed is not available."
 msgstr ""
 
-#: includes/class-jeo.php:1317
+#: includes/class-jeo.php:1333
 msgid "Embed not available"
 msgstr ""
 
@@ -235,62 +235,62 @@ msgstr ""
 msgid "Explore"
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:424
-#: includes/maps/class-map-style-composer.php:477
+#: includes/maps/class-map-style-composer.php:511
+#: includes/maps/class-map-style-composer.php:564
 msgid "Mapbox composed styles are disabled."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:449
-#: includes/maps/class-map-style-composer.php:501
+#: includes/maps/class-map-style-composer.php:536
+#: includes/maps/class-map-style-composer.php:588
 msgid "Could not create the Mapbox composed style cache directory."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:589
+#: includes/maps/class-map-style-composer.php:676
 msgid "Map not found."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:599
-#: includes/maps/class-map-style-composer.php:662
+#: includes/maps/class-map-style-composer.php:686
+#: includes/maps/class-map-style-composer.php:749
 msgid "A Mapbox access token is required to compose Mapbox styles."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:639
+#: includes/maps/class-map-style-composer.php:726
 msgid "Public payload composition is only available for one-time maps."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:645
+#: includes/maps/class-map-style-composer.php:732
 msgid "The map preview payload is too large."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:657
+#: includes/maps/class-map-style-composer.php:744
 msgid "The map preview has too many layers to compose."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:668
+#: includes/maps/class-map-style-composer.php:755
 msgid "The map preview does not include any renderable layers."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:690
+#: includes/maps/class-map-style-composer.php:777
 msgid "Map preview"
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:931
+#: includes/maps/class-map-style-composer.php:1018
 msgid "Invalid composed style hash."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:1019
+#: includes/maps/class-map-style-composer.php:1106
 msgid "One or more Mapbox styles could not be fetched."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:1404
+#: includes/maps/class-map-style-composer.php:1507
 msgid "The PHP GD extension is required to merge Mapbox sprites."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:1521
+#: includes/maps/class-map-style-composer.php:1626
 msgid "Could not decode a Mapbox sprite image."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:2238
+#: includes/maps/class-map-style-composer.php:2343
 msgid "Composed style artifact was not found."
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 
 #: includes/settings/class-settings.php:347
 #: includes/settings/class-settings.php:348
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Settings"
 msgstr ""
 
@@ -790,7 +790,7 @@ msgid "Download from source"
 msgstr ""
 
 #: includes/layer-types/mapbox-tileset-raster.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -799,14 +799,14 @@ msgstr ""
 
 #: includes/layer-types/mapbox-tileset-raster.js:68
 #: includes/layer-types/mapbox-tileset-vector.js:70
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Tileset ID"
 msgstr ""
 
 #: includes/layer-types/mapbox-tileset-raster.js:69
 #: includes/layer-types/mapbox-tileset-vector.js:71
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Example: username.tilesetid"
 msgstr ""
@@ -814,34 +814,34 @@ msgstr ""
 #: includes/layer-types/mapbox-tileset-raster.js:72
 #: includes/layer-types/mapbox-tileset-vector.js:99
 #: includes/layer-types/mvt.js:101
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Style Source Type"
 msgstr ""
 
 #: includes/layer-types/mapbox-tileset-raster.js:73
 #: includes/layer-types/mvt.js:102
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Which data the map should display"
 msgstr ""
 
 #: includes/layer-types/mapbox-tileset-raster.js:79
 #: includes/layer-types/mapbox-tileset-vector.js:79
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Layer Type"
 msgstr ""
 
 #: includes/layer-types/mapbox-tileset-raster.js:81
 #: includes/layer-types/mapbox-tileset-vector.js:81
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Layers take the data that they get from a source, optionally filter features, and then define how those features are styled."
 msgstr ""
 
 #: includes/layer-types/mapbox-tileset-vector.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -850,25 +850,25 @@ msgstr ""
 
 #: includes/layer-types/mapbox-tileset-vector.js:75
 #: includes/layer-types/mvt.js:83
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Source layer"
 msgstr ""
 
 #: includes/layer-types/mapbox-tileset-vector.js:76
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Which data the map should display."
 msgstr ""
 
 #: includes/layer-types/mapbox-tileset-vector.js:100
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "The layer source type style"
 msgstr ""
 
 #: includes/layer-types/mapbox.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -876,31 +876,31 @@ msgid "Mapbox Style"
 msgstr ""
 
 #: includes/layer-types/mapbox.js:117
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Style ID"
 msgstr ""
 
 #: includes/layer-types/mapbox.js:119
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "The Mapbox Style ID includes the user name and id. Example: username/id or mapbox://styles/username/id"
 msgstr ""
 
 #: includes/layer-types/mapbox.js:126
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Access token"
 msgstr ""
 
 #: includes/layer-types/mapbox.js:128
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Optional. If this layer needs a different access token from the one set in Settings, inform it here."
 msgstr ""
 
 #: includes/layer-types/mvt.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -911,19 +911,19 @@ msgstr ""
 #: includes/layer-types/tilelayer.js:57
 #: includes/legend-types/circles.js:25
 #: includes/legend-types/icons.js:25
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "URL"
 msgstr ""
 
 #: includes/layer-types/mvt.js:84
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Layer to use from a vector tile source."
 msgstr ""
 
 #: includes/layer-types/tilelayer.js:5
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
 #: js/build/mapsSidebar.js:1
@@ -931,25 +931,25 @@ msgid "Raster Tiled Source"
 msgstr ""
 
 #: includes/layer-types/tilelayer.js:61
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Scheme"
 msgstr ""
 
 #: includes/layer-types/tilelayer.js:62
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Influences the Y direction of the tile coordinates."
 msgstr ""
 
 #: includes/layer-types/tilelayer.js:65
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "Slippy Map tilenames (XYZ)"
 msgstr ""
 
 #: includes/layer-types/tilelayer.js:66
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 #: js/build/mapBlocks.js:1
 msgid "OSGeo spec (TMS)"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 
 #: js/build/discovery.js:6
 #: js/build/jeoMap.js:1
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Legend"
 msgstr ""
 
@@ -1531,35 +1531,75 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: js/build/layersSidebar.js:7
+#. translators: %d: number of maps whose composed style cache was refreshed.
+#: js/build/layersSidebar.js:8
+#, js-format
+msgid "%d map"
+msgid_plural "%d maps"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: number of map refresh failures.
+#: js/build/layersSidebar.js:9
+#, js-format
+msgid "%d failure"
+msgid_plural "%d failures"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: refreshed maps count label, 2: failed refresh count label.
+#: js/build/layersSidebar.js:10
+#, js-format
+msgid "Composed style cache refreshed for %1$s, with %2$s."
+msgstr ""
+
+#. translators: %s: refreshed maps count label.
+#: js/build/layersSidebar.js:11
+#, js-format
+msgid "Composed style cache refreshed for %s."
+msgstr ""
+
+#: js/build/layersSidebar.js:11
+msgid "Unable to refresh composed style cache."
+msgstr ""
+
+#: js/build/layersSidebar.js:11
+msgid "Refreshing composed style cache"
+msgstr ""
+
+#: js/build/layersSidebar.js:11
+msgid "Refresh composed style cache"
+msgstr ""
+
+#: js/build/layersSidebar.js:11
 msgid "Edit interactions"
 msgstr ""
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Please fill all required fields, you will not be able to publish or update until that."
 msgstr ""
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Your Mapbox access token may be invalid. You will not be able to publish or update. Please check your settings."
 msgstr ""
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Your layer was not found. You will not be able to publish or update. Please check your settings."
 msgstr ""
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Error loading your layer, you will not be able to publish or update. Please check your settings."
 msgstr ""
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Your Mapbox API Key was not found in your JEO Settings. You will not be able to publish or update."
 msgstr ""
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Please, check your settings."
 msgstr ""
 
-#: js/build/layersSidebar.js:7
+#: js/build/layersSidebar.js:11
 msgid "Attributions"
 msgstr ""
 

--- a/src/languages/jeowp.pot
+++ b/src/languages/jeowp.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-24T19:34:31+00:00\n"
+"POT-Creation-Date: 2026-06-25T18:09:05+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: jeowp\n"
@@ -36,31 +36,31 @@ msgstr ""
 msgid "InfoAmazonia"
 msgstr ""
 
-#: includes/class-jeo.php:367
+#: includes/class-jeo.php:368
 msgid "Ordered list of map-layer IDs to return."
 msgstr ""
 
-#: includes/class-jeo.php:372
+#: includes/class-jeo.php:373
 msgid "Request context."
 msgstr ""
 
-#: includes/class-jeo.php:568
+#: includes/class-jeo.php:569
 msgid "Mapbox was selected as the rendering library, but no Mapbox API key is configured. Falling back to MapLibre."
 msgstr ""
 
-#: includes/class-jeo.php:569
+#: includes/class-jeo.php:570
 msgid "Mapbox was selected as the rendering library, but the external Mapbox SDK could not be loaded. Falling back to MapLibre."
 msgstr ""
 
-#: includes/class-jeo.php:1075
+#: includes/class-jeo.php:1091
 msgid "Read more"
 msgstr ""
 
-#: includes/class-jeo.php:1300
+#: includes/class-jeo.php:1316
 msgid "This JEO embed is not available."
 msgstr ""
 
-#: includes/class-jeo.php:1301
+#: includes/class-jeo.php:1317
 msgid "Embed not available"
 msgstr ""
 
@@ -223,16 +223,75 @@ msgid "Layer type not registered"
 msgstr ""
 
 #. translators: 1: Mapbox terms URL, 2: Mapbox privacy URL, 3: Nominatim usage policy URL, 4: OSMF privacy URL, 5: OSM tile policy URL.
-#: includes/loaders.php:342
+#: includes/loaders.php:351
 #, php-format
 msgid "<p>JEO can connect to third-party services depending on your configuration.</p><ul><li><strong>Mapbox</strong>: only used when Mapbox is selected as the rendering library or when a map uses Mapbox-hosted resources. In that case the site loads JavaScript/CSS from Mapbox and sends the configured access token plus the visitor&#8217;s IP address, browser details and requested map resources to Mapbox. Terms: <a href=\"%1$s\">Mapbox Terms of Service</a>. Privacy Policy: <a href=\"%2$s\">Mapbox Privacy Policy</a>.</li><li><strong>Nominatim (OpenStreetMap)</strong>: used when an editor explicitly runs an address search or reverse geocoding request in the post geolocation UI. The typed address or selected coordinates, the site URL in the user agent string and the server IP address are sent to the Nominatim service. Usage Policy: <a href=\"%3$s\">Nominatim Usage Policy</a>. Privacy Policy: <a href=\"%4$s\">OpenStreetMap Foundation Privacy Policy</a>.</li><li><strong>OpenStreetMap raster tiles</strong>: the default MapLibre preview style requests map tiles from the OpenStreetMap tile service, which receives the visitor&#8217;s IP address, browser details and requested tile URLs. Tile Policy: <a href=\"%5$s\">OpenStreetMap Tile Usage Policy</a>. Privacy Policy: <a href=\"%4$s\">OpenStreetMap Foundation Privacy Policy</a>.</li><li><strong>Optional external asset URLs configured by the site administrator</strong>: if you configure an external typography stylesheet or footer logo URL, visitors&#8217; browsers will request that asset directly from the selected host. That host may receive the visitor&#8217;s IP address, browser details and referrer according to its own terms and privacy policy.</li></ul>"
 msgstr ""
 
 #. translators: Explore is the name of JEO's discovery page feature.
-#: includes/loaders.php:526
+#: includes/loaders.php:535
 #: templates/embed-discovery.php:18
 #: js/build/discovery.js:6
 msgid "Explore"
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:424
+#: includes/maps/class-map-style-composer.php:477
+msgid "Mapbox composed styles are disabled."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:449
+#: includes/maps/class-map-style-composer.php:501
+msgid "Could not create the Mapbox composed style cache directory."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:589
+msgid "Map not found."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:599
+#: includes/maps/class-map-style-composer.php:662
+msgid "A Mapbox access token is required to compose Mapbox styles."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:639
+msgid "Public payload composition is only available for one-time maps."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:645
+msgid "The map preview payload is too large."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:657
+msgid "The map preview has too many layers to compose."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:668
+msgid "The map preview does not include any renderable layers."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:690
+msgid "Map preview"
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:931
+msgid "Invalid composed style hash."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:1019
+msgid "One or more Mapbox styles could not be fetched."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:1404
+msgid "The PHP GD extension is required to merge Mapbox sprites."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:1521
+msgid "Could not decode a Mapbox sprite image."
+msgstr ""
+
+#: includes/maps/class-map-style-composer.php:2238
+msgid "Composed style artifact was not found."
 msgstr ""
 
 #: includes/maps/class-maps.php:54
@@ -808,7 +867,7 @@ msgstr ""
 msgid "The layer source type style"
 msgstr ""
 
-#: includes/layer-types/mapbox.js:10
+#: includes/layer-types/mapbox.js:5
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 #: js/build/mapBlocks.js:3
@@ -816,25 +875,25 @@ msgstr ""
 msgid "Mapbox Style"
 msgstr ""
 
-#: includes/layer-types/mapbox.js:155
+#: includes/layer-types/mapbox.js:117
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "Style ID"
 msgstr ""
 
-#: includes/layer-types/mapbox.js:157
+#: includes/layer-types/mapbox.js:119
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "The Mapbox Style ID includes the user name and id. Example: username/id or mapbox://styles/username/id"
 msgstr ""
 
-#: includes/layer-types/mapbox.js:164
+#: includes/layer-types/mapbox.js:126
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "Access token"
 msgstr ""
 
-#: includes/layer-types/mapbox.js:166
+#: includes/layer-types/mapbox.js:128
 #: js/build/layersSidebar.js:7
 #: js/build/mapBlocks.js:1
 msgid "Optional. If this layer needs a different access token from the one set in Settings, inform it here."
@@ -1184,6 +1243,15 @@ msgid "Unable to load map layers right now."
 msgstr ""
 
 #: js/build/discovery.js:6
+msgid "Mapbox style composition is unavailable."
+msgstr ""
+
+#: js/build/discovery.js:6
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition is unavailable for this map."
+msgstr ""
+
+#: js/build/discovery.js:6
 msgid "Search map"
 msgstr ""
 
@@ -1228,6 +1296,14 @@ msgid "Expand discovery panel"
 msgstr ""
 
 #: js/build/discovery.js:6
+msgid "Unable to load map information right now."
+msgstr ""
+
+#: js/build/discovery.js:6
+msgid "Map information"
+msgstr ""
+
+#: js/build/discovery.js:6
 msgctxt "discovery share action"
 msgid "Embed"
 msgstr ""
@@ -1238,16 +1314,43 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: js/build/jeoMap.js:1
-msgid "This map doesn't have layers"
-msgstr ""
-
+#: js/build/discovery.js:6
 #: js/build/jeoMap.js:1
 msgid "Info"
 msgstr ""
 
+#: js/build/discovery.js:6
 #: js/build/jeoMap.js:1
 msgid "Close popup"
+msgstr ""
+
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition did not return renderable layers for this map."
+msgstr ""
+
+#: js/build/jeoMap.js:1
+msgid "Unable to load composed Mapbox style for this map."
+msgstr ""
+
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition is unavailable for this one-time map."
+msgstr ""
+
+#: js/build/jeoMap.js:1
+msgid "Mapbox style composition did not return renderable layers for this one-time map."
+msgstr ""
+
+#: js/build/jeoMap.js:1
+msgid "Unable to load composed Mapbox style for this one-time map."
+msgstr ""
+
+#: js/build/jeoMap.js:1
+#: js/build/jeoStorymap.js:3
+msgid "Mapbox style layers could not be loaded because the composed style is unavailable."
+msgstr ""
+
+#: js/build/jeoMap.js:1
+msgid "This map doesn't have layers"
 msgstr ""
 
 #: js/build/jeoMap.js:1
@@ -1270,6 +1373,18 @@ msgstr[1] ""
 #: js/build/jeoStorymap.js:3
 #, js-format
 msgid "By %s"
+msgstr ""
+
+#: js/build/jeoStorymap.js:3
+msgid "Mapbox style composition is unavailable for this storymap."
+msgstr ""
+
+#: js/build/jeoStorymap.js:3
+msgid "Mapbox style composition did not return renderable layers for this storymap."
+msgstr ""
+
+#: js/build/jeoStorymap.js:3
+msgid "Unable to load composed Mapbox style for this storymap."
 msgstr ""
 
 #: js/build/jeoStorymap.js:3


### PR DESCRIPTION
# Replace Mapbox Static Tiles style overlays with composed Mapbox GL styles

## Summary

This PR migrates JEO away from rendering `mapbox` layer posts as raster overlays through the Mapbox Static Tiles API. Instead, JEO now composes the Mapbox styles used by a map into a single Mapbox GL Style JSON and uses that composed style across regular maps, storymaps, Discovery, embeds, and editor previews.

The main goal is to preserve the current editorial model while removing the Static Tiles API usage generated by stacked Mapbox style layers. Editors can continue creating maps from multiple JEO layers, changing layer order, toggling default visibility, configuring switchable/swappable layers, adding legends, building storymaps from maps, using Discovery, and choosing Mapbox GL JS or MapLibre GL as the rendering library.

This change is also a response to Mapbox's request that InfoAmazonia reduce or eliminate Static Tiles API usage in order to keep the implementation cost-efficient and strengthen the case for future grant/discount renewals.

This work implements the migration mapped in #628.

## Why

Historically, JEO allowed editors to compose several Mapbox styles in one map by rendering one style as the WebGL base map and rendering additional Mapbox styles as raster tile overlays from the Static Tiles API. That solved an editorial need five years ago: different teams could maintain separate styles in Mapbox Studio and combine them in JEO without manually consolidating styles.

The downside is cost and platform alignment. Mapbox has specifically recommended moving applications away from APIs such as Static Tiles and toward current Mapbox GL JS usage. Their guidance ties a cost-efficient implementation to a stronger discount position in future cycles.

An analysis we made shows why this matters:

- In a representative high-composition map used for the estimate, the map had `9` editorial layers, `7` layers composed from Mapbox styles, `2` direct layers, `42` generated Mapbox GL style layers, and `31` generated style layers initially visible.
- In that scenario, the old model could generate roughly `48-120` Static Tiles API requests on a single initial map opening, because each additional Mapbox style layer was requested as a raster overlay.
- With the composer and Mapbox GL JS, the same composition moves to one Mapbox GL JS map load with vector/raster sources inside the GL style.
- InfoAmazonia's March-May 2026 Mapbox invoices show that Static Tiles API usage represented about `92.4%` of undiscounted Mapbox charges in those months.
- The three-month average Static Tiles line was about `USD 816.93/month`, or roughly `USD 9,803/year` annualized before discount.
- The composer does not target unrelated Mapbox costs such as tileset hosting or processing. Its target is specifically the Static Tiles API line generated by rendering extra Mapbox styles as raster overlays.

In short: this PR keeps the editorial flexibility that led JEO to use Static Tiles in the first place, but moves the rendering model to a modern Mapbox GL style composition approach.

## What Changed

### Backend composer

Adds a server-side Mapbox style composer that:

- Reads the map and layer configuration already stored in WordPress.
- Fetches referenced Mapbox styles.
- Namespaces source, layer, sprite, glyph, and metadata references to avoid collisions.
- Adds direct JEO layer types such as `mvt`, `tilelayer`, `mapbox-tileset-vector`, and `mapbox-tileset-raster`.
- Writes composed style artifacts and manifests to a cache directory.
- Supports temporary preview composition for editor and one-time map states that are not saved as a reusable map post.
- Preserves custom Mapbox tokens defined on individual layers.

### Shared frontend composer utilities

Adds shared JavaScript helpers for:

- Loading composed style metadata, style JSON, and manifests.
- Applying composed layer visibility.
- Finding composed manifest entries for original JEO layers.
- Wiring composed layer interactions and popups consistently across maps, storymaps, and Discovery.

### Regular maps and storymaps

Regular maps and storymaps now:

- Load the composed style when `mapbox` style layers are present.
- Use the composed manifest to preserve initial layer visibility and later layer toggles.
- Apply interactions from more than one Mapbox layer when the editor enables them.
- Show controlled warnings when composition is unavailable, instead of falling back to Static Tiles.
- Omit only problematic Mapbox style layers when needed, while continuing to render other direct layer types.

### Discovery and embeds

Discovery now uses composed Mapbox styles instead of Static Tiles when users combine maps/layers dynamically.

This includes:

- Loading composed map styles by map ID.
- Injecting composed sources and layers into the live Discovery map.
- Preloading sprite images needed by composed style layers.
- Preserving custom Mapbox access tokens from the selected layers.
- Keeping story pins above layer interaction popups.
- Adding layer interaction popups and map information popups with visual styling aligned with regular maps.
- Supporting exported Discovery embeds without storing an arbitrary user-generated style bundle on the server for every URL state.

### Editor and preview flows

Editor previews now use the composer too:

- Map post editor previews.
- Layer post editor previews.
- Storymap editor previews.
- One-time map block previews.
- Unsaved preview state through temporary composer payloads.

This means editors can see the current unsaved map/layer/storymap configuration before publishing, without relying on the removed Static Tiles path.

### Static Tiles removal

The legacy `mapbox` layer type no longer exposes an `addLayer()` implementation that creates a raster source from:

```text
https://api.mapbox.com/styles/v1/{styleId}/tiles/512/{z}/{x}/{y}@2x
```

`addStyle()`, `getStyleUrl()`, `getStyleLayers()`, and `addInteractions()` remain available for the code paths that still need style metadata or interaction definitions. Other layer types keep their existing rendering behavior.

This PR intentionally does not add a legacy Static Tiles fallback. If the composer cannot produce a valid style, JEO reports a controlled warning and avoids rendering only the affected Mapbox style layers.

### MapLibre compatibility

The composed style also works with MapLibre GL. The loader normalizes Mapbox style data where needed so MapLibre does not fail on unsupported or Mapbox-specific style properties.

Cost expectations differ by runtime:

- With Mapbox GL JS, the composed model aligns with Mapbox's map-load pricing model.
- With MapLibre GL, Mapbox-hosted vector/raster tiles may still be billed as tile requests, but the Static Tiles API path is still avoided.

## Editorial Behavior

The intended editorial workflow is mostly unchanged.

Editors still:

- Create reusable JEO maps from multiple layers.
- Add Mapbox style layers, MVT layers, tile layers, Mapbox vector tilesets, and Mapbox raster tilesets.
- Reorder layers.
- Decide which layers are active by default.
- Configure fixed, swappable, and switchable layers.
- Add legends and attribution.
- Create storymaps from maps.
- Add maps to Discovery.
- Export Discovery compositions as embeds.

The important conceptual change is internal: JEO now owns a style build/cache step. Editors do not need to manually merge styles in Mapbox Studio.

One visible editorial improvement is that `Load interactions` for Mapbox style layers is now an independent checkbox per layer. Previously the old raster-overlay model effectively required only one Mapbox layer to carry interactions, because other Mapbox styles were rendered as flat rasters. With the composer, interactions can be enabled for multiple composed Mapbox layers.

## Supporting Documentation

The implementation follows the transition specification in [mapbox-style-composition.md](https://github.com/user-attachments/files/29446536/mapbox-style-composition.md)

The cost and grant/discount rationale is documented in [mapbox-composer-cost-estimate.md](https://github.com/user-attachments/files/29446545/mapbox-composer-cost-estimate.md)

The cost estimate is especially relevant for review because this PR is not only a rendering refactor. It is also intended to materially reduce InfoAmazonia's Static Tiles API usage profile and support Mapbox discount/grant renewal conversations.

## Commits

This branch is organized into nine reviewable commits:

1. `Add Mapbox style composer backend`
2. `Add shared composed style frontend utilities`
3. `Render maps and storymaps with composed Mapbox styles`
4. `Remove legacy Static Tiles rendering for Mapbox layers`
5. `Use composed styles in editor map previews`
6. `Allow multiple Mapbox layers to load interactions`
7. `Use composed Mapbox styles in Discovery`
8. `Improve MapLibre handling for composed styles`
9. `Refresh translations and validation thresholds`

## Validation

Local validation performed during the branch:

- `composer validate --no-check-publish`
- `vendor/bin/phpcs --standard=phpcs.xml.dist`
- `vendor/bin/phpcs --standard=phpcs-compat.xml.dist`
- `npm ci`
- `npm run build:assets`
- `npm run build`
- `npm run build:release`
- `npm run build:report`
- `npm run test:unit -- --runInBand`
- `npm run i18n:compile`
- WordPress smoke test through `scripts/wordpress-smoke.sh`
- Local WordPress Plugin Check run
- Manual checks in `infoamazonia.local` for maps, storymaps, Discovery, embeds, editor previews, Mapbox GL JS, and MapLibre GL

Additional static validation:

```bash
rg "/tiles/512|styles/v1/.*/tiles|Static Tiles|api\\.mapbox\\.com/styles/v1/.*/tiles" src
```

Expected result: no executable Static Tiles path remains in `src`.

## Notes From Manual Testing

The composer was validated visually against representative existing maps and storymaps in `infoamazonia.local`, including maps with:

- Multiple Mapbox style layers.
- `mapbox-tileset-raster` layers.
- `mapbox-tileset-vector` layers.
- MVT layers.
- Tile layers.
- Layer legends.
- Click and hover interactions.
- Storymap navigation.
- Discovery layer composition and iframe embeds.

The visual comparison was considered good enough to proceed with implementation. During testing we also confirmed that this change should not rely on theme-specific CSS fixes; theme problems should remain in the theme.

## Risks and Review Focus

Areas that deserve careful review:

- Style composition and cache invalidation in `Map_Style_Composer`.
- Sprite merging and image preloading, especially for styles with custom icons or patterns.
- Custom Mapbox token handling.
- Temporary composer payloads for unsaved editor previews and one-time maps.
- Discovery behavior when combining layers from multiple maps.
- Interaction popups when multiple composed Mapbox layers are active.
- MapLibre normalization of Mapbox style properties.
- Integration with future branches that still contain legacy Static Tiles code paths.

Important guardrail:

- Do not reintroduce `mapbox.addLayer()` as a raster Static Tiles renderer.
- Do not add a legacy Static Tiles fallback when composition fails.
- Do not add broad Mapbox v4 tile proxying as a fallback.

## Follow-up Work

Potential future improvements that are intentionally outside this PR:

- Add first-class interaction support for `mvt` and `mapbox-tileset-vector` layer types.
- Add UI-assisted source-layer/type discovery for vector tileset and MVT layers.
- Add simple color/opacity controls for supported vector layer types.
- Add deeper observability around composer cache hits, failures, and per-map composition diagnostics.
- Reconcile this branch carefully with `feature/experimental`, preserving this composer as the new baseline and removing the Static Tiles paths still present there.
