### PR TITLE
[codex] Fix composed style loading for map previews

### DIFF
--- a/src/includes/maps/class-map-style-composer.php
+++ b/src/includes/maps/class-map-style-composer.php
@@ -652,12 +652,20 @@ class Map_Style_Composer {
 			$warnings = $report['warnings'];
 		}
 
+		$style_url    = rest_url( sprintf( 'jeo/v1/map-style/%s/%s/style', $scope, rawurlencode( $hash ) ) );
+		$manifest_url = rest_url( sprintf( 'jeo/v1/map-style/%s/%s/manifest', $scope, rawurlencode( $hash ) ) );
+		if ( self::VIRTUAL_SCOPE_PREVIEW === $scope && is_user_logged_in() ) {
+			$nonce        = wp_create_nonce( 'wp_rest' );
+			$style_url    = add_query_arg( '_wpnonce', $nonce, $style_url );
+			$manifest_url = add_query_arg( '_wpnonce', $nonce, $manifest_url );
+		}
+
 		return array(
 			'enabled'      => true,
 			'scope'        => $scope,
 			'hash'         => $hash,
-			'style'        => rest_url( sprintf( 'jeo/v1/map-style/%s/%s/style', $scope, rawurlencode( $hash ) ) ),
-			'manifest'     => rest_url( sprintf( 'jeo/v1/map-style/%s/%s/manifest', $scope, rawurlencode( $hash ) ) ),
+			'style'        => $style_url,
+			'manifest'     => $manifest_url,
 			'warnings'     => $warnings,
 			'stylePath'    => $paths['stylePath'],
 			'manifestPath' => $paths['manifestPath'],

--- a/src/js/src/jeo-map/class-jeo-map.js
+++ b/src/js/src/jeo-map/class-jeo-map.js
@@ -317,10 +317,14 @@ export default class JeoMap {
 		if ( previewMapPayload ) {
 			try {
 				this.map_post_object = JSON.parse( previewMapPayload );
-				await this.getLayers();
-				return;
 			} catch ( error ) {
 				console.warn( 'Unable to parse preview map payload. Falling back to REST data.', error );
+			}
+
+			if ( this.map_post_object ) {
+				await this.getLayers();
+				await this.fetchPreviewComposedStyleData();
+				return;
 			}
 		}
 
@@ -376,6 +380,34 @@ export default class JeoMap {
 		);
 	}
 
+	async fetchPreviewComposedStyleData() {
+		if (
+			! window.jeoMapVars?.composedStyleComposeUrl ||
+			! this.layers.some( ( layer ) => this.isMapboxStyleLayer( layer ) )
+		) {
+			return;
+		}
+
+		await this.loadComposedStyleData(
+			() => loadComposedStyleData( {
+				payload: this.getPreviewComposedStylePayload(),
+				unavailableMessage: __(
+					'Mapbox style composition is unavailable for this map.',
+					'jeowp'
+				),
+				emptyManifestMessage: __(
+					'Mapbox style composition did not return renderable layers for this map.',
+					'jeowp'
+				),
+			} ),
+			__(
+				'Unable to load composed Mapbox style for this map.',
+				'jeowp'
+			),
+			'Unable to load composed Mapbox style for preview map. Mapbox style layers will be omitted.'
+		);
+	}
+
 	async fetchOnetimeComposedStyleData() {
 		if (
 			! window.jeoMapVars?.composedStyleComposeUrl ||
@@ -419,6 +451,22 @@ export default class JeoMap {
 			this.composedStyleError = error?.message || fallbackErrorMessage;
 			console.warn( consoleMessage, error );
 		}
+	}
+
+	getPreviewComposedStylePayload() {
+		const meta = this.map_post_object?.meta || {};
+
+		return {
+			scope: 'preview',
+			kind: 'map-preview',
+			postId: this.map_post_object?.id || null,
+			title: this.map_post_object?.title?.rendered || '',
+			url: globalThis.location?.href || '',
+			layers: this.layersDefinitions || meta.layers || [],
+			center_lat: meta.center_lat ?? null,
+			center_lon: meta.center_lon ?? null,
+			initial_zoom: meta.initial_zoom ?? null,
+		};
 	}
 
 	getOnetimeComposedStylePayload() {
@@ -1050,14 +1098,21 @@ export default class JeoMap {
 
 			if ( layersDefinitions ) {
 				const layersIds = layersDefinitions.map( ( el ) => el.id );
+				const requestContext = this.map_post_object ? 'edit' : 'view';
 
-				jQuery.get(
-					jeoMapVars.layersUrl,
-					{
+				jQuery.ajax( {
+					type: 'GET',
+					url: jeoMapVars.layersUrl,
+					data: {
 						include: layersIds,
-						context: 'view',
+						context: requestContext,
 					},
-					( data ) => {
+					beforeSend: function ( request ) {
+						if ( 'edit' === requestContext && jeoMapVars.nonce ) {
+							request.setRequestHeader( 'X-WP-Nonce', jeoMapVars.nonce );
+						}
+					},
+					success: ( data ) => {
 						const returnLayers = [];
 						const returnLegends = [];
 						const ordered = [];
@@ -1101,8 +1156,9 @@ export default class JeoMap {
 						this.layers = returnLayers;
 						this.legends = returnLegends;
 						resolve( returnLayers );
-					}
-				);
+					},
+					error: reject,
+				} );
 			}
 		} );
 	}

--- a/src/languages/jeowp-es_CO.po
+++ b/src/languages/jeowp-es_CO.po
@@ -2028,52 +2028,52 @@ msgstr "Los estilos compuestos de Mapbox están desactivados."
 msgid "Could not create the Mapbox composed style cache directory."
 msgstr "No fue posible crear el directorio de caché de estilos compuestos de Mapbox."
 
-#: includes/maps/class-map-style-composer.php:676
+#: includes/maps/class-map-style-composer.php:684
 msgid "Map not found."
 msgstr "Mapa no encontrado."
 
-#: includes/maps/class-map-style-composer.php:686
-#: includes/maps/class-map-style-composer.php:749
+#: includes/maps/class-map-style-composer.php:694
+#: includes/maps/class-map-style-composer.php:757
 msgid "A Mapbox access token is required to compose Mapbox styles."
 msgstr "Se requiere un token de acceso de Mapbox para componer estilos de Mapbox."
 
-#: includes/maps/class-map-style-composer.php:726
+#: includes/maps/class-map-style-composer.php:734
 msgid "Public payload composition is only available for one-time maps."
 msgstr "La composición con datos públicos solo está disponible para mapas de un solo uso."
 
-#: includes/maps/class-map-style-composer.php:732
+#: includes/maps/class-map-style-composer.php:740
 msgid "The map preview payload is too large."
 msgstr "Los datos de la vista previa del mapa son demasiado grandes."
 
-#: includes/maps/class-map-style-composer.php:744
+#: includes/maps/class-map-style-composer.php:752
 msgid "The map preview has too many layers to compose."
 msgstr "La vista previa del mapa tiene demasiadas capas para componer."
 
-#: includes/maps/class-map-style-composer.php:755
+#: includes/maps/class-map-style-composer.php:763
 msgid "The map preview does not include any renderable layers."
 msgstr "La vista previa del mapa no incluye ninguna capa renderizable."
 
-#: includes/maps/class-map-style-composer.php:777
+#: includes/maps/class-map-style-composer.php:785
 msgid "Map preview"
 msgstr "Vista previa del mapa"
 
-#: includes/maps/class-map-style-composer.php:1018
+#: includes/maps/class-map-style-composer.php:1026
 msgid "Invalid composed style hash."
 msgstr "Hash de estilo compuesto no válido."
 
-#: includes/maps/class-map-style-composer.php:1106
+#: includes/maps/class-map-style-composer.php:1114
 msgid "One or more Mapbox styles could not be fetched."
 msgstr "No fue posible obtener uno o más estilos de Mapbox."
 
-#: includes/maps/class-map-style-composer.php:1507
+#: includes/maps/class-map-style-composer.php:1515
 msgid "The PHP GD extension is required to merge Mapbox sprites."
 msgstr "Se requiere la extensión PHP GD para fusionar sprites de Mapbox."
 
-#: includes/maps/class-map-style-composer.php:1626
+#: includes/maps/class-map-style-composer.php:1634
 msgid "Could not decode a Mapbox sprite image."
 msgstr "No fue posible decodificar una imagen de sprite de Mapbox."
 
-#: includes/maps/class-map-style-composer.php:2343
+#: includes/maps/class-map-style-composer.php:2351
 msgid "Composed style artifact was not found."
 msgstr "No se encontró el artefacto del estilo compuesto."
 

--- a/src/languages/jeowp-pt_BR.po
+++ b/src/languages/jeowp-pt_BR.po
@@ -2028,52 +2028,52 @@ msgstr "Os estilos compostos do Mapbox estão desativados."
 msgid "Could not create the Mapbox composed style cache directory."
 msgstr "Não foi possível criar o diretório de cache dos estilos compostos do Mapbox."
 
-#: includes/maps/class-map-style-composer.php:676
+#: includes/maps/class-map-style-composer.php:684
 msgid "Map not found."
 msgstr "Mapa não encontrado."
 
-#: includes/maps/class-map-style-composer.php:686
-#: includes/maps/class-map-style-composer.php:749
+#: includes/maps/class-map-style-composer.php:694
+#: includes/maps/class-map-style-composer.php:757
 msgid "A Mapbox access token is required to compose Mapbox styles."
 msgstr "Um token de acesso do Mapbox é necessário para compor estilos do Mapbox."
 
-#: includes/maps/class-map-style-composer.php:726
+#: includes/maps/class-map-style-composer.php:734
 msgid "Public payload composition is only available for one-time maps."
 msgstr "A composição com dados públicos está disponível apenas para mapas de uso único."
 
-#: includes/maps/class-map-style-composer.php:732
+#: includes/maps/class-map-style-composer.php:740
 msgid "The map preview payload is too large."
 msgstr "Os dados da prévia do mapa são grandes demais."
 
-#: includes/maps/class-map-style-composer.php:744
+#: includes/maps/class-map-style-composer.php:752
 msgid "The map preview has too many layers to compose."
 msgstr "A prévia do mapa tem camadas demais para compor."
 
-#: includes/maps/class-map-style-composer.php:755
+#: includes/maps/class-map-style-composer.php:763
 msgid "The map preview does not include any renderable layers."
 msgstr "A prévia do mapa não inclui nenhuma camada renderizável."
 
-#: includes/maps/class-map-style-composer.php:777
+#: includes/maps/class-map-style-composer.php:785
 msgid "Map preview"
 msgstr "Prévia do mapa"
 
-#: includes/maps/class-map-style-composer.php:1018
+#: includes/maps/class-map-style-composer.php:1026
 msgid "Invalid composed style hash."
 msgstr "Hash do estilo composto inválido."
 
-#: includes/maps/class-map-style-composer.php:1106
+#: includes/maps/class-map-style-composer.php:1114
 msgid "One or more Mapbox styles could not be fetched."
 msgstr "Não foi possível obter um ou mais estilos do Mapbox."
 
-#: includes/maps/class-map-style-composer.php:1507
+#: includes/maps/class-map-style-composer.php:1515
 msgid "The PHP GD extension is required to merge Mapbox sprites."
 msgstr "A extensão PHP GD é necessária para mesclar sprites do Mapbox."
 
-#: includes/maps/class-map-style-composer.php:1626
+#: includes/maps/class-map-style-composer.php:1634
 msgid "Could not decode a Mapbox sprite image."
 msgstr "Não foi possível decodificar uma imagem de sprite do Mapbox."
 
-#: includes/maps/class-map-style-composer.php:2343
+#: includes/maps/class-map-style-composer.php:2351
 msgid "Composed style artifact was not found."
 msgstr "O artefato do estilo composto não foi encontrado."
 

--- a/src/languages/jeowp.pot
+++ b/src/languages/jeowp.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-01T19:37:18+00:00\n"
+"POT-Creation-Date: 2026-07-06T18:22:33+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: jeowp\n"
@@ -245,52 +245,52 @@ msgstr ""
 msgid "Could not create the Mapbox composed style cache directory."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:676
+#: includes/maps/class-map-style-composer.php:684
 msgid "Map not found."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:686
-#: includes/maps/class-map-style-composer.php:749
+#: includes/maps/class-map-style-composer.php:694
+#: includes/maps/class-map-style-composer.php:757
 msgid "A Mapbox access token is required to compose Mapbox styles."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:726
+#: includes/maps/class-map-style-composer.php:734
 msgid "Public payload composition is only available for one-time maps."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:732
+#: includes/maps/class-map-style-composer.php:740
 msgid "The map preview payload is too large."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:744
+#: includes/maps/class-map-style-composer.php:752
 msgid "The map preview has too many layers to compose."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:755
+#: includes/maps/class-map-style-composer.php:763
 msgid "The map preview does not include any renderable layers."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:777
+#: includes/maps/class-map-style-composer.php:785
 msgid "Map preview"
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:1018
+#: includes/maps/class-map-style-composer.php:1026
 msgid "Invalid composed style hash."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:1106
+#: includes/maps/class-map-style-composer.php:1114
 msgid "One or more Mapbox styles could not be fetched."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:1507
+#: includes/maps/class-map-style-composer.php:1515
 msgid "The PHP GD extension is required to merge Mapbox sprites."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:1626
+#: includes/maps/class-map-style-composer.php:1634
 msgid "Could not decode a Mapbox sprite image."
 msgstr ""
 
-#: includes/maps/class-map-style-composer.php:2343
+#: includes/maps/class-map-style-composer.php:2351
 msgid "Composed style artifact was not found."
 msgstr ""
 


### PR DESCRIPTION
## Summary

This fixes unpublished map previews that include Mapbox style layers after the 3.1.0 style-composition update.

The preview template already provides the unpublished map payload through `data-preview-map`. The map runtime parsed that payload and loaded the referenced layers, but returned before running the composed-style flow used by published map loads. As a result, preview maps could omit the composed Mapbox style and show the fallback message instead of rendering the map.

After adding the preview compose request, there was a second authentication issue: Mapbox GL loads the returned style URL itself, outside of our `jQuery.ajax` request pipeline. That direct request does not include the `X-WP-Nonce` header, so authenticated preview style URLs were returning `401`, which Mapbox surfaced as a generic `ajax.ts`/`loadURL` error.

## Changes

- Load preview map layers using REST `context=edit` and `X-WP-Nonce` so unpublished/private layer data is available to authenticated previews.
- Compose a preview-specific style payload when the preview map contains Mapbox style layers.
- Add `_wpnonce` to authenticated virtual preview style and manifest URLs so Mapbox GL can fetch those URLs directly.
- Update WordPress language file references after the PHP line-number shift.
- Leave published/onetime style URLs unchanged.

## Expected impact

Authenticated previews for unpublished maps should render composed Mapbox styles the same way the editor does, without requiring the map to be published. Public map rendering and saved virtual styles should keep their existing URL behavior.

## Validation

Local checks run before pushing/updating the branch:

- `gh --version`
- `gh auth status`
- `git diff --check`
- `composer validate --no-check-publish`
- `composer install --no-interaction --no-progress --prefer-dist`
- `php -l src/includes/maps/class-map-style-composer.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist`
- `vendor/bin/phpcs --standard=phpcs-compat.xml.dist`
- `npm ci`
- `npm run build`
- `npm run build:report`
- `npm run test:unit`
- `php -d memory_limit=1024M $(command -v wp) i18n make-pot src src/languages/jeowp.pot --slug=jeowp --domain=jeowp --exclude=js/src`
- `php -d memory_limit=1024M $(command -v wp) i18n update-po src/languages/jeowp.pot src/languages`

GitHub Actions is used for the WordPress/MySQL service-backed checks and the final language-file validation.

Notes:

- `npm run build` completed successfully; local WP-CLI under PHP 8.5 emitted deprecation warnings from WP-CLI dependencies during i18n generation.
